### PR TITLE
fix: Send Devtron mode for events[EA2][1122]

### DIFF
--- a/client/telemetry/TelemetryEventClientExtended.go
+++ b/client/telemetry/TelemetryEventClientExtended.go
@@ -72,6 +72,7 @@ type TelemetryEventDto struct {
 	Summary        *SummaryDto        `json:"summary,omitempty"`
 	ServerVersion  string             `json:"serverVersion,omitempty"`
 	DevtronVersion string             `json:"devtronVersion,omitempty"`
+	DevtronMode    string             `json:"devtronMode,omitempty"`
 }
 
 type SummaryDto struct {
@@ -85,7 +86,6 @@ type SummaryDto struct {
 	HelmChartCount          int    `json:"helmChartCount,omitempty"`
 	SecurityScanCountPerDay int    `json:"securityScanCountPerDay,omitempty"`
 	DevtronVersion          string `json:"devtronVersion,omitempty"`
-	DevtronMode             string `json:"devtronMode,omitempty"`
 }
 
 func (impl *TelemetryEventClientImplExtended) SummaryEventForTelemetry() {
@@ -146,10 +146,9 @@ func (impl *TelemetryEventClientImplExtended) SummaryEventForTelemetry() {
 		CiCountPerDay:    len(ciPipeline),
 		CdCountPerDay:    len(cdPipeline),
 		DevtronVersion:   devtronVersion.GitCommit,
-		DevtronMode:      devtronVersion.ServerMode,
 	}
 	payload.Summary = summary
-
+	payload.DevtronMode = devtronVersion.ServerMode
 	reqBody, err := json.Marshal(payload)
 	if err != nil {
 		impl.logger.Errorw("SummaryEventForTelemetry, payload marshal error", "error", err)


### PR DESCRIPTION
Description

Sending Devtron mode for both Full mode and Hyperion mode

Cause: Payload didn't have Devtron mode
CounterMeasure: Added Devtron mode in payload

Fixes # (issue) 1122

Type of change

[ Yes] Bug fix (non-breaking change which fixes an issue)
  New feature (non-breaking change which adds functionality)
  Breaking change (fix or feature that would cause existing functionality to not work as expected)
  This change requires a documentation update
How Has This Been Tested?

Test case A: Tested it by installing EA mode (Updated PostHog API key value to send events to mine) and have seen the events send to my PostHog server and also checked again re-running the pod which will not send the event as we store the value in config map and ignore if it is already sent

Test case B: Tested by sending Summary Events also, those events were also sent to the server

Checklist:

[yes ] The title of the PR states what changed and the related issues number (used for the release note).
[ no] Does this PR require documentation updates?
  I've updated documentation as required by this PR.
  I have performed a self-review of my own code
  I have commented my code, particularly in hard-to-understand areas
  I have tested it for all user roles