### PR TITLE
Job Cronjob security context

### DIFF
--- a/scripts/devtron-reference-helm-charts/cronjob-chart_1-2-0/app-values.yaml
+++ b/scripts/devtron-reference-helm-charts/cronjob-chart_1-2-0/app-values.yaml
@@ -237,3 +237,11 @@ envoyproxy:
 imagePullSecrets: []
   # - test1
   # - test2
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+
+podSecurityContext: {}
+  # runAsUser: 1000
+  # runAsGroup: 3000
+  # fsGroup: 2000

--- a/scripts/devtron-reference-helm-charts/cronjob-chart_1-2-0/templates/Cronjob.yaml
+++ b/scripts/devtron-reference-helm-charts/cronjob-chart_1-2-0/templates/Cronjob.yaml
@@ -87,6 +87,10 @@ spec:
           tolerations:
     {{- toYaml .Values.tolerations | nindent 12 }}
       {{- end }}
+{{- if $.Values.podSecurityContext }}
+          securityContext:
+{{ toYaml .Values.podSecurityContext | indent 12 }}
+{{- end }}
     {{- if $.Values.imagePullSecrets}}
           imagePullSecrets:
       {{- range .Values.imagePullSecrets }}
@@ -149,6 +153,15 @@ spec:
               securityContext:
                 privileged: true
     {{- end}}
+{{- if $.Values.containerSecurityContext }}
+              securityContext:
+{{ toYaml .Values.containerSecurityContext | indent 16 }}
+{{- end }}
+{{- if and $.Values.containerSecurityContext $.Values.privileged }}
+              securityContext:
+                privileged: true
+{{ toYaml .Values.containerSecurityContext | indent 16 }}
+{{- end }}
               ports:
               {{- range $.Values.ContainerPort }}
                 - name: {{ .name}}

--- a/scripts/devtron-reference-helm-charts/cronjob-chart_1-2-0/templates/job.yaml
+++ b/scripts/devtron-reference-helm-charts/cronjob-chart_1-2-0/templates/job.yaml
@@ -82,6 +82,10 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
   {{- end }}
+{{- if $.Values.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
+{{- end }}
 {{- if $.Values.imagePullSecrets}}
       imagePullSecrets:
   {{- range .Values.imagePullSecrets }}
@@ -144,6 +148,15 @@ spec:
           securityContext:
             privileged: true
 {{- end}}
+{{- if $.Values.containerSecurityContext }}
+          securityContext:
+{{ toYaml .Values.containerSecurityContext | indent 12 }}
+{{- end }}
+{{- if and $.Values.containerSecurityContext $.Values.privileged }}
+          securityContext:
+            privileged: true
+{{ toYaml .Values.containerSecurityContext | indent 12 }}
+{{- end }}
           ports:
           {{- range $.Values.ContainerPort }}
             - name: {{ .name}}

--- a/scripts/devtron-reference-helm-charts/cronjob-chart_1-2-0/test_values.yaml
+++ b/scripts/devtron-reference-helm-charts/cronjob-chart_1-2-0/test_values.yaml
@@ -423,3 +423,11 @@ podAnnotations:
 
 podLabels:
   severity: critical
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+
+podSecurityContext: {}
+  # runAsUser: 1000
+  # runAsGroup: 3000
+  # fsGroup: 2000


### PR DESCRIPTION
# Description

Currently in Job and CronJob manifest there is no option to add security context. 

Fixes # (issue)

Updated the Job and CronJob manifests to support security context.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

