### PR TITLE
feat: Allow custom headers on LivenessProbe and ReadinessProbe

### DIFF
--- a/docs/user-guide/creating-application/deployment-template.md
+++ b/docs/user-guide/creating-application/deployment-template.md
@@ -71,7 +71,7 @@ LivenessProbe:
   successThreshold: 1
   timeoutSeconds: 5
   failureThreshold: 3
-  httpHeader:
+  httpHeaders:
   scheme: ""
   tcp: true
 ```
@@ -84,7 +84,7 @@ LivenessProbe:
 | `periodSeconds` | It defines the time to check a given container for liveness. |
 | `successThreshold` | It defines the number of successes required before a given container is said to fulfil the liveness probe. |
 | `timeoutSeconds` | It defines the time for checking timeout. |
-| `httpHeader` | Custom headers to set in the request. HTTP allows repeated headers,You can override the default headers by defining .httpHeaders for the probe. |
+| `httpHeaders` | Custom headers to set in the request. HTTP allows repeated headers,You can override the default headers by defining .httpHeaders for the probe. |
 | `scheme` | Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.
 | `tcp` | The kubelet will attempt to open a socket to your container on the specified port. If it can establish a connection, the container is considered healthy. |
 
@@ -124,7 +124,7 @@ ReadinessProbe:
   successThreshold: 1
   timeoutSeconds: 5
   failureThreshold: 3
-  httpHeader:
+  httpHeaders:
   scheme: ""
   tcp: true
 ```
@@ -137,7 +137,7 @@ ReadinessProbe:
 | `periodSeconds` | It defines the time to check a given container for readiness. |
 | `successThreshold` | It defines the number of successes required before a given container is said to fulfill the readiness probe. |
 | `timeoutSeconds` | It defines the time for checking timeout. |
-| `httpHeader` | Custom headers to set in the request. HTTP allows repeated headers,You can override the default headers by defining .httpHeaders for the probe. |
+| `httpHeaders` | Custom headers to set in the request. HTTP allows repeated headers,You can override the default headers by defining .httpHeaders for the probe. |
 | `scheme` | Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.
 | `tcp` | The kubelet will attempt to open a socket to your container on the specified port. If it can establish a connection, the container is considered healthy. |
 

--- a/scripts/devtron-reference-helm-charts/reference-chart_3-12-0/templates/deployment.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_3-12-0/templates/deployment.yaml
@@ -210,6 +210,13 @@ spec:
             httpGet:
               path: {{ $.Values.LivenessProbe.Path  }}
               port: {{ $.Values.LivenessProbe.port }}
+            {{- if $.Values.LivenessProbe.httpHeaders }}
+              httpHeaders:
+              {{- range $.Values.LivenessProbe.httpHeaders}}
+                - name: {{.name}}
+                  value: {{.value}}
+              {{- end}}
+	    {{- end }}
 {{- end }}
 {{- if $.Values.LivenessProbe.command }}
             exec:
@@ -232,6 +239,13 @@ spec:
             httpGet:
               path: {{ $.Values.ReadinessProbe.Path  }}
               port: {{ $.Values.ReadinessProbe.port }}
+            {{- if $.Values.ReadinessProbe.httpHeaders }}
+              httpHeaders:
+              {{- range $.Values.ReadinessProbe.httpHeaders}}
+                - name: {{.name}}
+                  value: {{.value}}
+              {{- end}}
+	    {{- end }}
 {{- end }}
 {{- if $.Values.ReadinessProbe.command }}
             exec:


### PR DESCRIPTION
# Description

Issue is described here: #863

Fixes #863

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. In `test_values.yaml`, edit `LivelinessProbe` to the following values:
```
LivenessProbe:
  ...
  httpHeaders:
    - name: host
      value: testhost
    - name: customheader
      value: testcustomheadervalue
```
Then run `helm template -f test_values.yaml ./` with the new template. You'll see the custom headers added.

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] I have tested it for all user roles


