### PR TITLE
Fix ingress new and legacy compatibility issues

### DIFF
--- a/scripts/devtron-reference-helm-charts/reference-chart_4-11-0/templates/ingress.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-11-0/templates/ingress.yaml
@@ -57,6 +57,7 @@ spec:
               servicePort: {{ $svcPort }}
               {{- end }}
   {{- end }}
+  {{- if .Values.ingress.hosts }}
   {{- range .Values.ingress.hosts }}
     {{ $outer := . -}}
     - host: {{ .host | quote }}
@@ -78,6 +79,7 @@ spec:
               servicePort: {{ $svcPort }}
               {{- end }}
         {{- end }}
+  {{- end }}
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
@@ -131,6 +133,7 @@ spec:
               servicePort: {{ $svcPort }}
               {{- end }}
   {{- end }}
+  {{- if .Values.ingressInternal.hosts }}
   {{- range .Values.ingressInternal.hosts }}
     {{ $outer := . -}}
     - host: {{ .host | quote }}
@@ -152,6 +155,7 @@ spec:
               servicePort: {{ $svcPort }}
               {{- end }}
         {{- end }}
+  {{- end }}
   {{- end }}
   {{- if .Values.ingressInternal.tls }}
   tls:


### PR DESCRIPTION
# Description

When using ingress in legacy format with the latest chart versions, it inserts the example.com values in the created ingress and gives pathType expected error.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test case A
- [ ] Test case B


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles


