### PR TITLE
FIX: Changed grafana datasource name and removed Prometheus datasource

### DIFF
--- a/manifests/installation-script
+++ b/manifests/installation-script
@@ -286,7 +286,7 @@ if !hasgrafana {
 	curl '` + grafanaUrlWithPwd + `/api/datasources' \
 	-H 'content-type: application/json' \
 	-H 'x-grafana-org-id: ` + orgId + `' \
-	--data-raw '{"name":"Prometheus-devtron","type":"prometheus","access":"proxy","isDefault":true}'
+	--data-raw '{"name":"Prometheus-devtron-demo","type":"prometheus","access":"proxy","isDefault":true}'
 	`;
 	prometheusDatasource = shellScript prometheusDatasourceScript;
 	log("data source setup step 1");
@@ -300,7 +300,7 @@ if !hasgrafana {
 	-H 'x-grafana-org-id: ` + orgId + `' \
 	--data-raw '{"id":` + datasourceId +` ,
 	"orgId":` + orgId + `,
-	"name":"Prometheus-devtron","type":"prometheus","access":"proxy",
+	"name":"Prometheus-devtron-demo","type":"prometheus","access":"proxy",
 	"url":"` + prometheusUrl + `",
 	"basicAuth":true,"jsonData":{},"version":1}'
 	`;

--- a/manifests/yamls/grafana.yaml
+++ b/manifests/yamls/grafana.yaml
@@ -186,43 +186,37 @@ data:
     --max-time 60 \
     -H "Accept: application/json" \
     -H "Content-Type: application/json;charset=UTF-8" \
-      "https://grafana.com/api/dashboards/13322/revisions/2/download" | sed '/-- .* --/! s/"datasource":.*,/"datasource": "Prometheus",/g'\
-    > "/var/lib/grafana/dashboards/devtron-provider/cpu-usage.json"
+      "https://grafana.com/api/dashboards/13322/revisions/2/download" > "/var/lib/grafana/dashboards/devtron-provider/cpu-usage.json"
     curl -skf \
     --connect-timeout 60 \
     --max-time 60 \
     -H "Accept: application/json" \
     -H "Content-Type: application/json;charset=UTF-8" \
-      "https://grafana.com/api/dashboards/13320/revisions/2/download" | sed '/-- .* --/! s/"datasource":.*,/"datasource": "Prometheus",/g'\
-    > "/var/lib/grafana/dashboards/devtron-provider/latency-status.json"
+      "https://grafana.com/api/dashboards/13320/revisions/2/download" > "/var/lib/grafana/dashboards/devtron-provider/latency-status.json"
     curl -skf \
     --connect-timeout 60 \
     --max-time 60 \
     -H "Accept: application/json" \
     -H "Content-Type: application/json;charset=UTF-8" \
-      "https://grafana.com/api/dashboards/13325/revisions/3/download" | sed '/-- .* --/! s/"datasource":.*,/"datasource": "Prometheus",/g'\
-    > "/var/lib/grafana/dashboards/devtron-provider/memory-usage.json"
+      "https://grafana.com/api/dashboards/13325/revisions/3/download" > "/var/lib/grafana/dashboards/devtron-provider/memory-usage.json"
     curl -skf \
     --connect-timeout 60 \
     --max-time 60 \
     -H "Accept: application/json" \
     -H "Content-Type: application/json;charset=UTF-8" \
-      "https://grafana.com/api/dashboards/13321/revisions/2/download" | sed '/-- .* --/! s/"datasource":.*,/"datasource": "Prometheus",/g'\
-    > "/var/lib/grafana/dashboards/devtron-provider/response-status.json"
+      "https://grafana.com/api/dashboards/13321/revisions/2/download" > "/var/lib/grafana/dashboards/devtron-provider/response-status.json"
     curl -skf \
     --connect-timeout 60 \
     --max-time 60 \
     -H "Accept: application/json" \
     -H "Content-Type: application/json;charset=UTF-8" \
-      "https://grafana.com/api/dashboards/13323/revisions/6/download" | sed '/-- .* --/! s/"datasource":.*,/"datasource": "Prometheus",/g'\
-    > "/var/lib/grafana/dashboards/devtron-provider/memory-usage-below-k8s1-15.json"
+      "https://grafana.com/api/dashboards/13323/revisions/6/download" > "/var/lib/grafana/dashboards/devtron-provider/memory-usage-below-k8s1-15.json"
     curl -skf \
     --connect-timeout 60 \
     --max-time 60 \
     -H "Accept: application/json" \
     -H "Content-Type: application/json;charset=UTF-8" \
-      "https://grafana.com/api/dashboards/13324/revisions/3/download" | sed '/-- .* --/! s/"datasource":.*,/"datasource": "Prometheus",/g'\
-    > "/var/lib/grafana/dashboards/devtron-provider/cpu-usage-below-k8s1-15.json"
+      "https://grafana.com/api/dashboards/13324/revisions/3/download" > "/var/lib/grafana/dashboards/devtron-provider/cpu-usage-below-k8s1-15.json"
 ---
 # Source: grafana/templates/dashboards-json-configmap.yaml
 apiVersion: v1


### PR DESCRIPTION
# Description

This PR fixes grafana metrics not visible on devtron dashboard issue and removes dependency on Prometheus datasource

Fixes # (issue)

- Changed default datasource name from Prometheus-devtron to Prometheus-devtron-demo as required by our default namespace name and the API was also using this name to fetch
- Removed Prometheus datasource from yaml file as we had to Manually update Prometheus datasource to show the metrics on dashboard

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] This has been tested several times on local minikube cluster K8s version 1.21
- [x] This has been tested on webhook Kops cluster K8s version 1.19


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles


