### PR TITLE
Hotifx chart 3.11 volume name validation

### DIFF
--- a/scripts/devtron-reference-helm-charts/reference-chart_3-11-0/templates/deployment.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_3-11-0/templates/deployment.yaml
@@ -241,11 +241,11 @@ spec:
           {{- $cmName := .name -}}
           {{- $cmMountPath := .mountPath -}}
           {{- if eq .subPath false }}
-            - name: {{ $cmName }}-vol
+            - name: {{ $cmName | replace "." "-"}}-vol
               mountPath: {{ $cmMountPath }}
           {{- else }}
           {{- range $k, $v := .data }}
-            - name: {{ $cmName }}-vol
+            - name: {{ $cmName | replace "." "-"}}-vol
               mountPath: {{ $cmMountPath }}/{{ $k}}
               subPath: {{ $k}}
           {{- end }}
@@ -260,18 +260,18 @@ spec:
           {{- $cmName := .name -}}
           {{- $cmMountPath := .mountPath -}}
           {{- if eq .subPath false }}
-            - name: {{ $cmName }}-vol
+            - name: {{ $cmName | replace "." "-"}}-vol
               mountPath: {{ $cmMountPath }}
           {{- else if and (eq (.subPath) true) (eq (.externalType) "KubernetesSecret") }}
           {{- else if and (eq (.subPath) true) (eq (.external) true) }}
           {{- range .secretData }}
-            - name: {{ $cmName }}-vol
+            - name: {{ $cmName | replace "." "-"}}-vol
               mountPath: {{ $cmMountPath}}/{{ .name }}
               subPath: {{ .name }}
           {{- end }}
           {{- else }}
           {{- range $k, $v := .data }}
-            - name: {{ $cmName}}-vol
+            - name: {{ $cmName | replace "." "-"}}-vol
               mountPath: {{ $cmMountPath}}/{{ $k}}
               subPath: {{ $k}}
           {{- end }}
@@ -294,7 +294,7 @@ spec:
       {{- if .Values.ConfigMaps.enabled }}
       {{- range .Values.ConfigMaps.maps }}
       {{- if eq .type "volume"}}
-        - name: {{ .name}}-vol
+        - name: {{ .name | replace "." "-"}}-vol
           configMap:
             {{- if eq .external true }}
             name: {{ .name }}
@@ -312,7 +312,7 @@ spec:
       {{- if .Values.ConfigSecrets.enabled }}
       {{- range .Values.ConfigSecrets.secrets }}
       {{- if eq .type "volume"}}
-        - name: {{ .name}}-vol
+        - name: {{ .name | replace "." "-"}}-vol
           secret:
             {{- if eq .external true }}
             secretName: {{ .name }}


### PR DESCRIPTION
# Description

Configmap as volume - Volume creation fails if the Configmap name has a dot #438 

Fixes # (issue) https://github.com/devtron-labs/devtron/issues/438

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Created configmap with env and volume both type with dot name.
- [x] Created secret with env and volume both type with dot name.


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles


