### PR TITLE
DOC: Add `delete_repo` in documentation on what perrmissions are needed in GitOps PAT

### DIFF
--- a/docs/user-guide/global-configurations/gitops.md
+++ b/docs/user-guide/global-configurations/gitops.md
@@ -50,6 +50,7 @@ A personal access token (PAT) is used as an alternate password to authenticate i
 
 * repo - Full control of private repositories(Access commit status , Access deployment status and Access public repositories).
 * admin:org - Full control of organizations and teams(Read and write access).
+* delete_repo - Grants delete repo access on private repositories.
 
 #### For GitLab [Creating a Gitlab Personal Access Token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html):
 


### PR DESCRIPTION
# Description

In order to validate GitOps configuration `delete_repo` permission on access token is needed. Without it, I get the following error:
```
DELETE https://api.github.com/repos/<my_org>/devtron-sample-repo-<random_string>: 403 Must have admin rights to Repository.
```

Fixes #725 

## Type of change

- [y] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- follow the steps from the issue related to this PR


# Checklist:

* [y] The title of the PR states what changed and the related issues number (used for the release note).
* [y] Does this PR require documentation updates?
* [y] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles


