### PR TITLE
fix: Namespace informer cache object close on config update

### DIFF
--- a/pkg/cluster/ClusterService.go
+++ b/pkg/cluster/ClusterService.go
@@ -381,6 +381,9 @@ func (impl *ClusterServiceImpl) Update(ctx context.Context, bean *ClusterBean, u
 	bean.Id = model.Id
 
 	if hasChangedInConfig {
+		//before creating new informer for cluster, close existing one
+		impl.K8sInformerFactory.CleanNamespaceInformer(model.ClusterName)
+		//create new informer for cluster with new config
 		clusterInfo := &bean2.ClusterInfo{
 			ClusterId:   model.Id,
 			ClusterName: model.ClusterName,

--- a/pkg/cluster/ClusterService.go
+++ b/pkg/cluster/ClusterService.go
@@ -25,6 +25,7 @@ import (
 	"github.com/devtron-labs/devtron/internal/constants"
 	"github.com/devtron-labs/devtron/internal/util"
 	"github.com/devtron-labs/devtron/pkg/cluster/repository"
+	util2 "github.com/devtron-labs/devtron/util"
 	"github.com/go-pg/pg"
 	"go.uber.org/zap"
 	"io/ioutil"
@@ -43,6 +44,7 @@ type ClusterBean struct {
 	DefaultClusterComponent []*DefaultClusterComponent `json:"defaultClusterComponent"`
 	AgentInstallationStage  int                        `json:"agentInstallationStage,notnull"` // -1=external, 0=not triggered, 1=progressing, 2=success, 3=fails
 	K8sVersion              string                     `json:"k8sVersion"`
+	HasConfigOrUrlChanged   bool                       `json:"-"`
 }
 
 type PrometheusAuth struct {
@@ -178,14 +180,10 @@ func (impl *ClusterServiceImpl) Save(parent context.Context, bean *ClusterBean, 
 	bean.Id = model.Id
 
 	//on successful creation of new cluster, update informer cache for namespace group by cluster
-	bearerToken := model.Config["bearer_token"]
-	clusterInfo := &bean2.ClusterInfo{
-		ClusterId:   model.Id,
-		ClusterName: model.ClusterName,
-		BearerToken: bearerToken,
-		ServerUrl:   model.ServerUrl,
+	//here sync for ea mode only
+	if util2.GetDevtronVersion().ServerMode != "FULL" {
+		impl.SyncNsInformer(bean)
 	}
-	impl.K8sInformerFactory.BuildInformer([]*bean2.ClusterInfo{clusterInfo})
 	return bean, err
 }
 
@@ -319,7 +317,6 @@ func (impl *ClusterServiceImpl) Update(ctx context.Context, bean *ClusterBean, u
 		impl.logger.Error(err)
 		return nil, err
 	}
-
 	existingModel, err := impl.clusterRepository.FindOne(bean.ClusterName)
 	if err != nil && err != pg.ErrNoRows {
 		impl.logger.Error(err)
@@ -333,9 +330,8 @@ func (impl *ClusterServiceImpl) Update(ctx context.Context, bean *ClusterBean, u
 	// check weather config modified or not, if yes create informer with updated config
 	dbConfig := model.Config["bearer_token"]
 	requestConfig := bean.Config["bearer_token"]
-	hasChangedInConfig := false
 	if bean.ServerUrl != model.ServerUrl || dbConfig != requestConfig {
-		hasChangedInConfig = true
+		bean.HasConfigOrUrlChanged = true
 	}
 	model.ClusterName = bean.ClusterName
 	model.ServerUrl = bean.ServerUrl
@@ -377,22 +373,27 @@ func (impl *ClusterServiceImpl) Update(ctx context.Context, bean *ClusterBean, u
 		}
 		return bean, err
 	}
-
 	bean.Id = model.Id
 
-	if hasChangedInConfig {
-		//before creating new informer for cluster, close existing one
-		impl.K8sInformerFactory.CleanNamespaceInformer(model.ClusterName)
-		//create new informer for cluster with new config
-		clusterInfo := &bean2.ClusterInfo{
-			ClusterId:   model.Id,
-			ClusterName: model.ClusterName,
-			BearerToken: dbConfig,
-			ServerUrl:   model.ServerUrl,
-		}
-		impl.K8sInformerFactory.BuildInformer([]*bean2.ClusterInfo{clusterInfo})
+	//here sync for ea mode only
+	if bean.HasConfigOrUrlChanged && util2.GetDevtronVersion().ServerMode != "FULL" {
+		impl.SyncNsInformer(bean)
 	}
 	return bean, err
+}
+
+func (impl *ClusterServiceImpl) SyncNsInformer(bean *ClusterBean) {
+	requestConfig := bean.Config["bearer_token"]
+	//before creating new informer for cluster, close existing one
+	impl.K8sInformerFactory.CleanNamespaceInformer(bean.ClusterName)
+	//create new informer for cluster with new config
+	clusterInfo := &bean2.ClusterInfo{
+		ClusterId:   bean.Id,
+		ClusterName: bean.ClusterName,
+		BearerToken: requestConfig,
+		ServerUrl:   bean.ServerUrl,
+	}
+	impl.K8sInformerFactory.BuildInformer([]*bean2.ClusterInfo{clusterInfo})
 }
 
 func (impl *ClusterServiceImpl) Delete(bean *ClusterBean, userId int32) error {

--- a/pkg/cluster/ClusterServiceExtended.go
+++ b/pkg/cluster/ClusterServiceExtended.go
@@ -222,6 +222,10 @@ func (impl *ClusterServiceImplExtended) Update(ctx context.Context, bean *Cluste
 		}
 		return nil, err
 	}
+
+	if bean.HasConfigOrUrlChanged {
+		impl.ClusterServiceImpl.SyncNsInformer(bean)
+	}
 	return bean, err
 }
 
@@ -323,5 +327,8 @@ func (impl *ClusterServiceImplExtended) Save(ctx context.Context, bean *ClusterB
 		return nil, err
 
 	}
+	//on successful creation of new cluster, update informer cache for namespace group by cluster
+	impl.SyncNsInformer(bean)
+	
 	return clusterBean, nil
 }


### PR DESCRIPTION
# Description

Requirement is to stop or close informer runner forcefully on cluster deletion or any cluster config update.
- added informer sync function,  triggered when config modified for any cluster.
- added in both ea and full mode.
- code refactored for buildInformer from Add and Update cluster request.

Fixes # (issue) : https://github.com/devtron-labs/devtron/issues/1165

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested in Ea - cluster create, update
- [x] Tested in EA - namespace list
- [x] Tested in Full - cluster create, update
- [x] Tested in Full - namespace list

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles


