### PR TITLE
FIX: Helm version fixed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,7 @@ require (
 	k8s.io/api v0.0.0-20191004102349-159aefb8556b
 	k8s.io/apimachinery v0.0.0-20190816221834-a9f1d8a9c101
 	k8s.io/client-go v11.0.1-0.20190820062731-7e43eff7c80a+incompatible
-	k8s.io/helm v2.12.3
+	k8s.io/helm v2.12.3+incompatible
 	k8s.io/klog v1.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20190918143330-0270cf2f1c1d // indirect
 	k8s.io/utils v0.0.0-20191010214722-8d271d903fe4 // indirect


### PR DESCRIPTION
# Description

Helm version has been fixed in go.mod file.

Fixes # (issue)

While installing dependencies, got this error for helm - 
```
go: errors parsing go.mod:
/Users/abhi/go/src/github.com/devtron/go.mod:109:2: require k8s.io/helm: version "v2.12.3" invalid: should be v0 or v1, not v2

```
changing the version in go.mod file solved the issue

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles


