### PR TITLE
FIX : auth bug causing panic

### DIFF
--- a/pkg/user/casbin/Adapter.go
+++ b/pkg/user/casbin/Adapter.go
@@ -63,6 +63,8 @@ func Create() *casbin.Enforcer {
 	if err != nil {
 		log.Fatal(err)
 	}
+	//adding our key matching func - MatchKeyFunc, to enforcer
+	e.AddFunction("matchKeyByPart", MatchKeyByPartFunc)
 	return e
 }
 

--- a/pkg/user/casbin/rbac.go
+++ b/pkg/user/casbin/rbac.go
@@ -100,8 +100,6 @@ func (e *EnforcerImpl) enforce(enf *casbin.Enforcer, rvals ...interface{}) bool 
 		email = sub
 	}
 	rvals[0] = strings.ToLower(email)
-	//adding our key matching func - MatchKeyFunc, to enforcer
-	enf.AddFunction("matchKeyByPart", MatchKeyByPartFunc)
 	return enf.Enforce(rvals...)
 }
 
@@ -111,8 +109,6 @@ func (e *EnforcerImpl) enforceByEmail(enf *casbin.Enforcer, rvals ...interface{}
 	if len(rvals) == 0 {
 		return false
 	}
-	//adding our key matching func - MatchKeyFunc, to enforcer
-	enf.AddFunction("matchKeyByPart", MatchKeyByPartFunc)
 	return enf.Enforce(rvals...)
 }
 


### PR DESCRIPTION
# Description

In the release #1128, a customised function in casbin enforcer was added for matching keys. This function was being added at runtime for every auth enforcer request. This was causing concurrent write and read operation in the map containing all the key matching functions. Fixed this and removed this function from runtime.