### PR TITLE
FIX : drop redundant tables in database

### DIFF
--- a/scripts/sql/35_alter_old_db.down.sql
+++ b/scripts/sql/35_alter_old_db.down.sql
@@ -1,0 +1,1 @@
+----empty script as up.sql for this contains dropping redundant tables

--- a/scripts/sql/35_alter_old_db.up.sql
+++ b/scripts/sql/35_alter_old_db.up.sql
@@ -1,0 +1,9 @@
+----Dropping tables which are not being used and are not deleted earlier by migration
+
+DROP TABLE IF EXISTS casbin_role CASCADE;
+
+DROP TABLE IF EXISTS casbin CASCADE;
+
+DROP TABLE IF EXISTS external_apps CASCADE;
+
+DROP TABLE IF EXISTS pipeline_config CASCADE;


### PR DESCRIPTION
# Description

Old database for orchestrator in some clusters contains redundant tables which are not used and are blocking other features due to some constraints they have. Create and drop queries of these tables are not present in earlier scripts, and they are either formed due to manual changes or wrong migration which are not reverted. Added script for dropping these tables if they exist. The tables are - 
1. casbin_role
2. casbin
3. external_apps
4. pipeline_config

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test case A
- [ ] Test case B


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles


