### PR TITLE
Fix Kuberntes External secret k8s 1.22 compatibility issue

### DIFF
--- a/manifests/installation-script
+++ b/manifests/installation-script
@@ -1,4 +1,4 @@
-LTAG="fix-ext-secret";
+LTAG="v0.3.12";
 REPO_RAW_URL="https://raw.githubusercontent.com/devtron-labs/devtron/";
 
 operatorSecret = kubectl get secret -n devtroncd devtron-operator-secret;

--- a/manifests/installation-script
+++ b/manifests/installation-script
@@ -1,4 +1,4 @@
-LTAG="v0.3.12";
+LTAG="fix-ext-secret";
 REPO_RAW_URL="https://raw.githubusercontent.com/devtron-labs/devtron/";
 
 operatorSecret = kubectl get secret -n devtroncd devtron-operator-secret;

--- a/manifests/yamls/external-secret.yaml
+++ b/manifests/yamls/external-secret.yaml
@@ -379,8 +379,6 @@ spec:
           env:
           - name: "AKEYLESS_API_ENDPOINT"
             value: "https://api.akeyless.io"
-          - name: "AWS_REGION"
-            value: "us-west-2"
           - name: "LOG_LEVEL"
             value: "info"
           - name: "LOG_MESSAGE_KEY"

--- a/manifests/yamls/external-secret.yaml
+++ b/manifests/yamls/external-secret.yaml
@@ -1,16 +1,231 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: externalsecrets.kubernetes-client.io
   annotations:
-    # for helm v2 backwards compatibility
-    helm.sh/hook: crd-install
     # used in e2e testing
     app.kubernetes.io/managed-by: helm
 spec:
   group: kubernetes-client.io
-  version: v1
   scope: Namespaced
+
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          required:
+            - spec
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                controllerId:
+                  description: The ID of controller instance that manages this ExternalSecret.
+                    This is needed in case there is more than a KES controller instances within the cluster.
+                  type: string
+                type:
+                  type: string
+                  description: >-
+                    DEPRECATED: Use spec.template.type
+                template:
+                  description: Template which will be deep merged without mutating
+                    any existing fields. into generated secret, can be used to
+                    set for example annotations or type on the generated secret
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                backendType:
+                  description: >-
+                    Determines which backend to use for fetching secrets
+                  type: string
+                  enum:
+                    - secretsManager
+                    - systemManager
+                    - vault
+                    - azureKeyVault
+                    - gcpSecretsManager
+                    - alicloudSecretsManager
+                    - ibmcloudSecretsManager
+                    - akeyless
+                vaultRole:
+                  description: >-
+                    Used by: vault
+                  type: string
+                vaultMountPoint:
+                  description: >-
+                    Used by: vault
+                  type: string
+                kvVersion:
+                  description: Vault K/V version either 1 or 2, default = 2
+                  type: integer
+                  minimum: 1
+                  maximum: 2
+                keyVaultName:
+                  description: >-
+                    Used by: azureKeyVault
+                  type: string
+                dataFrom:
+                  type: array
+                  items:
+                    type: string
+                dataFromWithOptions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      key:
+                        description: Secret key in backend
+                        type: string
+                      isBinary:
+                        description: >-
+                          Whether the backend secret shall be treated as binary data
+                          represented by a base64-encoded string. You must set this to true
+                          for any base64-encoded binary data in the backend - to ensure it
+                          is not encoded in base64 again. Default is false.
+                        type: boolean
+                      versionStage:
+                        description: >-
+                          Used by: alicloudSecretsManager, secretsManager
+                        type: string
+                      versionId:
+                        description: >-
+                          Used by: secretsManager
+                        type: string
+                    required:
+                    - key
+                data:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      key:
+                        description: Secret key in backend
+                        type: string
+                      name:
+                        description: Name set for this key in the generated secret
+                        type: string
+                      property:
+                        description: Property to extract if secret in backend is a JSON object
+                        type: string
+                      isBinary:
+                        description: >-
+                          Whether the backend secret shall be treated as binary data
+                          represented by a base64-encoded string. You must set this to true
+                          for any base64-encoded binary data in the backend - to ensure it
+                          is not encoded in base64 again. Default is false.
+                        type: boolean
+                      path:
+                        description: >-
+                          Path from SSM to scrape secrets
+                          This will fetch all secrets and use the key from the secret as variable name
+                        type: string
+                      recursive:
+                        description: Allow to recurse thru all child keys on a given path, default false
+                        type: boolean
+                      secretType:
+                        description: >-
+                          Used by: ibmcloudSecretsManager
+                          Type of secret - one of username_password, iam_credentials or arbitrary
+                        type: string
+                      version:
+                        description: >-
+                          Used by: gcpSecretsManager
+                        type: string
+                        x-kubernetes-int-or-string: true
+                      versionStage:
+                        description: >-
+                          Used by: alicloudSecretsManager, secretsManager
+                        type: string
+                      versionId:
+                        description: >-
+                          Used by: secretsManager
+                        type: string
+                    oneOf:
+                      - required:
+                          - key
+                          - name
+                      - required:
+                          - path
+                roleArn:
+                  type: string
+                  description: >-
+                    Used by: alicloudSecretsManager, secretsManager, systemManager
+                region:
+                  type: string
+                  description: >-
+                    Used by: secretsManager, systemManager
+                projectId:
+                  type: string
+                  description: >-
+                    Used by: gcpSecretsManager
+                keyByName:
+                  type: boolean
+                  description: >-
+                    Whether to interpret the key as a secret name (if true) or ID (the default).
+                    Used by: ibmcloudSecretsManager
+              oneOf:
+                - properties:
+                    backendType:
+                      enum:
+                        - secretsManager
+                        - systemManager
+                - properties:
+                    backendType:
+                      enum:
+                        - vault
+                - properties:
+                    backendType:
+                      enum:
+                        - azureKeyVault
+                  required:
+                    - keyVaultName
+                - properties:
+                    backendType:
+                      enum:
+                        - gcpSecretsManager
+                - properties:
+                    backendType:
+                      enum:
+                        - alicloudSecretsManager
+                - properties:
+                    backendType:
+                      enum:
+                        - ibmcloudSecretsManager
+                - properties:
+                    backendType:
+                      enum:
+                        - akeyless
+              anyOf:
+                - required:
+                    - data
+                - required:
+                    - dataFrom
+                - required:
+                    - dataFromWithOptions
+            status:
+              type: object
+              properties:
+                lastSync:
+                  type: string
+                status:
+                  type: string
+                observedGeneration:
+                  type: number
+      additionalPrinterColumns:
+        - jsonPath: .status.lastSync
+          name: Last Sync
+          type: date
+        - jsonPath: .status.status
+          name: status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
 
   names:
     shortNames:
@@ -18,110 +233,6 @@ spec:
     kind: ExternalSecret
     plural: externalsecrets
     singular: externalsecret
-
-  additionalPrinterColumns:
-    - JSONPath: .status.lastSync
-      name: Last Sync
-      type: date
-    - JSONPath: .status.status
-      name: status
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          type: object
-          properties:
-            template:
-              description: Template which will be deep merged without mutating
-                any existing fields. into generated secret, can be used to
-                set for example annotations or type on the generated secret
-              type: object
-            backendType:
-              type: string
-              enum:
-                - secretsManager
-                - systemManager
-                - vault
-                - azureKeyVault
-                - gcpSecretsManager
-                - alicloudSecretsManager
-            vaultRole:
-              type: string
-            vaultMountPoint:
-              type: string
-            kvVersion:
-              description: Vault K/V version either 1 or 2, default = 2
-              type: integer
-              minimum: 1
-              maximum: 2
-            keyVaultName:
-              type: string
-            key:
-              type: string
-            dataFrom:
-              type: array
-              items:
-                type: string
-            data:
-              type: array
-              items:
-                type: object
-                properties:
-                  key:
-                    description: Secret key in backend
-                    type: string
-                  name:
-                    description: Name set for this key in the generated secret
-                    type: string
-                  property:
-                    description: Property to extract if secret in backend is a JSON object
-                  isBinary:
-                    description: >-
-                      You must set this to true if configuring an item for a binary file stored in Azure KeyVault.
-                      Azure automatically base64 encodes binary files and setting this to true ensures External Secrets
-                      does not base64 encode the base64 encoded binary files.
-                    type: boolean
-                required:
-                  - name
-                  - key
-            roleArn:
-              type: string
-          oneOf:
-            - properties:
-                backendType:
-                  enum:
-                    - secretsManager
-                    - systemManager
-            - properties:
-                backendType:
-                  enum:
-                    - vault
-            - properties:
-                backendType:
-                  enum:
-                    - azureKeyVault
-              required:
-                - keyVaultName
-            - properties:
-                backendType:
-                  enum:
-                    - gcpSecretsManager
-            - properties:
-                backendType:
-                  enum:
-                    - alicloudSecretsManager
-          anyOf:
-            - required:
-                - data
-            - required:
-                - dataFrom
-  subresources:
-    status: {}
 ---
 # Source: devtron/templates/secret.yaml
 apiVersion: v1
@@ -148,7 +259,7 @@ metadata:
   namespace: "devtroncd"
   labels:
     app.kubernetes.io/name: kubernetes-external-secrets
-    helm.sh/chart: kubernetes-external-secrets-6.0.0
+    helm.sh/chart: kubernetes-external-secrets-8.5.1
     app.kubernetes.io/instance: devtron
 ---
 # Source: kubernetes-external-secrets/templates/rbac.yaml
@@ -158,12 +269,12 @@ metadata:
   name: devtron-kubernetes-external-secrets
   labels:
     app.kubernetes.io/name: kubernetes-external-secrets
-    helm.sh/chart: kubernetes-external-secrets-6.0.0
+    helm.sh/chart: kubernetes-external-secrets-8.5.1
     app.kubernetes.io/instance: devtron
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["create", "update"]
+    verbs: ["create", "update", "get"]
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "watch", "list"]
@@ -177,9 +288,6 @@ rules:
   - apiGroups: ["kubernetes-client.io"]
     resources: ["externalsecrets/status"]
     verbs: ["get", "update"]
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["create"]
 ---
 # Source: kubernetes-external-secrets/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -188,7 +296,7 @@ metadata:
   name: devtron-kubernetes-external-secrets
   labels:
     app.kubernetes.io/name: kubernetes-external-secrets
-    helm.sh/chart: kubernetes-external-secrets-6.0.0
+    helm.sh/chart: kubernetes-external-secrets-8.5.1
     app.kubernetes.io/instance: devtron
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -206,7 +314,7 @@ metadata:
   name: devtron-kubernetes-external-secrets-auth
   labels:
     app.kubernetes.io/name: kubernetes-external-secrets
-    helm.sh/chart: kubernetes-external-secrets-6.0.0
+    helm.sh/chart: kubernetes-external-secrets-8.5.1
     app.kubernetes.io/instance: devtron
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -225,7 +333,7 @@ metadata:
   namespace: "devtroncd"
   labels:
     app.kubernetes.io/name: kubernetes-external-secrets
-    helm.sh/chart: kubernetes-external-secrets-6.0.0
+    helm.sh/chart: kubernetes-external-secrets-8.5.1
     app.kubernetes.io/instance: devtron
 spec:
   selector:
@@ -244,7 +352,7 @@ metadata:
   namespace: "devtroncd"
   labels:
     app.kubernetes.io/name: kubernetes-external-secrets
-    helm.sh/chart: kubernetes-external-secrets-6.0.0
+    helm.sh/chart: kubernetes-external-secrets-8.5.1
     app.kubernetes.io/instance: devtron
 spec:
   replicas: 1
@@ -261,12 +369,18 @@ spec:
       serviceAccountName: devtron-kubernetes-external-secrets
       containers:
         - name: kubernetes-external-secrets
-          image: "quay.io/devtron/kubernetes-external-secrets:6.0.0"
+          image: "ghcr.io/external-secrets/kubernetes-external-secrets:8.5.1"
           ports:
           - name: prometheus
             containerPort: 3001
           imagePullPolicy: IfNotPresent
+          resources:
+            {}
           env:
+          - name: "AKEYLESS_API_ENDPOINT"
+            value: "https://api.akeyless.io"
+          - name: "AWS_REGION"
+            value: "us-west-2"
           - name: "LOG_LEVEL"
             value: "info"
           - name: "LOG_MESSAGE_KEY"
@@ -275,11 +389,15 @@ spec:
             value: "3001"
           - name: "POLLER_INTERVAL_MILLISECONDS"
             value: "10000"
+          - name: "VAULT_ADDR"
+            value: "http://127.0.0.1:8200"
+          - name: "WATCH_TIMEOUT"
+            value: "60000"
+          # Params for env vars populated from k8s secrets and configmap
           envFrom:
           - configMapRef:
               name: devtron-kubernetes-external-cm
           - secretRef:
               name: devtron-kubernetes-external-secret
-          # Params for env vars populated from k8s secrets
       securityContext:
         runAsNonRoot: true

--- a/scripts/devtron-reference-helm-charts/cronjob-chart_1-2-0/templates/secret.yaml
+++ b/scripts/devtron-reference-helm-charts/cronjob-chart_1-2-0/templates/secret.yaml
@@ -31,7 +31,7 @@ metadata:
   name: {{ .name}}
 spec:
   {{- if .roleARN }}
-  roleArn: .roleArn
+  roleArn: .roleARN
   {{- end}}
   {{- if eq .externalType "AWSSecretsManager"}}
   backendType: secretsManager

--- a/scripts/devtron-reference-helm-charts/reference-chart_3-10-0/templates/secret.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_3-10-0/templates/secret.yaml
@@ -31,7 +31,7 @@ metadata:
   name: {{ .name}}
 spec:
   {{- if .roleARN }}
-  roleArn: .roleArn
+  roleArn: .roleARN
   {{- end}}
   {{- if eq .externalType "AWSSecretsManager"}}
   backendType: secretsManager

--- a/scripts/devtron-reference-helm-charts/reference-chart_3-11-0/templates/secret.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_3-11-0/templates/secret.yaml
@@ -31,7 +31,7 @@ metadata:
   name: {{ .name}}
 spec:
   {{- if .roleARN }}
-  roleArn: .roleArn
+  roleArn: .roleARN
   {{- end}}
   {{- if eq .externalType "AWSSecretsManager"}}
   backendType: secretsManager

--- a/scripts/devtron-reference-helm-charts/reference-chart_3-12-0/templates/secret.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_3-12-0/templates/secret.yaml
@@ -31,7 +31,7 @@ metadata:
   name: {{ .name}}
 spec:
   {{- if .roleARN }}
-  roleArn: .roleArn
+  roleArn: .roleARN
   {{- end}}
   {{- if eq .externalType "AWSSecretsManager"}}
   backendType: secretsManager

--- a/scripts/devtron-reference-helm-charts/reference-chart_3-8-0/templates/secret.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_3-8-0/templates/secret.yaml
@@ -31,7 +31,7 @@ metadata:
   name: {{ .name}}
 spec:
   {{- if .roleARN }}
-  roleArn: .roleArn
+  roleArn: .roleARN
   {{- end}}
   {{- if eq .externalType "AWSSecretsManager"}}
   backendType: secretsManager

--- a/scripts/devtron-reference-helm-charts/reference-chart_3-9-0/templates/secret.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_3-9-0/templates/secret.yaml
@@ -31,7 +31,7 @@ metadata:
   name: {{ .name}}
 spec:
   {{- if .roleARN }}
-  roleArn: .roleArn
+  roleArn: .roleARN
   {{- end}}
   {{- if eq .externalType "AWSSecretsManager"}}
   backendType: secretsManager

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-10-0/templates/secret.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-10-0/templates/secret.yaml
@@ -31,7 +31,7 @@ metadata:
   name: {{ .name}}
 spec:
   {{- if .roleARN }}
-  roleArn: .roleArn
+  roleArn: .roleARN
   {{- end}}
   {{- if eq .externalType "AWSSecretsManager"}}
   backendType: secretsManager

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-11-0/templates/secret.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-11-0/templates/secret.yaml
@@ -31,7 +31,7 @@ metadata:
   name: {{ .name}}
 spec:
   {{- if .roleARN }}
-  roleArn: .roleArn
+  roleArn: .roleARN
   {{- end}}
   {{- if eq .externalType "AWSSecretsManager"}}
   backendType: secretsManager


### PR DESCRIPTION
# Description

- Updated Kubernetes External secret CRDs
- Sync Kubernetes External chart from latest chart (8.5.1)
- Fixed ExternalSecret roleARN issue

Fixes #1068 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Tested on a k8s 1.22 cluster

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles


