### PR TITLE
FEATURE: Specifying Docker repo should be an upsert operation

### DIFF
--- a/pkg/pipeline/PipelineBuilder.go
+++ b/pkg/pipeline/PipelineBuilder.go
@@ -574,13 +574,15 @@ func (impl PipelineBuilderImpl) CreateCiPipeline(createRequest *bean.CiConfigReq
 	}
 
 	if store.RegistryType == repository.REGISTRYTYPE_ECR {
-		impl.logger.Debugw("repo is empty creating ecr repo ", "repo", repo)
-		err := util.CreateEcrRepo(repo, createRequest.DockerRepository, store.AWSRegion, store.AWSAccessKeyId, store.AWSSecretAccessKey)
+		impl.logger.Debugw("attempting repo creation ", "repo", repo)
+		err := util.CreateEcrRepo(repo, createRequest.DockerRepository, store.AWSRegion, store.AWSAccessKeyId,
+			store.AWSSecretAccessKey)
 		if err != nil {
 			if errors.IsAlreadyExists(err) {
-				impl.logger.Warnw("This repo already exists!!. Please create with a new name , skipping", "repo", repo)
+				impl.logger.Warnw("this repo already exists!!, skipping repo creation", "repo", repo)
 			} else {
-				impl.logger.Errorw("You can leave the Docker repo name as blank, and we will create it for you as devtron/app_name", "repo", repo, "err", err)
+				impl.logger.Errorw("ecr repo creation failed, it might be due to authorization or any other external " +
+					"dependency. please create repo manually before triggering ci", "repo", repo, "err", err)
 				return nil, err
 			}
 		}


### PR DESCRIPTION
# Description

Currently, in the Docker Build Config section, if a user specifies a Docker repository name, then the repo is never created. Devtron only creates a new Docker repo in the registry if that field is left blank. This is very confusing to the user, as on saving the config, the user expects a repo to be created.

Proposal

Specifying a Docker repo name should always be an upsert operation. If there is no repo in registry with the same name, a new repo should be created. If there is already an existing repo with same name, UI can display a warning message to the user: Proceed/Rename, with a suggestion like: You can leave the Docker repo name as blank, and we will create it for you as devtron/app_name.

Fixes #441 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Manually



