### PR TITLE
Resource tree APIs k8s

### DIFF
--- a/Wire.go
+++ b/Wire.go
@@ -81,6 +81,7 @@ import (
 	"github.com/devtron-labs/devtron/util/rbac"
 	"github.com/devtron-labs/devtron/util/session"
 	"github.com/google/wire"
+	application2 "github.com/devtron-labs/devtron/client/k8s/application"
 )
 
 func InitializeApp() (*App, error) {
@@ -634,6 +635,11 @@ func InitializeApp() (*App, error) {
 		pipelineConfig.NewAppLabelRepositoryImpl,
 		wire.Bind(new(pipelineConfig.AppLabelRepository), new(*pipelineConfig.AppLabelRepositoryImpl)),
 		util2.NewGoJsonSchemaCustomFormatChecker,
+
+		restHandler.NewK8sApplicationRestHandlerImpl,
+		wire.Bind(new(restHandler.K8sApplicationRestHandler),new(*restHandler.K8sApplicationRestHandlerImpl)),
+		application2.NewK8sApplicationServiceImpl,
+		wire.Bind(new(application2.K8sApplicationService),new(*application2.K8sApplicationServiceImpl)),
 	)
 	return &App{}, nil
 }

--- a/api/restHandler/K8sApplicationRestHandler.go
+++ b/api/restHandler/K8sApplicationRestHandler.go
@@ -36,7 +36,8 @@ func (impl K8sApplicationRestHandlerImpl) GetResource(w http.ResponseWriter, r *
 	group := v.Get("group")
 	kind := v.Get("kind")
 	resourceName := v.Get("resourceName")
-	token := r.Header.Get("token")
+	bearerToken := v.Get("bearerToken")
+	//token := r.Header.Get("token")
 	request := &application.GetRequest{
 		Name:         resourceName,
 		Namespace: nameSpace,
@@ -46,7 +47,7 @@ func (impl K8sApplicationRestHandlerImpl) GetResource(w http.ResponseWriter, r *
 			Version: version,
 		},
 	}
-	resource, err := impl.k8sApplication.GetResource(token, request)
+	resource, err := impl.k8sApplication.GetResource(bearerToken, request)
 	if err!=nil{
 		common.WriteJsonResp(w,err,resource,http.StatusInternalServerError)
 		return

--- a/api/restHandler/K8sApplicationRestHandler.go
+++ b/api/restHandler/K8sApplicationRestHandler.go
@@ -1,0 +1,26 @@
+package restHandler
+
+import (
+	"go.uber.org/zap"
+	"net/http"
+)
+
+type K8sApplicationRestHandler interface {
+	GetResource(w http.ResponseWriter, r *http.Request)
+	UpdateResource(w http.ResponseWriter, r *http.Request)
+}
+
+type K8sApplicationRestHandlerImpl struct {
+	logger                 *zap.SugaredLogger
+}
+
+func NewK8sApplicationRestHandlerImpl(logger *zap.SugaredLogger,) *K8sApplicationRestHandlerImpl {
+	return &K8sApplicationRestHandlerImpl{
+		logger:                 logger,
+	}
+}
+
+
+UpdateResource(w http.ResponseWriter, r *http.Request){
+
+}

--- a/api/restHandler/K8sApplicationRestHandler.go
+++ b/api/restHandler/K8sApplicationRestHandler.go
@@ -32,16 +32,18 @@ func (impl K8sApplicationRestHandlerImpl) GetResource(w http.ResponseWriter, r *
 	var request application.K8sRequestBean
 	err := decoder.Decode(&request)
 	if err != nil {
+		impl.logger.Errorw("error in decoding request body","err",err)
 		common.WriteJsonResp(w, err, nil, http.StatusBadRequest)
 		return
 	}
+	//TODO : add rbac
 	resource, err := impl.k8sApplication.GetResource(&request)
 	if err!=nil{
+		impl.logger.Errorw("error in getting resource","err",err)
 		common.WriteJsonResp(w,err,resource,http.StatusInternalServerError)
 		return
 	}
 	common.WriteJsonResp(w,nil,resource,http.StatusOK)
-	return
 }
 
 func (impl K8sApplicationRestHandlerImpl) UpdateResource(w http.ResponseWriter, r *http.Request) {
@@ -49,16 +51,18 @@ func (impl K8sApplicationRestHandlerImpl) UpdateResource(w http.ResponseWriter, 
 	var request application.K8sRequestBean
 	err := decoder.Decode(&request)
 	if err != nil {
+		impl.logger.Errorw("error in decoding request body","err",err)
 		common.WriteJsonResp(w, err, nil, http.StatusBadRequest)
 		return
 	}
+	//TODO : add rbac
 	resource, err := impl.k8sApplication.UpdateResource(&request)
 	if err!=nil{
+		impl.logger.Errorw("error in updating resource","err",err)
 		common.WriteJsonResp(w,err,resource,http.StatusInternalServerError)
 		return
 	}
 	common.WriteJsonResp(w,nil,resource,http.StatusOK)
-	return
 }
 
 func (impl K8sApplicationRestHandlerImpl) DeleteResource(w http.ResponseWriter, r *http.Request) {
@@ -66,16 +70,18 @@ func (impl K8sApplicationRestHandlerImpl) DeleteResource(w http.ResponseWriter, 
 	var request application.K8sRequestBean
 	err := decoder.Decode(&request)
 	if err != nil {
+		impl.logger.Errorw("error in decoding request body","err",err)
 		common.WriteJsonResp(w, err, nil, http.StatusBadRequest)
 		return
 	}
+	//TODO : add rbac
 	resource, err := impl.k8sApplication.DeleteResource(&request)
 	if err!=nil{
+		impl.logger.Errorw("error in deleting resource","err",err)
 		common.WriteJsonResp(w,err,resource,http.StatusInternalServerError)
 		return
 	}
 	common.WriteJsonResp(w,nil,resource,http.StatusOK)
-	return
 }
 
 func (impl K8sApplicationRestHandlerImpl) ListEvents(w http.ResponseWriter, r *http.Request) {
@@ -83,14 +89,16 @@ func (impl K8sApplicationRestHandlerImpl) ListEvents(w http.ResponseWriter, r *h
 	var request application.K8sRequestBean
 	err := decoder.Decode(&request)
 	if err != nil {
+		impl.logger.Errorw("error in decoding request body","err",err)
 		common.WriteJsonResp(w, err, nil, http.StatusBadRequest)
 		return
 	}
+	//TODO : add rbac
 	events, err := impl.k8sApplication.ListEvents(&request)
 	if err!=nil{
+		impl.logger.Errorw("error in getting events list","err",err)
 		common.WriteJsonResp(w,err,events,http.StatusInternalServerError)
 		return
 	}
 	common.WriteJsonResp(w,nil,events,http.StatusOK)
-	return
 }

--- a/api/restHandler/K8sApplicationRestHandler.go
+++ b/api/restHandler/K8sApplicationRestHandler.go
@@ -1,10 +1,10 @@
 package restHandler
 
 import (
+	"encoding/json"
 	"github.com/devtron-labs/devtron/api/restHandler/common"
 	"github.com/devtron-labs/devtron/client/k8s/application"
 	"go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"net/http"
 )
 
@@ -28,26 +28,14 @@ func NewK8sApplicationRestHandlerImpl(logger *zap.SugaredLogger, k8sApplication 
 }
 
 func (impl K8sApplicationRestHandlerImpl) GetResource(w http.ResponseWriter, r *http.Request) {
-	//vars := mux.Vars(r)
-	//name := vars["name"]
-	v := r.URL.Query()
-	nameSpace := v.Get("namespace")
-	version := v.Get("version")
-	group := v.Get("group")
-	kind := v.Get("kind")
-	resourceName := v.Get("resourceName")
-	bearerToken := v.Get("bearerToken")
-	//token := r.Header.Get("token")
-	request := &application.GetRequest{
-		Name:         resourceName,
-		Namespace: nameSpace,
-		GroupVersionKind: schema.GroupVersionKind{
-			Kind: kind,
-			Group: group,
-			Version: version,
-		},
+	decoder := json.NewDecoder(r.Body)
+	var request application.K8sRequestBean
+	err := decoder.Decode(&request)
+	if err != nil {
+		common.WriteJsonResp(w, err, nil, http.StatusBadRequest)
+		return
 	}
-	resource, err := impl.k8sApplication.GetResource(bearerToken, request)
+	resource, err := impl.k8sApplication.GetResource(&request)
 	if err!=nil{
 		common.WriteJsonResp(w,err,resource,http.StatusInternalServerError)
 		return
@@ -57,24 +45,14 @@ func (impl K8sApplicationRestHandlerImpl) GetResource(w http.ResponseWriter, r *
 }
 
 func (impl K8sApplicationRestHandlerImpl) UpdateResource(w http.ResponseWriter, r *http.Request) {
-	v := r.URL.Query()
-	nameSpace := v.Get("namespace")
-	version := v.Get("version")
-	group := v.Get("group")
-	kind := v.Get("kind")
-	resourceName := v.Get("resourceName")
-	token := r.Header.Get("token")
-	//TODO : confirm patch & patchType placement(header/url param)
-	request := &application.UpdateRequest{
-		Name:         resourceName,
-		Namespace: nameSpace,
-		GroupVersionKind: schema.GroupVersionKind{
-			Kind: kind,
-			Group: group,
-			Version: version,
-		},
+	decoder := json.NewDecoder(r.Body)
+	var request application.K8sRequestBean
+	err := decoder.Decode(&request)
+	if err != nil {
+		common.WriteJsonResp(w, err, nil, http.StatusBadRequest)
+		return
 	}
-	resource, err := impl.k8sApplication.UpdateResource(token, request)
+	resource, err := impl.k8sApplication.UpdateResource(&request)
 	if err!=nil{
 		common.WriteJsonResp(w,err,resource,http.StatusInternalServerError)
 		return
@@ -84,24 +62,14 @@ func (impl K8sApplicationRestHandlerImpl) UpdateResource(w http.ResponseWriter, 
 }
 
 func (impl K8sApplicationRestHandlerImpl) DeleteResource(w http.ResponseWriter, r *http.Request) {
-	v := r.URL.Query()
-	nameSpace := v.Get("namespace")
-	version := v.Get("version")
-	group := v.Get("group")
-	kind := v.Get("kind")
-	resourceName := v.Get("resourceName")
-	token := r.Header.Get("token")
-	//TODO : confirm force bool value
-	request := &application.DeleteRequest{
-		Name:         resourceName,
-		Namespace: nameSpace,
-		GroupVersionKind: schema.GroupVersionKind{
-			Kind: kind,
-			Group: group,
-			Version: version,
-		},
+	decoder := json.NewDecoder(r.Body)
+	var request application.K8sRequestBean
+	err := decoder.Decode(&request)
+	if err != nil {
+		common.WriteJsonResp(w, err, nil, http.StatusBadRequest)
+		return
 	}
-	resource, err := impl.k8sApplication.DeleteResource(token, request)
+	resource, err := impl.k8sApplication.DeleteResource(&request)
 	if err!=nil{
 		common.WriteJsonResp(w,err,resource,http.StatusInternalServerError)
 		return
@@ -111,23 +79,14 @@ func (impl K8sApplicationRestHandlerImpl) DeleteResource(w http.ResponseWriter, 
 }
 
 func (impl K8sApplicationRestHandlerImpl) ListEvents(w http.ResponseWriter, r *http.Request) {
-	v := r.URL.Query()
-	nameSpace := v.Get("namespace")
-	version := v.Get("version")
-	group := v.Get("group")
-	kind := v.Get("kind")
-	resourceName := v.Get("resourceName")
-	token := r.Header.Get("token")
-	request := &application.GetRequest{
-		Name:         resourceName,
-		Namespace: nameSpace,
-		GroupVersionKind: schema.GroupVersionKind{
-			Kind: kind,
-			Group: group,
-			Version: version,
-		},
+	decoder := json.NewDecoder(r.Body)
+	var request application.K8sRequestBean
+	err := decoder.Decode(&request)
+	if err != nil {
+		common.WriteJsonResp(w, err, nil, http.StatusBadRequest)
+		return
 	}
-	events, err := impl.k8sApplication.ListEvents(token, request)
+	events, err := impl.k8sApplication.ListEvents(&request)
 	if err!=nil{
 		common.WriteJsonResp(w,err,events,http.StatusInternalServerError)
 		return

--- a/api/restHandler/K8sApplicationRestHandler.go
+++ b/api/restHandler/K8sApplicationRestHandler.go
@@ -1,7 +1,10 @@
 package restHandler
 
 import (
+	"github.com/devtron-labs/devtron/api/restHandler/common"
+	"github.com/devtron-labs/devtron/client/k8s/application"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"net/http"
 )
 
@@ -9,26 +12,125 @@ type K8sApplicationRestHandler interface {
 	GetResource(w http.ResponseWriter, r *http.Request)
 	UpdateResource(w http.ResponseWriter, r *http.Request)
 	DeleteResource(w http.ResponseWriter, r *http.Request)
+	ListEvents(w http.ResponseWriter, r *http.Request)
 }
 
 type K8sApplicationRestHandlerImpl struct {
-	logger                 *zap.SugaredLogger
+	logger         *zap.SugaredLogger
+	k8sApplication application.K8sApplicationService
 }
 
-func NewK8sApplicationRestHandlerImpl(logger *zap.SugaredLogger,) *K8sApplicationRestHandlerImpl {
+func NewK8sApplicationRestHandlerImpl(logger *zap.SugaredLogger, k8sApplication application.K8sApplicationService) *K8sApplicationRestHandlerImpl {
 	return &K8sApplicationRestHandlerImpl{
-		logger:                 logger,
+		logger:         logger,
+		k8sApplication: k8sApplication,
 	}
 }
 
-func(impl K8sApplicationRestHandlerImpl) GetResource(w http.ResponseWriter, r *http.Request){
-
+func (impl K8sApplicationRestHandlerImpl) GetResource(w http.ResponseWriter, r *http.Request) {
+	//vars := mux.Vars(r)
+	//name := vars["name"]
+	v := r.URL.Query()
+	nameSpace := v.Get("namespace")
+	version := v.Get("version")
+	group := v.Get("group")
+	kind := v.Get("kind")
+	resourceName := v.Get("resourceName")
+	token := r.Header.Get("token")
+	request := &application.GetRequest{
+		Name:         resourceName,
+		Namespace: nameSpace,
+		GroupVersionKind: schema.GroupVersionKind{
+			Kind: kind,
+			Group: group,
+			Version: version,
+		},
+	}
+	resource, err := impl.k8sApplication.GetResource(token, request)
+	if err!=nil{
+		common.WriteJsonResp(w,err,resource,http.StatusInternalServerError)
+		return
+	}
+	common.WriteJsonResp(w,nil,resource,http.StatusOK)
+	return
 }
 
-func(impl K8sApplicationRestHandlerImpl) UpdateResource(w http.ResponseWriter, r *http.Request){
-
+func (impl K8sApplicationRestHandlerImpl) UpdateResource(w http.ResponseWriter, r *http.Request) {
+	v := r.URL.Query()
+	nameSpace := v.Get("namespace")
+	version := v.Get("version")
+	group := v.Get("group")
+	kind := v.Get("kind")
+	resourceName := v.Get("resourceName")
+	token := r.Header.Get("token")
+	//TODO : confirm patch & patchType placement(header/url param)
+	request := &application.UpdateRequest{
+		Name:         resourceName,
+		Namespace: nameSpace,
+		GroupVersionKind: schema.GroupVersionKind{
+			Kind: kind,
+			Group: group,
+			Version: version,
+		},
+	}
+	resource, err := impl.k8sApplication.UpdateResource(token, request)
+	if err!=nil{
+		common.WriteJsonResp(w,err,resource,http.StatusInternalServerError)
+		return
+	}
+	common.WriteJsonResp(w,nil,resource,http.StatusOK)
+	return
 }
 
-func(impl K8sApplicationRestHandlerImpl) DeleteResource(w http.ResponseWriter, r *http.Request){
+func (impl K8sApplicationRestHandlerImpl) DeleteResource(w http.ResponseWriter, r *http.Request) {
+	v := r.URL.Query()
+	nameSpace := v.Get("namespace")
+	version := v.Get("version")
+	group := v.Get("group")
+	kind := v.Get("kind")
+	resourceName := v.Get("resourceName")
+	token := r.Header.Get("token")
+	//TODO : confirm force bool value
+	request := &application.DeleteRequest{
+		Name:         resourceName,
+		Namespace: nameSpace,
+		GroupVersionKind: schema.GroupVersionKind{
+			Kind: kind,
+			Group: group,
+			Version: version,
+		},
+	}
+	resource, err := impl.k8sApplication.DeleteResource(token, request)
+	if err!=nil{
+		common.WriteJsonResp(w,err,resource,http.StatusInternalServerError)
+		return
+	}
+	common.WriteJsonResp(w,nil,resource,http.StatusOK)
+	return
+}
 
+func (impl K8sApplicationRestHandlerImpl) ListEvents(w http.ResponseWriter, r *http.Request) {
+	v := r.URL.Query()
+	nameSpace := v.Get("namespace")
+	version := v.Get("version")
+	group := v.Get("group")
+	kind := v.Get("kind")
+	resourceName := v.Get("resourceName")
+	token := r.Header.Get("token")
+	request := &application.GetRequest{
+		Name:         resourceName,
+		Namespace: nameSpace,
+		GroupVersionKind: schema.GroupVersionKind{
+			Kind: kind,
+			Group: group,
+			Version: version,
+		},
+	}
+	events, err := impl.k8sApplication.ListEvents(token, request)
+	if err!=nil{
+		common.WriteJsonResp(w,err,events,http.StatusInternalServerError)
+		return
+	}
+	common.WriteJsonResp(w,nil,events,http.StatusOK)
+	return
 }

--- a/api/restHandler/K8sApplicationRestHandler.go
+++ b/api/restHandler/K8sApplicationRestHandler.go
@@ -8,6 +8,7 @@ import (
 type K8sApplicationRestHandler interface {
 	GetResource(w http.ResponseWriter, r *http.Request)
 	UpdateResource(w http.ResponseWriter, r *http.Request)
+	DeleteResource(w http.ResponseWriter, r *http.Request)
 }
 
 type K8sApplicationRestHandlerImpl struct {
@@ -20,7 +21,14 @@ func NewK8sApplicationRestHandlerImpl(logger *zap.SugaredLogger,) *K8sApplicatio
 	}
 }
 
+func(impl K8sApplicationRestHandlerImpl) GetResource(w http.ResponseWriter, r *http.Request){
 
-UpdateResource(w http.ResponseWriter, r *http.Request){
+}
+
+func(impl K8sApplicationRestHandlerImpl) UpdateResource(w http.ResponseWriter, r *http.Request){
+
+}
+
+func(impl K8sApplicationRestHandlerImpl) DeleteResource(w http.ResponseWriter, r *http.Request){
 
 }

--- a/api/router/ApplicationRouter.go
+++ b/api/router/ApplicationRouter.go
@@ -71,7 +71,7 @@ func (r ApplicationRouterImpl) initApplicationRouter(router *mux.Router) {
 	//	HandlerFunc(r.handler.GetResource)
 	router.Path("/{name}/resource").
 		Queries("version", "{version}", "namespace", "{namespace}", "group", "{group}", "kind", "{kind}", "resourceName", "{resourceName}").
-		Methods("GET").
+		Methods("POST").
 		HandlerFunc(r.handler2.GetResource)
 	//TODO:
 	//router.Path("/{name}/events").

--- a/api/router/ApplicationRouter.go
+++ b/api/router/ApplicationRouter.go
@@ -65,23 +65,21 @@ func (r ApplicationRouterImpl) initApplicationRouter(router *mux.Router) {
 	router.Path("/{name}/resource-tree").
 		Methods("GET").
 		HandlerFunc(r.handler.GetResourceTree)
-	//router.Path("/{name}/resource").
-	//	Queries("version", "{version}", "namespace", "{namespace}", "group", "{group}", "kind", "{kind}", "resourceName", "{resourceName}").
-	//	Methods("GET").
-	//	HandlerFunc(r.handler.GetResource)
+
+
 	router.Path("/{name}/resource").
-		Queries("version", "{version}", "namespace", "{namespace}", "group", "{group}", "kind", "{kind}", "resourceName", "{resourceName}").
 		Methods("POST").
 		HandlerFunc(r.handler2.GetResource)
-	//TODO:
-	//router.Path("/{name}/events").
-	//	Queries("resourceNamespace", "{resourceNamespace}", "resourceUID", "{resourceUID}", "resourceName", "{resourceName}").
-	//	Methods("GET").
-	//	HandlerFunc(r.handler.ListResourceEvents)
 	router.Path("/{name}/events").
-		Queries("version", "{version}", "namespace", "{namespace}", "group", "{group}", "kind", "{kind}", "resourceName", "{resourceName}").
-		Methods("GET").
+		Methods("POST").
 		HandlerFunc(r.handler2.ListEvents)
+	router.Path("/{name}/resource").
+		Methods("PUT").
+		HandlerFunc(r.handler2.UpdateResource)
+	router.Path("/{name}/resource/delete").
+		Methods("POST").
+		HandlerFunc(r.handler2.DeleteResource)
+
 	router.Path("/{name}/events").
 		Methods("GET").
 		HandlerFunc(r.handler.ListResourceEvents)

--- a/api/router/ApplicationRouter.go
+++ b/api/router/ApplicationRouter.go
@@ -31,12 +31,15 @@ type ApplicationRouter interface {
 type ApplicationRouterImpl struct {
 	handler restHandler.ArgoApplicationRestHandler
 	logger  *zap.SugaredLogger
+	handler2 restHandler.K8sApplicationRestHandler
 }
 
-func NewApplicationRouterImpl(handler restHandler.ArgoApplicationRestHandler, logger *zap.SugaredLogger) *ApplicationRouterImpl {
+func NewApplicationRouterImpl(handler restHandler.ArgoApplicationRestHandler, logger *zap.SugaredLogger,
+	handler2 restHandler.K8sApplicationRestHandler) *ApplicationRouterImpl {
 	return &ApplicationRouterImpl{
 		handler: handler,
 		logger:  logger,
+		handler2: handler2,
 	}
 }
 
@@ -62,14 +65,23 @@ func (r ApplicationRouterImpl) initApplicationRouter(router *mux.Router) {
 	router.Path("/{name}/resource-tree").
 		Methods("GET").
 		HandlerFunc(r.handler.GetResourceTree)
+	//router.Path("/{name}/resource").
+	//	Queries("version", "{version}", "namespace", "{namespace}", "group", "{group}", "kind", "{kind}", "resourceName", "{resourceName}").
+	//	Methods("GET").
+	//	HandlerFunc(r.handler.GetResource)
 	router.Path("/{name}/resource").
 		Queries("version", "{version}", "namespace", "{namespace}", "group", "{group}", "kind", "{kind}", "resourceName", "{resourceName}").
 		Methods("GET").
-		HandlerFunc(r.handler.GetResource)
+		HandlerFunc(r.handler2.GetResource)
+	//TODO:
+	//router.Path("/{name}/events").
+	//	Queries("resourceNamespace", "{resourceNamespace}", "resourceUID", "{resourceUID}", "resourceName", "{resourceName}").
+	//	Methods("GET").
+	//	HandlerFunc(r.handler.ListResourceEvents)
 	router.Path("/{name}/events").
-		Queries("resourceNamespace", "{resourceNamespace}", "resourceUID", "{resourceUID}", "resourceName", "{resourceName}").
+		Queries("version", "{version}", "namespace", "{namespace}", "group", "{group}", "kind", "{kind}", "resourceName", "{resourceName}").
 		Methods("GET").
-		HandlerFunc(r.handler.ListResourceEvents)
+		HandlerFunc(r.handler2.ListEvents)
 	router.Path("/{name}/events").
 		Methods("GET").
 		HandlerFunc(r.handler.ListResourceEvents)

--- a/authWire.go
+++ b/authWire.go
@@ -8,7 +8,7 @@ import (
 
 // AuthWireSet:	 set of components used to initialise authentication with dex
 var AuthWireSet = wire.NewSet(
-	wire.Value(client.LocalDevMode(false)),
+	wire.Value(client.LocalDevMode(true)),
 	client.NewK8sClient,
 	client.BuildDexConfig,
 	client.GetSettings,

--- a/client/k8s/application/Application.go
+++ b/client/k8s/application/Application.go
@@ -6,6 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
@@ -13,6 +14,8 @@ import (
 
 type k8sApplication interface {
 	GetResource(request *GetRequest)(resp *ManifestResponse, err error)
+	UpdateResource(request *UpdateRequest)(resp *ManifestResponse, err error)
+	DeleteResource(request *DeleteRequest)(resp *ManifestResponse, err error)
 }
 
 type K8sApplicationServiceImpl struct {
@@ -28,16 +31,34 @@ func NewK8sApplicationServiceImpl(restConfig *rest.Config, logger *zap.SugaredLo
 }
 
 type GetRequest struct {
-	//TODO : update validations for struct
+	//TODO : update validations
 	Name             string                  `protobuf:"bytes,1,req,name=name" json:"name,omitempty"`
 	Namespace        string                  `protobuf:"bytes,2,req,name=namespace" json:"namespace,omitempty"`
 	GroupVersionKind schema.GroupVersionKind `protobuf:"bytes,3,req,name=groupVersionKind" json:"groupVersionKind,omitempty"`
 }
+
+type UpdateRequest struct {
+	//TODO : update validations
+	Name             string                  `protobuf:"bytes,1,req,name=name" json:"name,omitempty"`
+	Namespace        string                  `protobuf:"bytes,2,req,name=namespace" json:"namespace,omitempty"`
+	GroupVersionKind schema.GroupVersionKind `protobuf:"bytes,3,req,name=groupVersionKind" json:"groupVersionKind,omitempty"`
+	Patch            string                  `protobuf:"bytes,4,req,name=patch" json:"patch,omitempty"`
+	PatchType        string                  `protobuf:"bytes,5,req,name=patchType" json:"patchType,omitempty"`
+}
+
+type DeleteRequest struct {
+	//TODO : update validations, confirm for force delete flag
+	Name             string                  `protobuf:"bytes,1,req,name=name" json:"name,omitempty"`
+	Namespace        string                  `protobuf:"bytes,2,req,name=namespace" json:"namespace,omitempty"`
+	GroupVersionKind schema.GroupVersionKind `protobuf:"bytes,3,req,name=groupVersionKind" json:"groupVersionKind,omitempty"`
+	Force            *bool                   `protobuf:"bytes,4,req,name=force" json:"force,omitempty"`
+}
+
 type ManifestResponse struct {
 	Manifest unstructured.Unstructured `protobuf:"bytes,1,req,name=manifest" json:"manifest,omitempty"`
 }
 
-func (impl K8sApplicationServiceImpl) GetResource(request *GetRequest)(resp *ManifestResponse, err error) {
+func (impl K8sApplicationServiceImpl) GetResource(request *GetRequest)(*ManifestResponse, error) {
 	dynamicIf, err := dynamic.NewForConfig(impl.restConfig)
 	if err != nil {
 		return nil, err
@@ -53,6 +74,51 @@ func (impl K8sApplicationServiceImpl) GetResource(request *GetRequest)(resp *Man
 	resource := request.GroupVersionKind.GroupVersion().WithResource(apiResource.Name)
 	//TODO : confirm for client-go version, updated version have changed arguments
 	obj, err := dynamicIf.Resource(resource).Namespace(request.Namespace).Get(request.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return &ManifestResponse{*obj}, nil
+}
+
+func (impl K8sApplicationServiceImpl) UpdateResource(request *UpdateRequest) (*ManifestResponse, error) {
+	dynamicIf, err := dynamic.NewForConfig(impl.restConfig)
+	if err != nil {
+		return nil, err
+	}
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(impl.restConfig)
+	if err != nil {
+		return nil, err
+	}
+	apiResource, err := ServerResourceForGroupVersionKind(discoveryClient, request.GroupVersionKind)
+	if err != nil {
+		return nil, err
+	}
+	resource := request.GroupVersionKind.GroupVersion().WithResource(apiResource.Name)
+	obj, err := dynamicIf.Resource(resource).Namespace(request.Namespace).Patch(request.Name, types.PatchType(request.PatchType), []byte(request.Patch), metav1.PatchOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return &ManifestResponse{*obj}, nil
+}
+func (impl K8sApplicationServiceImpl) DeleteResource(request *DeleteRequest) (*ManifestResponse, error) {
+	dynamicIf, err := dynamic.NewForConfig(impl.restConfig)
+	if err != nil {
+		return nil, err
+	}
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(impl.restConfig)
+	if err != nil {
+		return nil, err
+	}
+	apiResource, err := ServerResourceForGroupVersionKind(discoveryClient, request.GroupVersionKind)
+	if err != nil {
+		return nil, err
+	}
+	resource := request.GroupVersionKind.GroupVersion().WithResource(apiResource.Name)
+	obj, err := dynamicIf.Resource(resource).Namespace(request.Namespace).Get(request.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	err = dynamicIf.Resource(resource).Namespace(request.Namespace).Delete(request.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/client/k8s/application/Application.go
+++ b/client/k8s/application/Application.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"github.com/devtron-labs/devtron/pkg/cluster/repository"
 	"go.uber.org/zap"
 	v1b1 "k8s.io/api/events/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -15,45 +16,41 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const DEFAULT_CLUSTER = "default_cluster"
+
 type K8sApplicationService interface {
-	GetResource(token string, request *GetRequest) (resp *ManifestResponse, err error)
-	UpdateResource(token string, request *UpdateRequest) (resp *ManifestResponse, err error)
-	DeleteResource(token string, request *DeleteRequest) (resp *ManifestResponse, err error)
-	ListEvents(token string, request *GetRequest) (*EventsResponse, error)
+	GetResource(request *K8sRequestBean) (resp *ManifestResponse, err error)
+	UpdateResource(request *K8sRequestBean) (resp *ManifestResponse, err error)
+	DeleteResource(request *K8sRequestBean) (resp *ManifestResponse, err error)
+	ListEvents(request *K8sRequestBean) (*EventsResponse, error)
 }
 
 type K8sApplicationServiceImpl struct {
-	logger        *zap.SugaredLogger
+	logger            *zap.SugaredLogger
+	clusterRepository repository.ClusterRepository
 }
 
-func NewK8sApplicationServiceImpl(logger *zap.SugaredLogger) *K8sApplicationServiceImpl {
+func NewK8sApplicationServiceImpl(logger *zap.SugaredLogger, clusterRepository repository.ClusterRepository) *K8sApplicationServiceImpl {
 	return &K8sApplicationServiceImpl{
-		logger:        logger,
+		logger:            logger,
+		clusterRepository: clusterRepository,
 	}
 }
 
-type GetRequest struct {
+type K8sRequestBean struct {
 	//TODO : update validations
-	Name             string                  `protobuf:"bytes,1,req,name=name" json:"name,omitempty"`
-	Namespace        string                  `protobuf:"bytes,2,req,name=namespace" json:"namespace,omitempty"`
-	GroupVersionKind schema.GroupVersionKind `protobuf:"bytes,3,req,name=groupVersionKind" json:"groupVersionKind,omitempty"`
+	AppId              int                `json:"appId"`
+	ClusterId          int                `json:"clusterId"`
+	ResourceIdentifier ResourceIdentifier `json:"resourceIdentifier"`
+	Patch              string             `json:"patch"`
+	PatchType          string             `json:"patchType"`
 }
 
-type UpdateRequest struct {
+type ResourceIdentifier struct {
 	//TODO : update validations
 	Name             string                  `protobuf:"bytes,1,req,name=name" json:"name,omitempty"`
 	Namespace        string                  `protobuf:"bytes,2,req,name=namespace" json:"namespace,omitempty"`
 	GroupVersionKind schema.GroupVersionKind `protobuf:"bytes,3,req,name=groupVersionKind" json:"groupVersionKind,omitempty"`
-	Patch            string                  `protobuf:"bytes,4,req,name=patch" json:"patch,omitempty"`
-	PatchType        string                  `protobuf:"bytes,5,req,name=patchType" json:"patchType,omitempty"`
-}
-
-type DeleteRequest struct {
-	//TODO : update validations
-	Name             string                  `protobuf:"bytes,1,req,name=name" json:"name,omitempty"`
-	Namespace        string                  `protobuf:"bytes,2,req,name=namespace" json:"namespace,omitempty"`
-	GroupVersionKind schema.GroupVersionKind `protobuf:"bytes,3,req,name=groupVersionKind" json:"groupVersionKind,omitempty"`
-	Force            *bool                   `protobuf:"bytes,4,req,name=force" json:"force,omitempty"`
 }
 
 type ManifestResponse struct {
@@ -66,100 +63,106 @@ type EventsResponse struct {
 	Events *v1b1.EventList
 }
 
-func (impl K8sApplicationServiceImpl) GetResource(token string, request *GetRequest) (*ManifestResponse, error) {
-	restConfig := &rest.Config{
-		BearerToken: token,
-	}
-	dynamicIf, err := dynamic.NewForConfig(restConfig)
+func (impl K8sApplicationServiceImpl) GetResource(request *K8sRequestBean) (*ManifestResponse, error) {
+	dynamicIf, resource, err := impl.GetResourceAndDynamicIf(request)
 	if err != nil {
 		return nil, err
 	}
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
-	if err != nil {
-		return nil, err
-	}
-	apiResource, err := ServerResourceForGroupVersionKind(discoveryClient, request.GroupVersionKind)
-	if err != nil {
-		return nil, err
-	}
-	resource := request.GroupVersionKind.GroupVersion().WithResource(apiResource.Name)
-	//TODO : confirm for client-go version, updated version have changed arguments
-	obj, err := dynamicIf.Resource(resource).Namespace(request.Namespace).Get(request.Name, metav1.GetOptions{})
+	obj, err := dynamicIf.Resource(resource).Namespace(request.ResourceIdentifier.Namespace).Get(request.ResourceIdentifier.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
 	return &ManifestResponse{*obj}, nil
 }
 
-func (impl K8sApplicationServiceImpl) UpdateResource(token string, request *UpdateRequest) (*ManifestResponse, error) {
-	restConfig := &rest.Config{
-		BearerToken: token,
-	}
-	dynamicIf, err := dynamic.NewForConfig(restConfig)
+func (impl K8sApplicationServiceImpl) UpdateResource(request *K8sRequestBean) (*ManifestResponse, error) {
+	dynamicIf, resource, err := impl.GetResourceAndDynamicIf(request)
 	if err != nil {
 		return nil, err
 	}
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
-	if err != nil {
-		return nil, err
-	}
-	apiResource, err := ServerResourceForGroupVersionKind(discoveryClient, request.GroupVersionKind)
-	if err != nil {
-		return nil, err
-	}
-	resource := request.GroupVersionKind.GroupVersion().WithResource(apiResource.Name)
-	obj, err := dynamicIf.Resource(resource).Namespace(request.Namespace).Patch(request.Name, types.PatchType(request.PatchType), []byte(request.Patch), metav1.PatchOptions{})
+	obj, err := dynamicIf.Resource(resource).Namespace(request.ResourceIdentifier.Namespace).Patch(request.ResourceIdentifier.Name, types.PatchType(request.PatchType), []byte(request.Patch), metav1.PatchOptions{})
 	if err != nil {
 		return nil, err
 	}
 	return &ManifestResponse{*obj}, nil
 }
-func (impl K8sApplicationServiceImpl) DeleteResource(token string, request *DeleteRequest) (*ManifestResponse, error) {
-	restConfig := &rest.Config{
-		BearerToken: token,
-	}
-	dynamicIf, err := dynamic.NewForConfig(restConfig)
+func (impl K8sApplicationServiceImpl) DeleteResource(request *K8sRequestBean) (*ManifestResponse, error) {
+	dynamicIf, resource, err := impl.GetResourceAndDynamicIf(request)
 	if err != nil {
 		return nil, err
 	}
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
+	obj, err := dynamicIf.Resource(resource).Namespace(request.ResourceIdentifier.Namespace).Get(request.ResourceIdentifier.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
-	apiResource, err := ServerResourceForGroupVersionKind(discoveryClient, request.GroupVersionKind)
-	if err != nil {
-		return nil, err
-	}
-	resource := request.GroupVersionKind.GroupVersion().WithResource(apiResource.Name)
-	obj, err := dynamicIf.Resource(resource).Namespace(request.Namespace).Get(request.Name, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	err = dynamicIf.Resource(resource).Namespace(request.Namespace).Delete(request.Name, &metav1.DeleteOptions{})
+	err = dynamicIf.Resource(resource).Namespace(request.ResourceIdentifier.Namespace).Delete(request.ResourceIdentifier.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		return nil, err
 	}
 	return &ManifestResponse{*obj}, nil
 }
 
-func (impl K8sApplicationServiceImpl) ListEvents(token string, request *GetRequest) (*EventsResponse, error) {
-	restConfig := &rest.Config{
-		BearerToken: token,
+func (impl K8sApplicationServiceImpl) ListEvents(request *K8sRequestBean) (*EventsResponse, error) {
+	restConfig, err := impl.GetClusterConfig(request.ClusterId)
+	if err != nil {
+		return nil, err
 	}
+	resourceIdentifier := request.ResourceIdentifier
 	var resourceMap map[string]string
-	resourceMap["involvedObject.apiVersion"] = request.GroupVersionKind.GroupVersion().String()
-	resourceMap["involvedObject.kind"] = request.GroupVersionKind.Kind
-	resourceMap["involvedObject.name"] = request.Name
-	resourceMap["involvedObject.namespace"] = request.Namespace
+	resourceMap["involvedObject.apiVersion"] = resourceIdentifier.GroupVersionKind.GroupVersion().String()
+	resourceMap["involvedObject.kind"] = resourceIdentifier.GroupVersionKind.Kind
+	resourceMap["involvedObject.name"] = resourceIdentifier.Name
+	resourceMap["involvedObject.namespace"] = resourceIdentifier.Namespace
 	listOptions := metav1.ListOptions{
 		FieldSelector: fields.Set(resourceMap).AsSelector().String(),
 	}
 	eventsClient, err := v1beta1.NewForConfig(restConfig)
-	events, err := eventsClient.Events(request.Namespace).List(listOptions)
+	events, err := eventsClient.Events(resourceIdentifier.Namespace).List(listOptions)
 	if err != nil {
 		return nil, err
 	}
 	return &EventsResponse{events}, nil
+}
+
+func (impl K8sApplicationServiceImpl) GetResourceAndDynamicIf(request *K8sRequestBean) (dynamicIf dynamic.Interface, resource schema.GroupVersionResource, err error) {
+	restConfig, err := impl.GetClusterConfig(request.ClusterId)
+	//TODO : remove hardcoding for token and url
+	restConfig.Host = "https://api.demo.devtron.info"
+	restConfig.BearerToken = "eyJhbGciOiJSUzI1NiIsImtpZCI6Ink4bnhvVGFaS011V1c3clRGR2pCTlhuY0hDcXFJT0NtaWUtYTR6bXJXSVkifQ.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZXZ0cm9uY2QiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlY3JldC5uYW1lIjoiY2QtdXNlci10b2tlbi13azRmZyIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJjZC11c2VyIiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQudWlkIjoiODY4ZWM0MTMtOWYxMS00ZmEyLWEzNDctMDU2NzE3ODVhNjNiIiwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OmRldnRyb25jZDpjZC11c2VyIn0.sEa6N_kGUwt8HztMzPPIGexxUStefLdw3v0JkGDUNJXLnJXtnAO9NiY068ZRkSLo8yCRgpkmfoqSbQHIRj8qdGuVltVdqNaZHVIMzy9wNoDOcuW_VDBwuMGdm7duotEtDdrGkSXOVe2ezqQGfa1ZTWCFAS6CSozsjUmyyQoAofsSTYB7h6yYsqqDaz4AVXuhuJ1wwKBcI_pLu_Rhv8COkjKcz-Hwk-xGB4x8b_cBiZlnXnhhCsX6ClIvV0Qv2F-Q90k9h9RwNG26XwsAGqXafKEC6LlZ-FT51Q7Ta_ZjrG-GGKixPpd-oSAqEi19bjW1syFMfY4cCR2uC072ZQZirA"
+	resourceIdentifier := request.ResourceIdentifier
+	dynamicIf, err = dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return dynamicIf, resource, err
+	}
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
+	if err != nil {
+		return dynamicIf, resource, err
+	}
+	apiResource, err := ServerResourceForGroupVersionKind(discoveryClient, resourceIdentifier.GroupVersionKind)
+	if err != nil {
+		return dynamicIf, resource, err
+	}
+	resource = resourceIdentifier.GroupVersionKind.GroupVersion().WithResource(apiResource.Name)
+	return dynamicIf, resource, nil
+}
+
+func (impl K8sApplicationServiceImpl) GetClusterConfig(clusterId int) (*rest.Config, error) {
+	cluster, err := impl.clusterRepository.FindById(clusterId)
+	if err != nil {
+		return nil, err
+	}
+	configMap := cluster.Config
+	bearerToken := configMap["bearer_token"]
+	var restConfig *rest.Config
+	if cluster.ClusterName == DEFAULT_CLUSTER && len(bearerToken) == 0 {
+		restConfig, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		restConfig = &rest.Config{Host: cluster.ServerUrl, BearerToken: bearerToken, TLSClientConfig: rest.TLSClientConfig{Insecure: true}}
+	}
+	return restConfig, nil
 }
 
 func ServerResourceForGroupVersionKind(discoveryClient discovery.DiscoveryInterface, gvk schema.GroupVersionKind) (*metav1.APIResource, error) {

--- a/client/k8s/application/Application.go
+++ b/client/k8s/application/Application.go
@@ -1,0 +1,74 @@
+package application
+
+import (
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+type k8sApplication interface {
+	GetResource(request *GetRequest)(resp *ManifestResponse, err error)
+}
+
+type K8sApplicationServiceImpl struct {
+	restConfig *rest.Config
+	logger     *zap.SugaredLogger
+}
+
+func NewK8sApplicationServiceImpl(restConfig *rest.Config, logger *zap.SugaredLogger) *K8sApplicationServiceImpl {
+	return &K8sApplicationServiceImpl{
+		restConfig: restConfig,
+		logger:     logger,
+	}
+}
+
+type GetRequest struct {
+	//TODO : update validations for struct
+	Name             string                  `protobuf:"bytes,1,req,name=name" json:"name,omitempty"`
+	Namespace        string                  `protobuf:"bytes,2,req,name=namespace" json:"namespace,omitempty"`
+	GroupVersionKind schema.GroupVersionKind `protobuf:"bytes,3,req,name=groupVersionKind" json:"groupVersionKind,omitempty"`
+}
+type ManifestResponse struct {
+	Manifest unstructured.Unstructured `protobuf:"bytes,1,req,name=manifest" json:"manifest,omitempty"`
+}
+
+func (impl K8sApplicationServiceImpl) GetResource(request *GetRequest)(resp *ManifestResponse, err error) {
+	dynamicIf, err := dynamic.NewForConfig(impl.restConfig)
+	if err != nil {
+		return nil, err
+	}
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(impl.restConfig)
+	if err != nil {
+		return nil, err
+	}
+	apiResource, err := ServerResourceForGroupVersionKind(discoveryClient, request.GroupVersionKind)
+	if err != nil {
+		return nil, err
+	}
+	resource := request.GroupVersionKind.GroupVersion().WithResource(apiResource.Name)
+	//TODO : confirm for client-go version, updated version have changed arguments
+	obj, err := dynamicIf.Resource(resource).Namespace(request.Namespace).Get(request.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return &ManifestResponse{*obj}, nil
+}
+
+func ServerResourceForGroupVersionKind(discoveryClient discovery.DiscoveryInterface, gvk schema.GroupVersionKind) (*metav1.APIResource, error) {
+	resources, err := discoveryClient.ServerResourcesForGroupVersion(gvk.GroupVersion().String())
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range resources.APIResources {
+		if r.Kind == gvk.Kind {
+			//log.Debugf("Chose API '%s' for %s", r.Name, gvk)
+			return &r, nil
+		}
+	}
+	return nil, errors.NewNotFound(schema.GroupResource{Group: gvk.Group, Resource: gvk.Kind}, "")
+}

--- a/wire_gen.go
+++ b/wire_gen.go
@@ -29,6 +29,7 @@ import (
 	"github.com/devtron-labs/devtron/client/gitSensor"
 	"github.com/devtron-labs/devtron/client/grafana"
 	client3 "github.com/devtron-labs/devtron/client/jira"
+	application2 "github.com/devtron-labs/devtron/client/k8s/application"
 	"github.com/devtron-labs/devtron/client/lens"
 	"github.com/devtron-labs/devtron/client/pubsub"
 	"github.com/devtron-labs/devtron/client/telemetry"
@@ -299,7 +300,9 @@ func InitializeApp() (*App, error) {
 	pumpImpl := connector.NewPumpImpl(sugaredLogger)
 	terminalSessionHandlerImpl := terminal.NewTerminalSessionHandlerImpl(environmentServiceImpl, clusterServiceImplExtended, sugaredLogger)
 	argoApplicationRestHandlerImpl := restHandler.NewArgoApplicationRestHandlerImpl(serviceClientImpl, pumpImpl, enforcerImpl, teamServiceImpl, environmentServiceImpl, sugaredLogger, enforcerUtilImpl, terminalSessionHandlerImpl)
-	applicationRouterImpl := router.NewApplicationRouterImpl(argoApplicationRestHandlerImpl, sugaredLogger)
+	k8sApplicationServiceImpl := application2.NewK8sApplicationServiceImpl(sugaredLogger)
+	k8sApplicationRestHandlerImpl := restHandler.NewK8sApplicationRestHandlerImpl(sugaredLogger, k8sApplicationServiceImpl)
+	applicationRouterImpl := router.NewApplicationRouterImpl(argoApplicationRestHandlerImpl, sugaredLogger, k8sApplicationRestHandlerImpl)
 	argoConfig, err := ArgoUtil.GetArgoConfig()
 	if err != nil {
 		return nil, err

--- a/wire_gen.go
+++ b/wire_gen.go
@@ -300,7 +300,7 @@ func InitializeApp() (*App, error) {
 	pumpImpl := connector.NewPumpImpl(sugaredLogger)
 	terminalSessionHandlerImpl := terminal.NewTerminalSessionHandlerImpl(environmentServiceImpl, clusterServiceImplExtended, sugaredLogger)
 	argoApplicationRestHandlerImpl := restHandler.NewArgoApplicationRestHandlerImpl(serviceClientImpl, pumpImpl, enforcerImpl, teamServiceImpl, environmentServiceImpl, sugaredLogger, enforcerUtilImpl, terminalSessionHandlerImpl)
-	k8sApplicationServiceImpl := application2.NewK8sApplicationServiceImpl(sugaredLogger)
+	k8sApplicationServiceImpl := application2.NewK8sApplicationServiceImpl(sugaredLogger, clusterRepositoryImpl)
 	k8sApplicationRestHandlerImpl := restHandler.NewK8sApplicationRestHandlerImpl(sugaredLogger, k8sApplicationServiceImpl)
 	applicationRouterImpl := router.NewApplicationRouterImpl(argoApplicationRestHandlerImpl, sugaredLogger, k8sApplicationRestHandlerImpl)
 	argoConfig, err := ArgoUtil.GetArgoConfig()

--- a/wire_gen.go
+++ b/wire_gen.go
@@ -459,7 +459,7 @@ func InitializeApp() (*App, error) {
 }
 
 var (
-	_wireLocalDevModeValue     = client2.LocalDevMode(false)
+	_wireLocalDevModeValue     = client2.LocalDevMode(true)
 	_wireChartWorkingDirValue  = util.ChartWorkingDir("/tmp/charts/")
 	_wireRefChartDirValue      = pipeline.RefChartDir("scripts/devtron-reference-helm-charts")
 	_wireDefaultChartValue     = pipeline.DefaultChart("reference-app-rolling")


### PR DESCRIPTION
# Description
 To migrate current methods for fetching resource tree components from argo-cd to kubernetes. The components affected will be - 
1. Manifest Get
2. Manifest Update
3. Delete
4. Event List
5. Logs
6. Terminal