### PR TITLE
environment identifier fixed for helm apps rbac

### DIFF
--- a/util/rbac/EnforcerUtil.go
+++ b/util/rbac/EnforcerUtil.go
@@ -256,7 +256,12 @@ func (impl EnforcerUtilImpl) GetHelmObject(appId int, envId int) string {
 	if err != nil {
 		return fmt.Sprintf("%s/%s/%s", "", "", "")
 	}
-	return fmt.Sprintf("%s/%s/%s", strings.ToLower(application.Team.Name), env.EnvironmentIdentifier, strings.ToLower(application.AppName))
+	environmentIdentifier := env.EnvironmentIdentifier
+	//here cluster, env, namespace must not have double underscore in names, as we are using that for separator.
+	if !strings.Contains(env.EnvironmentIdentifier, "__") {
+		environmentIdentifier = fmt.Sprintf("%s__%s", env.Cluster.ClusterName, env.EnvironmentIdentifier)
+	}
+	return fmt.Sprintf("%s/%s/%s", strings.ToLower(application.Team.Name), environmentIdentifier, strings.ToLower(application.AppName))
 }
 
 func (impl EnforcerUtilImpl) GetHelmObjectByAppNameAndEnvId(appName string, envId int) string {
@@ -268,5 +273,10 @@ func (impl EnforcerUtilImpl) GetHelmObjectByAppNameAndEnvId(appName string, envI
 	if err != nil {
 		return fmt.Sprintf("%s/%s/%s", "", "", "")
 	}
-	return fmt.Sprintf("%s/%s/%s", strings.ToLower(application.Team.Name), env.EnvironmentIdentifier, strings.ToLower(application.AppName))
+	environmentIdentifier := env.EnvironmentIdentifier
+	//here cluster, env, namespace must not have double underscore in names, as we are using that for separator.
+	if !strings.Contains(env.EnvironmentIdentifier, "__") {
+		environmentIdentifier = fmt.Sprintf("%s__%s", env.Cluster.ClusterName, env.EnvironmentIdentifier)
+	}
+	return fmt.Sprintf("%s/%s/%s", strings.ToLower(application.Team.Name), environmentIdentifier, strings.ToLower(application.AppName))
 }

--- a/util/rbac/EnforcerUtil.go
+++ b/util/rbac/EnforcerUtil.go
@@ -258,7 +258,7 @@ func (impl EnforcerUtilImpl) GetHelmObject(appId int, envId int) string {
 	}
 	environmentIdentifier := env.EnvironmentIdentifier
 	//here cluster, env, namespace must not have double underscore in names, as we are using that for separator.
-	if !strings.Contains(env.EnvironmentIdentifier, "__") {
+	if !strings.HasPrefix(env.EnvironmentIdentifier, fmt.Sprintf("%s__", env.Cluster.ClusterName)) {
 		environmentIdentifier = fmt.Sprintf("%s__%s", env.Cluster.ClusterName, env.EnvironmentIdentifier)
 	}
 	return fmt.Sprintf("%s/%s/%s", strings.ToLower(application.Team.Name), environmentIdentifier, strings.ToLower(application.AppName))
@@ -275,7 +275,7 @@ func (impl EnforcerUtilImpl) GetHelmObjectByAppNameAndEnvId(appName string, envI
 	}
 	environmentIdentifier := env.EnvironmentIdentifier
 	//here cluster, env, namespace must not have double underscore in names, as we are using that for separator.
-	if !strings.Contains(env.EnvironmentIdentifier, "__") {
+	if !strings.HasPrefix(env.EnvironmentIdentifier, fmt.Sprintf("%s__", env.Cluster.ClusterName)) {
 		environmentIdentifier = fmt.Sprintf("%s__%s", env.Cluster.ClusterName, env.EnvironmentIdentifier)
 	}
 	return fmt.Sprintf("%s/%s/%s", strings.ToLower(application.Team.Name), environmentIdentifier, strings.ToLower(application.AppName))


### PR DESCRIPTION
# Description

Issue Fixed
Issue: Not able to see charts for permission project:devtron-demo; cluster:demo1; All apps; permission: view & edit even though there are helm apps available for selected permission.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Get Charts 
- [x] Update and Deploy Charts


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles


