### PR TITLE
FIx: hotfix k8s factory cluster config nil pointer issue

### DIFF
--- a/client/k8s/informer/K8sInformerFactory.go
+++ b/client/k8s/informer/K8sInformerFactory.go
@@ -81,11 +81,12 @@ func (impl *K8sInformerFactoryImpl) BuildInformer(clusterInfo []*bean.ClusterInf
 					impl.logger.Errorw("Error while building config from flags", "error", err)
 				}
 			} else {
-				restConfig, err := rest.InClusterConfig()
+				clusterConfig, err := rest.InClusterConfig()
 				if err != nil {
 					impl.logger.Errorw("error in fetch default cluster config", "err", err, "servername", restConfig.ServerName)
 					continue
 				}
+				restConfig = clusterConfig
 			}
 
 			impl.buildInformerAndNamespaceList(info.ClusterName, restConfig, &impl.mutex)


### PR DESCRIPTION
# Description

Getting error while application startup, as k8s factory gives nil pointer. fixed rest client variable initialisation. 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Orchestrator start cluster config clients correctly setup.


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles
* [ ] I have added all the required unit/api test cases



