### PR TITLE
FIX: Fixed Rollout CRDs for configmaps

### DIFF
--- a/manifests/yamls/rollout.yaml
+++ b/manifests/yamls/rollout.yaml
@@ -15508,230 +15508,402 @@ kind: CustomResourceDefinition
 metadata:
   name: rollouts.argoproj.io
 spec:
-  conversion:
-    strategy: None
   group: argoproj.io
   names:
     kind: Rollout
-    listKind: RolloutList
     plural: rollouts
     shortNames:
-      - ro
-    singular: rollout
+    - ro
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - description: Number of desired pods
-          jsonPath: .spec.replicas
-          name: Desired
-          type: integer
-        - description: Total number of non-terminated pods targeted by this rollout
-          jsonPath: .status.replicas
-          name: Current
-          type: integer
-        - description: Total number of non-terminated pods targeted by this rollout that
-            have the desired template spec
-          jsonPath: .status.updatedReplicas
-          name: Up-to-date
-          type: integer
-        - description: Total number of available pods (ready for at least minReadySeconds)
-            targeted by this rollout
-          jsonPath: .status.availableReplicas
-          name: Available
-          type: integer
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                minReadySeconds:
-                  format: int32
-                  type: integer
-                paused:
-                  type: boolean
-                progressDeadlineSeconds:
-                  format: int32
-                  type: integer
-                replicas:
-                  format: int32
-                  type: integer
-                revisionHistoryLimit:
-                  format: int32
-                  type: integer
-                selector:
-                  properties:
-                    matchExpressions:
-                      items:
-                        properties:
-                          key:
-                            type: string
-                          operator:
-                            type: string
-                          values:
-                            items:
-                              type: string
-                            type: array
-                        required:
-                          - key
-                          - operator
-                        type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      type: object
-                  type: object
-                strategy:
-                  properties:
-                    blueGreen:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.replicas
+      description: Number of desired pods
+      name: Desired
+      type: integer
+    - jsonPath: .status.replicas
+      description: Total number of non-terminated pods targeted by this rollout
+      name: Current
+      type: integer
+    - jsonPath: .status.updatedReplicas
+      description: Total number of non-terminated pods targeted by this rollout that
+        have the desired template spec
+      name: Up-to-date
+      type: integer
+    - jsonPath: .status.availableReplicas
+      description: Total number of available pods (ready for at least minReadySeconds)
+        targeted by this rollout
+      name: Available
+      type: integer
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.HPAReplicas
+    name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              minReadySeconds:
+                format: int32
+                type: integer
+              paused:
+                type: boolean
+              progressDeadlineSeconds:
+                format: int32
+                type: integer
+              replicas:
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                format: int32
+                type: integer
+              selector:
+                properties:
+                  matchExpressions:
+                    items:
                       properties:
-                        activeService:
+                        key:
                           type: string
-                        autoPromotionEnabled:
-                          type: boolean
-                        autoPromotionSeconds:
-                          format: int32
-                          type: integer
-                        previewReplicaCount:
-                          format: int32
-                          type: integer
-                        previewService:
+                        operator:
                           type: string
-                        scaleDownDelayRevisionLimit:
-                          format: int32
-                          type: integer
-                        scaleDownDelaySeconds:
-                          format: int32
-                          type: integer
-                      required:
-                        - activeService
-                      type: object
-                    canary:
-                      properties:
-                        analysis:
-                          properties:
-                            args:
-                              items:
-                                properties:
-                                  name:
-                                    type: string
-                                  value:
-                                    type: string
-                                  valueFrom:
-                                    properties:
-                                      podTemplateHashValue:
-                                        type: string
-                                    type: object
-                                required:
-                                  - name
-                                type: object
-                              type: array
-                            templateName:
-                              type: string
-                          required:
-                            - templateName
-                          type: object
-                        canaryService:
-                          type: string
-                        maxSurge:
-                          anyOf:
-                            - type: integer
-                            - type: string
-                          x-kubernetes-int-or-string: true
-                        maxUnavailable:
-                          anyOf:
-                            - type: integer
-                            - type: string
-                          x-kubernetes-int-or-string: true
-                        primaryService:
-                          type: string
-                        stableService:
-                          type: string
-                        steps:
+                        values:
                           items:
-                            properties:
-                              analysis:
-                                properties:
-                                  args:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                        valueFrom:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              strategy:
+                properties:
+                  blueGreen:
+                    properties:
+                      activeService:
+                        type: string
+                      autoPromotionEnabled:
+                        type: boolean
+                      autoPromotionSeconds:
+                        format: int32
+                        type: integer
+                      previewReplicaCount:
+                        format: int32
+                        type: integer
+                      previewService:
+                        type: string
+                      scaleDownDelayRevisionLimit:
+                        format: int32
+                        type: integer
+                      scaleDownDelaySeconds:
+                        format: int32
+                        type: integer
+                    required:
+                    - activeService
+                    type: object
+                  canary:
+                    properties:
+                      analysis:
+                        properties:
+                          args:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    podTemplateHashValue:
+                                      type: string
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          templateName:
+                            type: string
+                        required:
+                        - templateName
+                        type: object
+                      canaryService:
+                        type: string
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        x-kubernetes-int-or-string: true
+                      primaryService:
+                        type: string
+                      stableService:
+                        type: string
+                      steps:
+                        items:
+                          properties:
+                            analysis:
+                              properties:
+                                args:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          podTemplateHashValue:
+                                            type: string
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                templateName:
+                                  type: string
+                              required:
+                              - templateName
+                              type: object
+                            experiment:
+                              properties:
+                                analyses:
+                                  items:
+                                    properties:
+                                      args:
+                                        items:
                                           properties:
-                                            podTemplateHashValue:
+                                            name:
                                               type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                podTemplateHashValue:
+                                                  type: string
+                                              type: object
+                                          required:
+                                          - name
                                           type: object
-                                      required:
-                                        - name
-                                      type: object
-                                    type: array
-                                  templateName:
-                                    type: string
-                                required:
-                                  - templateName
-                                type: object
-                              experiment:
-                                properties:
-                                  analyses:
-                                    items:
+                                        type: array
+                                      name:
+                                        type: string
+                                      templateName:
+                                        type: string
+                                    required:
+                                    - name
+                                    - templateName
+                                    type: object
+                                  type: array
+                                duration:
+                                  type: string
+                                templates:
+                                  items:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      name:
+                                        type: string
+                                      replicas:
+                                        format: int32
+                                        type: integer
+                                      selector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      specRef:
+                                        type: string
+                                    required:
+                                    - name
+                                    - specRef
+                                    type: object
+                                  type: array
+                              required:
+                              - templates
+                              type: object
+                            pause:
+                              properties:
+                                duration:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            setWeight:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: array
+                    type: object
+                  recreate:
+                    properties:
+                      activeService:
+                        type: string
+                    type: object
+                type: object
+              template:
+                properties:
+                  metadata:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  spec:
+                    properties:
+                      activeDeadlineSeconds:
+                        format: int64
+                        type: integer
+                      affinity:
+                        properties:
+                          nodeAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    preference:
                                       properties:
-                                        args:
+                                        matchExpressions:
                                           items:
                                             properties:
-                                              name:
+                                              key:
                                                 type: string
-                                              value:
+                                              operator:
                                                 type: string
-                                              valueFrom:
-                                                properties:
-                                                  podTemplateHashValue:
-                                                    type: string
-                                                type: object
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
                                             required:
-                                              - name
+                                              - key
+                                              - operator
                                             type: object
                                           type: array
-                                        name:
-                                          type: string
-                                        templateName:
-                                          type: string
-                                      required:
-                                        - name
-                                        - templateName
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
                                       type: object
-                                    type: array
-                                  duration:
-                                    type: string
-                                  templates:
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - preference
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                properties:
+                                  nodeSelectorTerms:
                                     items:
                                       properties:
-                                        metadata:
-                                          properties:
-                                            annotations:
-                                              additionalProperties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
                                                 type: string
-                                              type: object
-                                            labels:
-                                              additionalProperties:
+                                              operator:
                                                 type: string
-                                              type: object
-                                          type: object
-                                        name:
-                                          type: string
-                                        replicas:
-                                          format: int32
-                                          type: integer
-                                        selector:
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                  - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
                                           properties:
                                             matchExpressions:
                                               items:
@@ -15754,2575 +15926,2201 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
-                                        specRef:
-                                          type: string
-                                      required:
-                                        - name
-                                        - specRef
-                                      type: object
-                                    type: array
-                                required:
-                                  - templates
-                                type: object
-                              pause:
-                                properties:
-                                  duration:
-                                    format: int32
-                                    type: integer
-                                type: object
-                              setWeight:
-                                format: int32
-                                type: integer
-                            type: object
-                          type: array
-                      type: object
-                    recreate:
-                      properties:
-                        activeService:
-                          type: string
-                      type: object
-                  type: object
-                template:
-                  properties:
-                    metadata:
-                      x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    spec:
-                      properties:
-                        activeDeadlineSeconds:
-                          format: int64
-                          type: integer
-                        affinity:
-                          properties:
-                            nodeAffinity:
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  items:
-                                    properties:
-                                      preference:
-                                        properties:
-                                          matchExpressions:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                operator:
-                                                  type: string
-                                                values:
-                                                  items:
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
                                                     type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                operator:
-                                                  type: string
-                                                values:
-                                                  items:
+                                                  operator:
                                                     type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      weight:
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - preference
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  properties:
-                                    nodeSelectorTerms:
-                                      items:
-                                        properties:
-                                          matchExpressions:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                operator:
-                                                  type: string
-                                                values:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                operator:
-                                                  type: string
-                                                values:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                  required:
-                                    - nodeSelectorTerms
-                                  type: object
-                              type: object
-                            podAffinity:
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  items:
-                                    properties:
-                                      podAffinityTerm:
-                                        properties:
-                                          labelSelector:
-                                            properties:
-                                              matchExpressions:
-                                                items:
-                                                  properties:
-                                                    key:
+                                                  values:
+                                                    items:
                                                       type: string
-                                                    operator:
-                                                      type: string
-                                                    values:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
                                                 type: object
-                                            type: object
-                                          namespaces:
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  items:
-                                    properties:
-                                      labelSelector:
-                                        properties:
-                                          matchExpressions:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                operator:
-                                                  type: string
-                                                values:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
                                               type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                            podAntiAffinity:
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  items:
-                                    properties:
-                                      podAffinityTerm:
-                                        properties:
-                                          labelSelector:
-                                            properties:
-                                              matchExpressions:
-                                                items:
-                                                  properties:
-                                                    key:
-                                                      type: string
-                                                    operator:
-                                                      type: string
-                                                    values:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  items:
-                                    properties:
-                                      labelSelector:
-                                        properties:
-                                          matchExpressions:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                operator:
-                                                  type: string
-                                                values:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                          type: object
-                        automountServiceAccountToken:
-                          type: boolean
-                        containers:
-                          items:
-                            properties:
-                              args:
-                                items:
-                                  type: string
-                                type: array
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                              env:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                    valueFrom:
-                                      properties:
-                                        configMapKeyRef:
-                                          properties:
-                                            key:
-                                              type: string
-                                            name:
-                                              type: string
-                                            optional:
-                                              type: boolean
-                                          required:
-                                            - key
                                           type: object
-                                        fieldRef:
-                                          properties:
-                                            apiVersion:
-                                              type: string
-                                            fieldPath:
-                                              type: string
-                                          required:
-                                            - fieldPath
-                                          type: object
-                                        resourceFieldRef:
-                                          properties:
-                                            containerName:
-                                              type: string
-                                            divisor:
-                                              type: string
-                                            resource:
-                                              type: string
-                                          required:
-                                            - resource
-                                          type: object
-                                        secretKeyRef:
-                                          properties:
-                                            key:
-                                              type: string
-                                            name:
-                                              type: string
-                                            optional:
-                                              type: boolean
-                                          required:
-                                            - key
-                                          type: object
-                                      type: object
-                                  required:
-                                    - name
-                                  type: object
-                                type: array
-                              envFrom:
-                                items:
-                                  properties:
-                                    configMapRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                        optional:
-                                          type: boolean
-                                      type: object
-                                    prefix:
-                                      type: string
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                        optional:
-                                          type: boolean
-                                      type: object
-                                  type: object
-                                type: array
-                              image:
-                                type: string
-                              imagePullPolicy:
-                                type: string
-                              lifecycle:
-                                properties:
-                                  postStart:
-                                    properties:
-                                      exec:
-                                        properties:
-                                          command:
-                                            items:
-                                              type: string
-                                            type: array
-                                        type: object
-                                      httpGet:
-                                        properties:
-                                          host:
-                                            type: string
-                                          httpHeaders:
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                value:
-                                                  type: string
-                                              required:
-                                                - name
-                                                - value
-                                              type: object
-                                            type: array
-                                          path:
-                                            type: string
-                                          port:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            x-kubernetes-int-or-string: true
-                                          scheme:
-                                            type: string
-                                        required:
-                                          - port
-                                        type: object
-                                      tcpSocket:
-                                        properties:
-                                          host:
-                                            type: string
-                                          port:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            x-kubernetes-int-or-string: true
-                                        required:
-                                          - port
-                                        type: object
-                                    type: object
-                                  preStop:
-                                    properties:
-                                      exec:
-                                        properties:
-                                          command:
-                                            items:
-                                              type: string
-                                            type: array
-                                        type: object
-                                      httpGet:
-                                        properties:
-                                          host:
-                                            type: string
-                                          httpHeaders:
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                value:
-                                                  type: string
-                                              required:
-                                                - name
-                                                - value
-                                              type: object
-                                            type: array
-                                          path:
-                                            type: string
-                                          port:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            x-kubernetes-int-or-string: true
-                                          scheme:
-                                            type: string
-                                        required:
-                                          - port
-                                        type: object
-                                      tcpSocket:
-                                        properties:
-                                          host:
-                                            type: string
-                                          port:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            x-kubernetes-int-or-string: true
-                                        required:
-                                          - port
-                                        type: object
-                                    type: object
-                                type: object
-                              livenessProbe:
-                                properties:
-                                  exec:
-                                    properties:
-                                      command:
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  failureThreshold:
-                                    format: int32
-                                    type: integer
-                                  httpGet:
-                                    properties:
-                                      host:
-                                        type: string
-                                      httpHeaders:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              type: string
-                                          required:
-                                            - name
-                                            - value
-                                          type: object
-                                        type: array
-                                      path:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        x-kubernetes-int-or-string: true
-                                      scheme:
-                                        type: string
-                                    required:
-                                      - port
-                                    type: object
-                                  initialDelaySeconds:
-                                    format: int32
-                                    type: integer
-                                  periodSeconds:
-                                    format: int32
-                                    type: integer
-                                  successThreshold:
-                                    format: int32
-                                    type: integer
-                                  tcpSocket:
-                                    properties:
-                                      host:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                      - port
-                                    type: object
-                                  timeoutSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
-                              name:
-                                type: string
-                              ports:
-                                items:
-                                  properties:
-                                    containerPort:
-                                      format: int32
-                                      type: integer
-                                    hostIP:
-                                      type: string
-                                    hostPort:
-                                      format: int32
-                                      type: integer
-                                    name:
-                                      type: string
-                                    protocol:
-                                      type: string
-                                  required:
-                                    - containerPort
-                                  type: object
-                                type: array
-                              readinessProbe:
-                                properties:
-                                  exec:
-                                    properties:
-                                      command:
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  failureThreshold:
-                                    format: int32
-                                    type: integer
-                                  httpGet:
-                                    properties:
-                                      host:
-                                        type: string
-                                      httpHeaders:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              type: string
-                                          required:
-                                            - name
-                                            - value
-                                          type: object
-                                        type: array
-                                      path:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        x-kubernetes-int-or-string: true
-                                      scheme:
-                                        type: string
-                                    required:
-                                      - port
-                                    type: object
-                                  initialDelaySeconds:
-                                    format: int32
-                                    type: integer
-                                  periodSeconds:
-                                    format: int32
-                                    type: integer
-                                  successThreshold:
-                                    format: int32
-                                    type: integer
-                                  tcpSocket:
-                                    properties:
-                                      host:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                      - port
-                                    type: object
-                                  timeoutSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
-                              resources:
-                                type: object
-                                x-kubernetes-preserve-unknown-fields: true
-                              securityContext:
-                                properties:
-                                  allowPrivilegeEscalation:
-                                    type: boolean
-                                  capabilities:
-                                    properties:
-                                      add:
-                                        items:
-                                          type: string
-                                        type: array
-                                      drop:
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  privileged:
-                                    type: boolean
-                                  procMount:
-                                    type: string
-                                  readOnlyRootFilesystem:
-                                    type: boolean
-                                  runAsGroup:
-                                    format: int64
-                                    type: integer
-                                  runAsNonRoot:
-                                    type: boolean
-                                  runAsUser:
-                                    format: int64
-                                    type: integer
-                                  seLinuxOptions:
-                                    properties:
-                                      level:
-                                        type: string
-                                      role:
-                                        type: string
-                                      type:
-                                        type: string
-                                      user:
-                                        type: string
-                                    type: object
-                                  windowsOptions:
-                                    properties:
-                                      gmsaCredentialSpec:
-                                        type: string
-                                      gmsaCredentialSpecName:
-                                        type: string
-                                      runAsUserName:
-                                        type: string
-                                    type: object
-                                type: object
-                              startupProbe:
-                                properties:
-                                  exec:
-                                    properties:
-                                      command:
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  failureThreshold:
-                                    format: int32
-                                    type: integer
-                                  httpGet:
-                                    properties:
-                                      host:
-                                        type: string
-                                      httpHeaders:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              type: string
-                                          required:
-                                            - name
-                                            - value
-                                          type: object
-                                        type: array
-                                      path:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        x-kubernetes-int-or-string: true
-                                      scheme:
-                                        type: string
-                                    required:
-                                      - port
-                                    type: object
-                                  initialDelaySeconds:
-                                    format: int32
-                                    type: integer
-                                  periodSeconds:
-                                    format: int32
-                                    type: integer
-                                  successThreshold:
-                                    format: int32
-                                    type: integer
-                                  tcpSocket:
-                                    properties:
-                                      host:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                      - port
-                                    type: object
-                                  timeoutSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
-                              stdin:
-                                type: boolean
-                              stdinOnce:
-                                type: boolean
-                              terminationMessagePath:
-                                type: string
-                              terminationMessagePolicy:
-                                type: string
-                              tty:
-                                type: boolean
-                              volumeDevices:
-                                items:
-                                  properties:
-                                    devicePath:
-                                      type: string
-                                    name:
-                                      type: string
-                                  required:
-                                    - devicePath
-                                    - name
-                                  type: object
-                                type: array
-                              volumeMounts:
-                                items:
-                                  properties:
-                                    mountPath:
-                                      type: string
-                                    mountPropagation:
-                                      type: string
-                                    name:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    subPath:
-                                      type: string
-                                    subPathExpr:
-                                      type: string
-                                  required:
-                                    - mountPath
-                                    - name
-                                  type: object
-                                type: array
-                              workingDir:
-                                type: string
-                            required:
-                              - name
-                            type: object
-                          type: array
-                        dnsConfig:
-                          properties:
-                            nameservers:
-                              items:
-                                type: string
-                              type: array
-                            options:
-                              items:
-                                properties:
-                                  name:
-                                    type: string
-                                  value:
-                                    type: string
-                                type: object
-                              type: array
-                            searches:
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        dnsPolicy:
-                          type: string
-                        enableServiceLinks:
-                          type: boolean
-                        ephemeralContainers:
-                          items:
-                            properties:
-                              args:
-                                items:
-                                  type: string
-                                type: array
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                              env:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                    valueFrom:
-                                      properties:
-                                        configMapKeyRef:
-                                          properties:
-                                            key:
-                                              type: string
-                                            name:
-                                              type: string
-                                            optional:
-                                              type: boolean
-                                          required:
-                                            - key
-                                          type: object
-                                        fieldRef:
-                                          properties:
-                                            apiVersion:
-                                              type: string
-                                            fieldPath:
-                                              type: string
-                                          required:
-                                            - fieldPath
-                                          type: object
-                                        resourceFieldRef:
-                                          properties:
-                                            containerName:
-                                              type: string
-                                            divisor:
-                                              type: string
-                                            resource:
-                                              type: string
-                                          required:
-                                            - resource
-                                          type: object
-                                        secretKeyRef:
-                                          properties:
-                                            key:
-                                              type: string
-                                            name:
-                                              type: string
-                                            optional:
-                                              type: boolean
-                                          required:
-                                            - key
-                                          type: object
-                                      type: object
-                                  required:
-                                    - name
-                                  type: object
-                                type: array
-                              envFrom:
-                                items:
-                                  properties:
-                                    configMapRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                        optional:
-                                          type: boolean
-                                      type: object
-                                    prefix:
-                                      type: string
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                        optional:
-                                          type: boolean
-                                      type: object
-                                  type: object
-                                type: array
-                              image:
-                                type: string
-                              imagePullPolicy:
-                                type: string
-                              lifecycle:
-                                properties:
-                                  postStart:
-                                    properties:
-                                      exec:
-                                        properties:
-                                          command:
-                                            items:
-                                              type: string
-                                            type: array
-                                        type: object
-                                      httpGet:
-                                        properties:
-                                          host:
-                                            type: string
-                                          httpHeaders:
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                value:
-                                                  type: string
-                                              required:
-                                                - name
-                                                - value
-                                              type: object
-                                            type: array
-                                          path:
-                                            type: string
-                                          port:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            x-kubernetes-int-or-string: true
-                                          scheme:
-                                            type: string
-                                        required:
-                                          - port
-                                        type: object
-                                      tcpSocket:
-                                        properties:
-                                          host:
-                                            type: string
-                                          port:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            x-kubernetes-int-or-string: true
-                                        required:
-                                          - port
-                                        type: object
-                                    type: object
-                                  preStop:
-                                    properties:
-                                      exec:
-                                        properties:
-                                          command:
-                                            items:
-                                              type: string
-                                            type: array
-                                        type: object
-                                      httpGet:
-                                        properties:
-                                          host:
-                                            type: string
-                                          httpHeaders:
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                value:
-                                                  type: string
-                                              required:
-                                                - name
-                                                - value
-                                              type: object
-                                            type: array
-                                          path:
-                                            type: string
-                                          port:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            x-kubernetes-int-or-string: true
-                                          scheme:
-                                            type: string
-                                        required:
-                                          - port
-                                        type: object
-                                      tcpSocket:
-                                        properties:
-                                          host:
-                                            type: string
-                                          port:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            x-kubernetes-int-or-string: true
-                                        required:
-                                          - port
-                                        type: object
-                                    type: object
-                                type: object
-                              livenessProbe:
-                                properties:
-                                  exec:
-                                    properties:
-                                      command:
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  failureThreshold:
-                                    format: int32
-                                    type: integer
-                                  httpGet:
-                                    properties:
-                                      host:
-                                        type: string
-                                      httpHeaders:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              type: string
-                                          required:
-                                            - name
-                                            - value
-                                          type: object
-                                        type: array
-                                      path:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        x-kubernetes-int-or-string: true
-                                      scheme:
-                                        type: string
-                                    required:
-                                      - port
-                                    type: object
-                                  initialDelaySeconds:
-                                    format: int32
-                                    type: integer
-                                  periodSeconds:
-                                    format: int32
-                                    type: integer
-                                  successThreshold:
-                                    format: int32
-                                    type: integer
-                                  tcpSocket:
-                                    properties:
-                                      host:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                      - port
-                                    type: object
-                                  timeoutSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
-                              name:
-                                type: string
-                              ports:
-                                items:
-                                  properties:
-                                    containerPort:
-                                      format: int32
-                                      type: integer
-                                    hostIP:
-                                      type: string
-                                    hostPort:
-                                      format: int32
-                                      type: integer
-                                    name:
-                                      type: string
-                                    protocol:
-                                      type: string
-                                  required:
-                                    - containerPort
-                                  type: object
-                                type: array
-                              readinessProbe:
-                                properties:
-                                  exec:
-                                    properties:
-                                      command:
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  failureThreshold:
-                                    format: int32
-                                    type: integer
-                                  httpGet:
-                                    properties:
-                                      host:
-                                        type: string
-                                      httpHeaders:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              type: string
-                                          required:
-                                            - name
-                                            - value
-                                          type: object
-                                        type: array
-                                      path:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        x-kubernetes-int-or-string: true
-                                      scheme:
-                                        type: string
-                                    required:
-                                      - port
-                                    type: object
-                                  initialDelaySeconds:
-                                    format: int32
-                                    type: integer
-                                  periodSeconds:
-                                    format: int32
-                                    type: integer
-                                  successThreshold:
-                                    format: int32
-                                    type: integer
-                                  tcpSocket:
-                                    properties:
-                                      host:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                      - port
-                                    type: object
-                                  timeoutSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
-                              resources:
-                                type: object
-                              securityContext:
-                                properties:
-                                  allowPrivilegeEscalation:
-                                    type: boolean
-                                  capabilities:
-                                    properties:
-                                      add:
-                                        items:
-                                          type: string
-                                        type: array
-                                      drop:
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  privileged:
-                                    type: boolean
-                                  procMount:
-                                    type: string
-                                  readOnlyRootFilesystem:
-                                    type: boolean
-                                  runAsGroup:
-                                    format: int64
-                                    type: integer
-                                  runAsNonRoot:
-                                    type: boolean
-                                  runAsUser:
-                                    format: int64
-                                    type: integer
-                                  seLinuxOptions:
-                                    properties:
-                                      level:
-                                        type: string
-                                      role:
-                                        type: string
-                                      type:
-                                        type: string
-                                      user:
-                                        type: string
-                                    type: object
-                                  windowsOptions:
-                                    properties:
-                                      gmsaCredentialSpec:
-                                        type: string
-                                      gmsaCredentialSpecName:
-                                        type: string
-                                      runAsUserName:
-                                        type: string
-                                    type: object
-                                type: object
-                              startupProbe:
-                                properties:
-                                  exec:
-                                    properties:
-                                      command:
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  failureThreshold:
-                                    format: int32
-                                    type: integer
-                                  httpGet:
-                                    properties:
-                                      host:
-                                        type: string
-                                      httpHeaders:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              type: string
-                                          required:
-                                            - name
-                                            - value
-                                          type: object
-                                        type: array
-                                      path:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        x-kubernetes-int-or-string: true
-                                      scheme:
-                                        type: string
-                                    required:
-                                      - port
-                                    type: object
-                                  initialDelaySeconds:
-                                    format: int32
-                                    type: integer
-                                  periodSeconds:
-                                    format: int32
-                                    type: integer
-                                  successThreshold:
-                                    format: int32
-                                    type: integer
-                                  tcpSocket:
-                                    properties:
-                                      host:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                      - port
-                                    type: object
-                                  timeoutSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
-                              stdin:
-                                type: boolean
-                              stdinOnce:
-                                type: boolean
-                              targetContainerName:
-                                type: string
-                              terminationMessagePath:
-                                type: string
-                              terminationMessagePolicy:
-                                type: string
-                              tty:
-                                type: boolean
-                              volumeDevices:
-                                items:
-                                  properties:
-                                    devicePath:
-                                      type: string
-                                    name:
-                                      type: string
-                                  required:
-                                    - devicePath
-                                    - name
-                                  type: object
-                                type: array
-                              volumeMounts:
-                                items:
-                                  properties:
-                                    mountPath:
-                                      type: string
-                                    mountPropagation:
-                                      type: string
-                                    name:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    subPath:
-                                      type: string
-                                    subPathExpr:
-                                      type: string
-                                  required:
-                                    - mountPath
-                                    - name
-                                  type: object
-                                type: array
-                              workingDir:
-                                type: string
-                            required:
-                              - name
-                            type: object
-                          type: array
-                        hostAliases:
-                          items:
-                            properties:
-                              hostnames:
-                                items:
-                                  type: string
-                                type: array
-                              ip:
-                                type: string
-                            type: object
-                          type: array
-                        hostIPC:
-                          type: boolean
-                        hostNetwork:
-                          type: boolean
-                        hostPID:
-                          type: boolean
-                        hostname:
-                          type: string
-                        imagePullSecrets:
-                          items:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          type: array
-                        initContainers:
-                          items:
-                            properties:
-                              args:
-                                items:
-                                  type: string
-                                type: array
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                              env:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                    valueFrom:
-                                      properties:
-                                        configMapKeyRef:
-                                          properties:
-                                            key:
-                                              type: string
-                                            name:
-                                              type: string
-                                            optional:
-                                              type: boolean
-                                          required:
-                                            - key
-                                          type: object
-                                        fieldRef:
-                                          properties:
-                                            apiVersion:
-                                              type: string
-                                            fieldPath:
-                                              type: string
-                                          required:
-                                            - fieldPath
-                                          type: object
-                                        resourceFieldRef:
-                                          properties:
-                                            containerName:
-                                              type: string
-                                            divisor:
-                                              type: string
-                                            resource:
-                                              type: string
-                                          required:
-                                            - resource
-                                          type: object
-                                        secretKeyRef:
-                                          properties:
-                                            key:
-                                              type: string
-                                            name:
-                                              type: string
-                                            optional:
-                                              type: boolean
-                                          required:
-                                            - key
-                                          type: object
-                                      type: object
-                                  required:
-                                    - name
-                                  type: object
-                                type: array
-                              envFrom:
-                                items:
-                                  properties:
-                                    configMapRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                        optional:
-                                          type: boolean
-                                      type: object
-                                    prefix:
-                                      type: string
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                        optional:
-                                          type: boolean
-                                      type: object
-                                  type: object
-                                type: array
-                              image:
-                                type: string
-                              imagePullPolicy:
-                                type: string
-                              lifecycle:
-                                properties:
-                                  postStart:
-                                    properties:
-                                      exec:
-                                        properties:
-                                          command:
-                                            items:
-                                              type: string
-                                            type: array
-                                        type: object
-                                      httpGet:
-                                        properties:
-                                          host:
-                                            type: string
-                                          httpHeaders:
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                value:
-                                                  type: string
-                                              required:
-                                                - name
-                                                - value
-                                              type: object
-                                            type: array
-                                          path:
-                                            type: string
-                                          port:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            x-kubernetes-int-or-string: true
-                                          scheme:
-                                            type: string
-                                        required:
-                                          - port
-                                        type: object
-                                      tcpSocket:
-                                        properties:
-                                          host:
-                                            type: string
-                                          port:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            x-kubernetes-int-or-string: true
-                                        required:
-                                          - port
-                                        type: object
-                                    type: object
-                                  preStop:
-                                    properties:
-                                      exec:
-                                        properties:
-                                          command:
-                                            items:
-                                              type: string
-                                            type: array
-                                        type: object
-                                      httpGet:
-                                        properties:
-                                          host:
-                                            type: string
-                                          httpHeaders:
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                value:
-                                                  type: string
-                                              required:
-                                                - name
-                                                - value
-                                              type: object
-                                            type: array
-                                          path:
-                                            type: string
-                                          port:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            x-kubernetes-int-or-string: true
-                                          scheme:
-                                            type: string
-                                        required:
-                                          - port
-                                        type: object
-                                      tcpSocket:
-                                        properties:
-                                          host:
-                                            type: string
-                                          port:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            x-kubernetes-int-or-string: true
-                                        required:
-                                          - port
-                                        type: object
-                                    type: object
-                                type: object
-                              livenessProbe:
-                                properties:
-                                  exec:
-                                    properties:
-                                      command:
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  failureThreshold:
-                                    format: int32
-                                    type: integer
-                                  httpGet:
-                                    properties:
-                                      host:
-                                        type: string
-                                      httpHeaders:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              type: string
-                                          required:
-                                            - name
-                                            - value
-                                          type: object
-                                        type: array
-                                      path:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        x-kubernetes-int-or-string: true
-                                      scheme:
-                                        type: string
-                                    required:
-                                      - port
-                                    type: object
-                                  initialDelaySeconds:
-                                    format: int32
-                                    type: integer
-                                  periodSeconds:
-                                    format: int32
-                                    type: integer
-                                  successThreshold:
-                                    format: int32
-                                    type: integer
-                                  tcpSocket:
-                                    properties:
-                                      host:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                      - port
-                                    type: object
-                                  timeoutSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
-                              name:
-                                type: string
-                              ports:
-                                items:
-                                  properties:
-                                    containerPort:
-                                      format: int32
-                                      type: integer
-                                    hostIP:
-                                      type: string
-                                    hostPort:
-                                      format: int32
-                                      type: integer
-                                    name:
-                                      type: string
-                                    protocol:
-                                      type: string
-                                  required:
-                                    - containerPort
-                                  type: object
-                                type: array
-                              readinessProbe:
-                                properties:
-                                  exec:
-                                    properties:
-                                      command:
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  failureThreshold:
-                                    format: int32
-                                    type: integer
-                                  httpGet:
-                                    properties:
-                                      host:
-                                        type: string
-                                      httpHeaders:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              type: string
-                                          required:
-                                            - name
-                                            - value
-                                          type: object
-                                        type: array
-                                      path:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        x-kubernetes-int-or-string: true
-                                      scheme:
-                                        type: string
-                                    required:
-                                      - port
-                                    type: object
-                                  initialDelaySeconds:
-                                    format: int32
-                                    type: integer
-                                  periodSeconds:
-                                    format: int32
-                                    type: integer
-                                  successThreshold:
-                                    format: int32
-                                    type: integer
-                                  tcpSocket:
-                                    properties:
-                                      host:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                      - port
-                                    type: object
-                                  timeoutSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
-                              resources:
-                                type: object
-                              securityContext:
-                                properties:
-                                  allowPrivilegeEscalation:
-                                    type: boolean
-                                  capabilities:
-                                    properties:
-                                      add:
-                                        items:
-                                          type: string
-                                        type: array
-                                      drop:
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  privileged:
-                                    type: boolean
-                                  procMount:
-                                    type: string
-                                  readOnlyRootFilesystem:
-                                    type: boolean
-                                  runAsGroup:
-                                    format: int64
-                                    type: integer
-                                  runAsNonRoot:
-                                    type: boolean
-                                  runAsUser:
-                                    format: int64
-                                    type: integer
-                                  seLinuxOptions:
-                                    properties:
-                                      level:
-                                        type: string
-                                      role:
-                                        type: string
-                                      type:
-                                        type: string
-                                      user:
-                                        type: string
-                                    type: object
-                                  windowsOptions:
-                                    properties:
-                                      gmsaCredentialSpec:
-                                        type: string
-                                      gmsaCredentialSpecName:
-                                        type: string
-                                      runAsUserName:
-                                        type: string
-                                    type: object
-                                type: object
-                              startupProbe:
-                                properties:
-                                  exec:
-                                    properties:
-                                      command:
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  failureThreshold:
-                                    format: int32
-                                    type: integer
-                                  httpGet:
-                                    properties:
-                                      host:
-                                        type: string
-                                      httpHeaders:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              type: string
-                                          required:
-                                            - name
-                                            - value
-                                          type: object
-                                        type: array
-                                      path:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        x-kubernetes-int-or-string: true
-                                      scheme:
-                                        type: string
-                                    required:
-                                      - port
-                                    type: object
-                                  initialDelaySeconds:
-                                    format: int32
-                                    type: integer
-                                  periodSeconds:
-                                    format: int32
-                                    type: integer
-                                  successThreshold:
-                                    format: int32
-                                    type: integer
-                                  tcpSocket:
-                                    properties:
-                                      host:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                      - port
-                                    type: object
-                                  timeoutSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
-                              stdin:
-                                type: boolean
-                              stdinOnce:
-                                type: boolean
-                              terminationMessagePath:
-                                type: string
-                              terminationMessagePolicy:
-                                type: string
-                              tty:
-                                type: boolean
-                              volumeDevices:
-                                items:
-                                  properties:
-                                    devicePath:
-                                      type: string
-                                    name:
-                                      type: string
-                                  required:
-                                    - devicePath
-                                    - name
-                                  type: object
-                                type: array
-                              volumeMounts:
-                                items:
-                                  properties:
-                                    mountPath:
-                                      type: string
-                                    mountPropagation:
-                                      type: string
-                                    name:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    subPath:
-                                      type: string
-                                    subPathExpr:
-                                      type: string
-                                  required:
-                                    - mountPath
-                                    - name
-                                  type: object
-                                type: array
-                              workingDir:
-                                type: string
-                            required:
-                              - name
-                            type: object
-                          type: array
-                        nodeName:
-                          type: string
-                        nodeSelector:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        overhead:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        preemptionPolicy:
-                          type: string
-                        priority:
-                          format: int32
-                          type: integer
-                        priorityClassName:
-                          type: string
-                        readinessGates:
-                          items:
-                            properties:
-                              conditionType:
-                                type: string
-                            required:
-                              - conditionType
-                            type: object
-                          type: array
-                        restartPolicy:
-                          type: string
-                        runtimeClassName:
-                          type: string
-                        schedulerName:
-                          type: string
-                        securityContext:
-                          properties:
-                            fsGroup:
-                              format: int64
-                              type: integer
-                            runAsGroup:
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              type: boolean
-                            runAsUser:
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              properties:
-                                level:
-                                  type: string
-                                role:
-                                  type: string
-                                type:
-                                  type: string
-                                user:
-                                  type: string
-                              type: object
-                            supplementalGroups:
-                              items:
-                                format: int64
-                                type: integer
-                              type: array
-                            sysctls:
-                              items:
-                                properties:
-                                  name:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            windowsOptions:
-                              properties:
-                                gmsaCredentialSpec:
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  type: string
-                                runAsUserName:
-                                  type: string
-                              type: object
-                          type: object
-                        serviceAccount:
-                          type: string
-                        serviceAccountName:
-                          type: string
-                        shareProcessNamespace:
-                          type: boolean
-                        subdomain:
-                          type: string
-                        terminationGracePeriodSeconds:
-                          format: int64
-                          type: integer
-                        tolerations:
-                          items:
-                            properties:
-                              effect:
-                                type: string
-                              key:
-                                type: string
-                              operator:
-                                type: string
-                              tolerationSeconds:
-                                format: int64
-                                type: integer
-                              value:
-                                type: string
-                            type: object
-                          type: array
-                        topologySpreadConstraints:
-                          items:
-                            properties:
-                              labelSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
+                                        namespaces:
                                           items:
                                             type: string
                                           type: array
+                                        topologyKey:
+                                          type: string
                                       required:
-                                        - key
-                                        - operator
+                                        - topologyKey
                                       type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              maxSkew:
-                                format: int32
-                                type: integer
-                              topologyKey:
-                                type: string
-                              whenUnsatisfiable:
-                                type: string
-                            required:
-                              - maxSkew
-                              - topologyKey
-                              - whenUnsatisfiable
-                            type: object
-                          type: array
-                        volumes:
-                          items:
-                            properties:
-                              awsElasticBlockStore:
-                                properties:
-                                  fsType:
-                                    type: string
-                                  partition:
-                                    format: int32
-                                    type: integer
-                                  readOnly:
-                                    type: boolean
-                                  volumeID:
-                                    type: string
-                                required:
-                                  - volumeID
-                                type: object
-                              azureDisk:
-                                properties:
-                                  cachingMode:
-                                    type: string
-                                  diskName:
-                                    type: string
-                                  diskURI:
-                                    type: string
-                                  fsType:
-                                    type: string
-                                  kind:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                required:
-                                  - diskName
-                                  - diskURI
-                                type: object
-                              azureFile:
-                                properties:
-                                  readOnly:
-                                    type: boolean
-                                  secretName:
-                                    type: string
-                                  shareName:
-                                    type: string
-                                required:
-                                  - secretName
-                                  - shareName
-                                type: object
-                              cephfs:
-                                properties:
-                                  monitors:
-                                    items:
-                                      type: string
-                                    type: array
-                                  path:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  secretFile:
-                                    type: string
-                                  secretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                    type: object
-                                  user:
-                                    type: string
-                                required:
-                                  - monitors
-                                type: object
-                              cinder:
-                                properties:
-                                  fsType:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  secretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                    type: object
-                                  volumeID:
-                                    type: string
-                                required:
-                                  - volumeID
-                                type: object
-                              csi:
-                                properties:
-                                  driver:
-                                    type: string
-                                  fsType:
-                                    type: string
-                                  nodePublishSecretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                    type: object
-                                  readOnly:
-                                    type: boolean
-                                  volumeAttributes:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                required:
-                                  - driver
-                                type: object
-                              emptyDir:
-                                properties:
-                                  medium:
-                                    type: string
-                                  sizeLimit:
-                                    type: string
-                                type: object
-                              fc:
-                                properties:
-                                  fsType:
-                                    type: string
-                                  lun:
-                                    format: int32
-                                    type: integer
-                                  readOnly:
-                                    type: boolean
-                                  targetWWNs:
-                                    items:
-                                      type: string
-                                    type: array
-                                  wwids:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              flexVolume:
-                                properties:
-                                  driver:
-                                    type: string
-                                  fsType:
-                                    type: string
-                                  options:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                  readOnly:
-                                    type: boolean
-                                  secretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                    type: object
-                                required:
-                                  - driver
-                                type: object
-                              flocker:
-                                properties:
-                                  datasetName:
-                                    type: string
-                                  datasetUUID:
-                                    type: string
-                                type: object
-                              gcePersistentDisk:
-                                properties:
-                                  fsType:
-                                    type: string
-                                  partition:
-                                    format: int32
-                                    type: integer
-                                  pdName:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                required:
-                                  - pdName
-                                type: object
-                              gitRepo:
-                                properties:
-                                  directory:
-                                    type: string
-                                  repository:
-                                    type: string
-                                  revision:
-                                    type: string
-                                required:
-                                  - repository
-                                type: object
-                              glusterfs:
-                                properties:
-                                  endpoints:
-                                    type: string
-                                  path:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                required:
-                                  - endpoints
-                                  - path
-                                type: object
-                              hostPath:
-                                properties:
-                                  path:
-                                    type: string
-                                  type:
-                                    type: string
-                                required:
-                                  - path
-                                type: object
-                              iscsi:
-                                properties:
-                                  chapAuthDiscovery:
-                                    type: boolean
-                                  chapAuthSession:
-                                    type: boolean
-                                  fsType:
-                                    type: string
-                                  initiatorName:
-                                    type: string
-                                  iqn:
-                                    type: string
-                                  iscsiInterface:
-                                    type: string
-                                  lun:
-                                    format: int32
-                                    type: integer
-                                  portals:
-                                    items:
-                                      type: string
-                                    type: array
-                                  readOnly:
-                                    type: boolean
-                                  secretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                    type: object
-                                  targetPortal:
-                                    type: string
-                                required:
-                                  - iqn
-                                  - lun
-                                  - targetPortal
-                                type: object
-                              name:
-                                type: string
-                              nfs:
-                                properties:
-                                  path:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  server:
-                                    type: string
-                                required:
-                                  - path
-                                  - server
-                                type: object
-                              persistentVolumeClaim:
-                                properties:
-                                  claimName:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                required:
-                                  - claimName
-                                type: object
-                              photonPersistentDisk:
-                                properties:
-                                  fsType:
-                                    type: string
-                                  pdID:
-                                    type: string
-                                required:
-                                  - pdID
-                                type: object
-                              portworxVolume:
-                                properties:
-                                  fsType:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  volumeID:
-                                    type: string
-                                required:
-                                  - volumeID
-                                type: object
-                              projected:
-                                properties:
-                                  defaultMode:
-                                    format: int32
-                                    type: integer
-                                  sources:
-                                    items:
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
                                       properties:
-                                        serviceAccountToken:
-                                          properties:
-                                            audience:
-                                              type: string
-                                            expirationSeconds:
-                                              format: int64
-                                              type: integer
-                                            path:
-                                              type: string
-                                          required:
-                                            - path
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                       type: object
-                                    type: array
-                                required:
-                                  - sources
-                                type: object
-                              quobyte:
-                                properties:
-                                  group:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  registry:
-                                    type: string
-                                  tenant:
-                                    type: string
-                                  user:
-                                    type: string
-                                  volume:
-                                    type: string
-                                required:
-                                  - registry
-                                  - volume
-                                type: object
-                              rbd:
-                                properties:
-                                  fsType:
-                                    type: string
-                                  image:
-                                    type: string
-                                  keyring:
-                                    type: string
-                                  monitors:
-                                    items:
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
                                       type: string
-                                    type: array
-                                  pool:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  secretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                    type: object
-                                  user:
-                                    type: string
-                                required:
-                                  - image
-                                  - monitors
-                                type: object
-                              scaleIO:
-                                properties:
-                                  fsType:
-                                    type: string
-                                  gateway:
-                                    type: string
-                                  protectionDomain:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  secretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                    type: object
-                                  sslEnabled:
-                                    type: boolean
-                                  storageMode:
-                                    type: string
-                                  storagePool:
-                                    type: string
-                                  system:
-                                    type: string
-                                  volumeName:
-                                    type: string
-                                required:
-                                  - gateway
-                                  - secretRef
-                                  - system
-                                type: object
-                              storageos:
-                                properties:
-                                  fsType:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  secretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                    type: object
-                                  volumeName:
-                                    type: string
-                                  volumeNamespace:
-                                    type: string
-                                type: object
-                              vsphereVolume:
-                                properties:
-                                  fsType:
-                                    type: string
-                                  storagePolicyID:
-                                    type: string
-                                  storagePolicyName:
-                                    type: string
-                                  volumePath:
-                                    type: string
-                                required:
-                                  - volumePath
-                                type: object
-                            required:
-                              - name
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
                             type: object
-                          type: array
-                      required:
-                        - containers
-                      type: object
-                  type: object
-              required:
-                - selector
-                - template
-              type: object
-            status:
-              properties:
-                HPAReplicas:
-                  format: int32
-                  type: integer
-                abort:
-                  type: boolean
-                availableReplicas:
-                  format: int32
-                  type: integer
-                blueGreen:
+                          podAntiAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      automountServiceAccountToken:
+                        type: boolean
+                      containers:
+                        items:
+                          properties:
+                            args:
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                            envFrom:
+                              items:
+                                properties:
+                                  configMapRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              type: string
+                            imagePullPolicy:
+                              type: string
+                            lifecycle:
+                              properties:
+                                postStart:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                              - name
+                                              - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                        - port
+                                      type: object
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                        - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                              - name
+                                              - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                        - port
+                                      type: object
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                        - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - containerPort
+                                - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                requests:
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              type: boolean
+                            stdinOnce:
+                              type: boolean
+                            terminationMessagePath:
+                              type: string
+                            terminationMessagePolicy:
+                              type: string
+                            tty:
+                              type: boolean
+                            volumeDevices:
+                              items:
+                                properties:
+                                  devicePath:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                  - devicePath
+                                  - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                            workingDir:
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                      dnsConfig:
+                        properties:
+                          nameservers:
+                            items:
+                              type: string
+                            type: array
+                          options:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                          searches:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      dnsPolicy:
+                        type: string
+                      enableServiceLinks:
+                        type: boolean
+                      ephemeralContainers:
+                        items:
+                          properties:
+                            args:
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                            envFrom:
+                              items:
+                                properties:
+                                  configMapRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              type: string
+                            imagePullPolicy:
+                              type: string
+                            lifecycle:
+                              properties:
+                                postStart:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                              - name
+                                              - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                        - port
+                                      type: object
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                        - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                              - name
+                                              - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                        - port
+                                      type: object
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                        - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                requests:
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              type: boolean
+                            stdinOnce:
+                              type: boolean
+                            targetContainerName:
+                              type: string
+                            terminationMessagePath:
+                              type: string
+                            terminationMessagePolicy:
+                              type: string
+                            tty:
+                              type: boolean
+                            volumeDevices:
+                              items:
+                                properties:
+                                  devicePath:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                  - devicePath
+                                  - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                            workingDir:
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                      hostAliases:
+                        items:
+                          properties:
+                            hostnames:
+                              items:
+                                type: string
+                              type: array
+                            ip:
+                              type: string
+                          type: object
+                        type: array
+                      hostIPC:
+                        type: boolean
+                      hostNetwork:
+                        type: boolean
+                      hostPID:
+                        type: boolean
+                      hostname:
+                        type: string
+                      imagePullSecrets:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                      initContainers:
+                        items:
+                          properties:
+                            args:
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                            envFrom:
+                              items:
+                                properties:
+                                  configMapRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              type: string
+                            imagePullPolicy:
+                              type: string
+                            lifecycle:
+                              properties:
+                                postStart:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                              - name
+                                              - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                        - port
+                                      type: object
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                        - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                              - name
+                                              - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                        - port
+                                      type: object
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                        - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - containerPort
+                                - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                requests:
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              type: boolean
+                            stdinOnce:
+                              type: boolean
+                            terminationMessagePath:
+                              type: string
+                            terminationMessagePolicy:
+                              type: string
+                            tty:
+                              type: boolean
+                            volumeDevices:
+                              items:
+                                properties:
+                                  devicePath:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                  - devicePath
+                                  - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                            workingDir:
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                      nodeName:
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      overhead:
+                        additionalProperties:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      preemptionPolicy:
+                        type: string
+                      priority:
+                        format: int32
+                        type: integer
+                      priorityClassName:
+                        type: string
+                      readinessGates:
+                        items:
+                          properties:
+                            conditionType:
+                              type: string
+                          required:
+                            - conditionType
+                          type: object
+                        type: array
+                      restartPolicy:
+                        type: string
+                      runtimeClassName:
+                        type: string
+                      schedulerName:
+                        type: string
+                      securityContext:
+                        properties:
+                          fsGroup:
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                            type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          supplementalGroups:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          sysctls:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                          windowsOptions:
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              runAsUserName:
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccount:
+                        type: string
+                      serviceAccountName:
+                        type: string
+                      setHostnameAsFQDN:
+                        type: boolean
+                      shareProcessNamespace:
+                        type: boolean
+                      subdomain:
+                        type: string
+                      terminationGracePeriodSeconds:
+                        format: int64
+                        type: integer
+                      tolerations:
+                        items:
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              format: int64
+                              type: integer
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      topologySpreadConstraints:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            maxSkew:
+                              format: int32
+                              type: integer
+                            topologyKey:
+                              type: string
+                            whenUnsatisfiable:
+                              type: string
+                          required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - topologyKey
+                          - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      volumes:
+                        x-kubernetes-preserve-unknown-fields: true
+                    required:
+                      - containers
+                    type: object
+                type: object
+            type: object
+          status:
+            properties:
+              HPAReplicas:
+                format: int32
+                type: integer
+              abort:
+                type: boolean
+              availableReplicas:
+                format: int32
+                type: integer
+              blueGreen:
+                properties:
+                  activeSelector:
+                    type: string
+                  previewSelector:
+                    type: string
+                  previousActiveSelector:
+                    type: string
+                  scaleDownDelayStartTime:
+                    format: date-time
+                    type: string
+                  scaleUpPreviewCheckPoint:
+                    type: boolean
+                type: object
+              canary:
+                properties:
+                  currentBackgroundAnalysisRun:
+                    type: string
+                  currentExperiment:
+                    type: string
+                  currentStepAnalysisRun:
+                    type: string
+                  stableRS:
+                    type: string
+                type: object
+              collisionCount:
+                format: int32
+                type: integer
+              conditions:
+                items:
                   properties:
-                    activeSelector:
-                      type: string
-                    previewSelector:
-                      type: string
-                    previousActiveSelector:
-                      type: string
-                    scaleDownDelayStartTime:
+                    lastTransitionTime:
                       format: date-time
                       type: string
-                    scaleUpPreviewCheckPoint:
-                      type: boolean
+                    lastUpdateTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - lastUpdateTime
+                  - message
+                  - reason
+                  - status
+                  - type
                   type: object
-                canary:
+                type: array
+              controllerPause:
+                type: boolean
+              currentPodHash:
+                type: string
+              currentStepHash:
+                type: string
+              currentStepIndex:
+                format: int32
+                type: integer
+              observedGeneration:
+                type: string
+              pauseConditions:
+                items:
                   properties:
-                    currentBackgroundAnalysisRun:
+                    reason:
                       type: string
-                    currentExperiment:
+                    startTime:
+                      format: date-time
                       type: string
-                    currentStepAnalysisRun:
-                      type: string
-                    stableRS:
-                      type: string
+                  required:
+                  - reason
+                  - startTime
                   type: object
-                collisionCount:
-                  format: int32
-                  type: integer
-                conditions:
-                  items:
-                    properties:
-                      lastTransitionTime:
-                        format: date-time
-                        type: string
-                      lastUpdateTime:
-                        format: date-time
-                        type: string
-                      message:
-                        type: string
-                      reason:
-                        type: string
-                      status:
-                        type: string
-                      type:
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - lastUpdateTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                controllerPause:
-                  type: boolean
-                currentPodHash:
-                  type: string
-                currentStepHash:
-                  type: string
-                currentStepIndex:
-                  format: int32
-                  type: integer
-                observedGeneration:
-                  type: string
-                pauseConditions:
-                  items:
-                    properties:
-                      reason:
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                    required:
-                      - reason
-                      - startTime
-                    type: object
-                  type: array
-                pauseStartTime:
-                  format: date-time
-                  type: string
-                readyReplicas:
-                  format: int32
-                  type: integer
-                replicas:
-                  format: int32
-                  type: integer
-                selector:
-                  type: string
-                updatedReplicas:
-                  format: int32
-                  type: integer
-              type: object
-          required:
-            - spec
-          type: object
-      served: true
-      storage: true
-      subresources:
-        scale:
-          labelSelectorPath: .status.selector
-          specReplicasPath: .spec.replicas
-          statusReplicasPath: .status.HPAReplicas
+                type: array
+              pauseStartTime:
+                format: date-time
+                type: string
+              readyReplicas:
+                format: int32
+                type: integer
+              recreate:
+                properties:
+                  currentRS:
+                    type: string
+                type: object
+              replicas:
+                format: int32
+                type: integer
+              selector:
+                type: string
+              updatedReplicas:
+                format: int32
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object


### PR DESCRIPTION
# Description

This PR fixes the issues with app-metrics or envoy configmap not being able to be mounted or configmaps and secrets not being able to be applied as data-volume

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested on K8s cluster 1.22
- [x] Tested on K8s cluster 1.21


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles


