### PR TITLE
Disable envoy multiplexing by default

### DIFF
--- a/scripts/devtron-reference-helm-charts/reference-chart_3-12-0/templates/sidecar-configmap.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_3-12-0/templates/sidecar-configmap.yaml
@@ -84,10 +84,7 @@ data:
 {{- if or $element.useHTTP2 $element.useGRPC }}
             "http2_protocol_options": {},
 {{- end }}
-{{- if not $element.useGRPC }}
-            "max_requests_per_connection": "1",
-{{- end }}
-{{- if not $element.supportStreaming }}
+{{- if and (not $element.useGRPC) (not $element.supportStreaming) }}
             "max_requests_per_connection": "1",
 {{- end }}
             "load_assignment": {


### PR DESCRIPTION
# Description

Disabled envoy multiplexing by default as multiplexing sometimes results in elevated 5xx in cases where timeout is very low.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have tested it for all user roles


