### PR TITLE
FIX : image scan bug

### DIFF
--- a/internal/sql/repository/CiArtifactRepository.go
+++ b/internal/sql/repository/CiArtifactRepository.go
@@ -115,7 +115,7 @@ func (impl CiArtifactRepositoryImpl) GetArtifactsByCDPipeline(cdPipelineId, limi
 	var artifactsAB []CiArtifact
 
 	queryFetchArtifacts := ""
-	queryFetchArtifacts = "SELECT cia.id, cia.data_source, cia.image, cia.image_digest FROM ci_artifact cia" +
+	queryFetchArtifacts = "SELECT cia.id, cia.data_source, cia.image, cia.image_digest, cia.scan_enabled, cia.scanned FROM ci_artifact cia" +
 		" INNER JOIN ci_pipeline cp on cp.id=cia.pipeline_id" +
 		" INNER JOIN pipeline p on p.ci_pipeline_id = cp.id" +
 		" WHERE p.id= ? ORDER BY cia.id DESC"

--- a/pkg/pipeline/CiService.go
+++ b/pkg/pipeline/CiService.go
@@ -341,6 +341,7 @@ func (impl *CiServiceImpl) buildWfRequestForCiPipeline(pipeline *pipelineConfig.
 		WorkflowNamePrefix:       strconv.Itoa(savedWf.Id) + "-" + savedWf.Name,
 		PipelineName:             pipeline.Name,
 		PipelineId:               pipeline.Id,
+		DockerRegistryId:         pipeline.CiTemplate.DockerRegistry.Id,
 		DockerRegistryType:       string(pipeline.CiTemplate.DockerRegistry.RegistryType),
 		DockerImageTag:           dockerImageTag,
 		DockerRegistryURL:        pipeline.CiTemplate.DockerRegistry.RegistryURL,

--- a/pkg/pipeline/WorkflowService.go
+++ b/pkg/pipeline/WorkflowService.go
@@ -61,6 +61,7 @@ type WorkflowRequest struct {
 	PipelineName             string             `json:"pipelineName"`
 	PipelineId               int                `json:"pipelineId"`
 	DockerImageTag           string             `json:"dockerImageTag"`
+	DockerRegistryId       string               `json:"dockerRegistryId"`
 	DockerRegistryType       string             `json:"dockerRegistryType"`
 	DockerRegistryURL        string             `json:"dockerRegistryURL"`
 	DockerConnection         string             `json:"dockerConnection"`

--- a/pkg/pipeline/WorkflowService.go
+++ b/pkg/pipeline/WorkflowService.go
@@ -61,7 +61,7 @@ type WorkflowRequest struct {
 	PipelineName             string             `json:"pipelineName"`
 	PipelineId               int                `json:"pipelineId"`
 	DockerImageTag           string             `json:"dockerImageTag"`
-	DockerRegistryId       string               `json:"dockerRegistryId"`
+	DockerRegistryId         string             `json:"dockerRegistryId"`
 	DockerRegistryType       string             `json:"dockerRegistryType"`
 	DockerRegistryURL        string             `json:"dockerRegistryURL"`
 	DockerConnection         string             `json:"dockerConnection"`

--- a/pkg/security/policyService.go
+++ b/pkg/security/policyService.go
@@ -128,17 +128,18 @@ type VerifyImageResponse struct {
 }
 
 type ScanEvent struct {
-	Image        string `json:"image"`
-	ImageDigest  string `json:"imageDigest"`
-	AppId        int    `json:"appId"`
-	EnvId        int    `json:"envId"`
-	PipelineId   int    `json:"pipelineId"`
-	CiArtifactId int    `json:"ciArtifactId"`
-	UserId       int    `json:"userId"`
-	AccessKey    string `json:"accessKey"`
-	SecretKey    string `json:"secretKey"`
-	Token        string `json:"token"`
-	AwsRegion    string `json:"awsRegion"`
+	Image            string `json:"image"`
+	ImageDigest      string `json:"imageDigest"`
+	AppId            int    `json:"appId"`
+	EnvId            int    `json:"envId"`
+	PipelineId       int    `json:"pipelineId"`
+	CiArtifactId     int    `json:"ciArtifactId"`
+	UserId           int    `json:"userId"`
+	AccessKey        string `json:"accessKey"`
+	SecretKey        string `json:"secretKey"`
+	Token            string `json:"token"`
+	AwsRegion        string `json:"awsRegion"`
+	DockerRegistryId string `json:"dockerRegistryId"`
 }
 
 func (impl *PolicyServiceImpl) SendEventToClairUtility(event *ScanEvent) error {
@@ -226,7 +227,7 @@ func (impl *PolicyServiceImpl) VerifyImage(verifyImageRequest *VerifyImageReques
 				impl.logger.Errorw("error in fetching docker reg ", "err", err)
 				return nil, err
 			}
-			scanEvent.AwsRegion = dockerReg.DockerRegistry.AWSRegion
+			scanEvent.DockerRegistryId = dockerReg.DockerRegistry.Id
 			err = impl.SendEventToClairUtility(scanEvent)
 			if err != nil {
 				impl.logger.Errorw("error in send event to image scanner ", "err", err)
@@ -269,7 +270,7 @@ func (impl *PolicyServiceImpl) VerifyImage(verifyImageRequest *VerifyImageReques
 		}
 		err = impl.imageScanObjectMetaRepository.Save(imageScanObjectMeta)
 		if err != nil {
-			impl.logger.Errorw("error in updataing imageScanObjectMetaRepository info", "err", err)
+			impl.logger.Errorw("error in updating imageScanObjectMetaRepository info", "err", err)
 			return imageBlockedCves, nil
 		}
 		typeId = imageScanObjectMeta.Id


### PR DESCRIPTION
# Description

When image scanning is enabled, user is not able to view scan results data when selecting image in cd pipeline. This bug is in the case when parent is ci pipeline. The query for finding artifacts from ci pipeline does not select data columns for image scan bool, which leads to the bug.  