### PR TITLE
[FIX] Grafana charts not imported issue

### DIFF
--- a/manifests/installation-script
+++ b/manifests/installation-script
@@ -1,4 +1,4 @@
-LTAG="v0.3.13";
+LTAG="grafana-unhealthy-issue";
 REPO_RAW_URL="https://raw.githubusercontent.com/devtron-labs/devtron/";
 
 operatorSecret = kubectl get secret -n devtroncd devtron-operator-secret;

--- a/manifests/installation-script
+++ b/manifests/installation-script
@@ -263,9 +263,20 @@ kubeYamlDelete(grafana, filter=`networking.k8s.io/Ingress/devtroncd/devtron-graf
 grafana = kubectl apply -n devtroncd grafana -u grafanaOverride;
 log("setup grafana");
 
+grafanahealth = kubectl -n devtroncd get deploy devtron-grafana -o jsonpath='{.status.readyReplicas}'
+if !grafanahealth {
+log("Grafana is unhealthy, waiting for it to become healthy");
+sleep50;
+}
+
+grafanahealth = kubectl -n devtroncd get deploy devtron-grafana -o jsonpath='{.status.readyReplicas}'
+if !grafanahealth {
+log("Grafana is unhealthy, waiting for it to become healthy");
+sleep50;
+}
+
 if !hasgrafana {
 	createOrgScript = shebang + `
-	sleep 50
 	ORG_ID=$( curl -d '{"name":"devtron-metrics-view"}' -H "Content-Type: application/json" -X POST '` + grafanaUrlWithPwd + `/api/orgs' )
 	echo $ORG_ID
 	`;

--- a/manifests/installation-script
+++ b/manifests/installation-script
@@ -263,17 +263,20 @@ kubeYamlDelete(grafana, filter=`networking.k8s.io/Ingress/devtroncd/devtron-graf
 grafana = kubectl apply -n devtroncd grafana -u grafanaOverride;
 log("setup grafana");
 
-grafanahealth = kubectl -n devtroncd get deploy devtron-grafana -o jsonpath='{.status.readyReplicas}'
-if !grafanahealth {
+grafanadeployment = kubectl get deployment -n devtroncd devtron-grafana;
+grafanastatus = jsonSelect(grafanadeployment, "status.readyReplicas");
+
+if !grafanastatus {
 log("Grafana is unhealthy, waiting for it to become healthy");
 sleep50;
 }
 
 grafanahealth = kubectl -n devtroncd get deploy devtron-grafana -o jsonpath='{.status.readyReplicas}'
-if !grafanahealth {
+if !grafanastatus {
 log("Grafana is unhealthy, waiting for it to become healthy");
 sleep50;
 }
+
 
 if !hasgrafana {
 	createOrgScript = shebang + `

--- a/manifests/installation-script
+++ b/manifests/installation-script
@@ -265,15 +265,15 @@ log("setup grafana");
 
 grafanadeployment = kubectl get deployment -n devtroncd devtron-grafana;
 grafanastatus = jsonSelect(grafanadeployment, "status.readyReplicas");
-
 if !grafanastatus {
 log("Grafana is unhealthy, waiting for it to become healthy");
 sleep50;
 }
 
-grafanahealth = kubectl -n devtroncd get deploy devtron-grafana -o jsonpath='{.status.readyReplicas}'
+grafanadeployment = kubectl get deployment -n devtroncd devtron-grafana;
+grafanastatus = jsonSelect(grafanadeployment, "status.readyReplicas");
 if !grafanastatus {
-log("Grafana is unhealthy, waiting for it to become healthy");
+log("Grafana is unhealthy, again waiting for it to become healthy");
 sleep50;
 }
 


### PR DESCRIPTION
# Description

When Devtron is installed with S3 as BLOB storage, the Grafana app-metrics chart import fails as the grafana pod is not ready when the script is run.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test case A
- [ ] Test case B


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles


