### PR TITLE
FIX: chart duplicate installation

### DIFF
--- a/internal/sql/repository/appstore/chartGroup/ChartGroupDeployments.go
+++ b/internal/sql/repository/appstore/chartGroup/ChartGroupDeployments.go
@@ -37,7 +37,7 @@ type ChartGroupDeployment struct {
 type ChartGroupDeploymentRepository interface {
 	Save(tx *pg.Tx, chartGroupDeployment *ChartGroupDeployment) error
 	FindByChartGroupId(chartGroupId int) ([]*ChartGroupDeployment, error)
-	Update(model *ChartGroupDeployment) (*ChartGroupDeployment, error)
+	Update(model *ChartGroupDeployment, tx *pg.Tx) (*ChartGroupDeployment, error)
 	FindByInstalledAppId(installedAppId int) (*ChartGroupDeployment, error)
 }
 
@@ -71,8 +71,8 @@ func (impl *ChartGroupDeploymentRepositoryImpl) FindByChartGroupId(chartGroupId 
 	return chartGroupDeployments, err
 }
 
-func (impl *ChartGroupDeploymentRepositoryImpl) Update(model *ChartGroupDeployment) (*ChartGroupDeployment, error) {
-	err := impl.dbConnection.Update(model)
+func (impl *ChartGroupDeploymentRepositoryImpl) Update(model *ChartGroupDeployment, tx *pg.Tx) (*ChartGroupDeployment, error) {
+	err := tx.Update(model)
 	if err != nil {
 		impl.Logger.Error(err)
 		return model, err


### PR DESCRIPTION
# Description

When you deploy a chart multiple times after deleting again and again, one of the deployments gets stuck and it isn't deleted from argocd side so you see multiple deployments of the same and isn't able to delete from the UI too.

Fixes # (issue) : https://github.com/devtron-labs/devtron/issues/679

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Fresh new chart install created success.
- [x] chart update success.
- [x] chart upgrade success.
- [x]  Fresh new chart install, than delete, recreate with same name, repeat this for 4-5 times found duplicate issues handled 
successfully.


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles


