### PR TITLE
docs: Fixing image resizing on external links page

### DIFF
--- a/docs/user-guide/creating-application/app-details.md
+++ b/docs/user-guide/creating-application/app-details.md
@@ -7,13 +7,13 @@ The users can access the configured external links from the **App Details** page
 1. Select **Applications** from the left navigation pane.
 2. After selecting a configured application, select the **App Details** tab.
    
-   > **Note**: The external link configured on the cluster where your app is located is the only one that is visible.
+> **Note**: The external link configured on the cluster where your app is located is the only one that is visible.
 
-   As shown in the screenshot, the monitoring tool appears at the configured component level:
+As shown in the screenshot, the monitoring tool appears at the configured component level:
 
-![](https://devtron-public-asset.s3.us-east-2.amazonaws.com/external-tools/link-app-pod-level.png)
+![External links at apps and pod level](https://devtron-public-asset.s3.us-east-2.amazonaws.com/external-tools/link-app-pod-level.png)
 
-![](https://devtron-public-asset.s3.us-east-2.amazonaws.com/external-tools/link-container-level.png)
+![External links at container level](https://devtron-public-asset.s3.us-east-2.amazonaws.com/external-tools/link-container-level.png)
 
 
 3. Click on an external link to access the Monitoring Tool.

--- a/docs/user-guide/global-configurations/external-links.md
+++ b/docs/user-guide/global-configurations/external-links.md
@@ -23,12 +23,12 @@ Before you begin, configure an application in the Devtron dashboard.
 1. On the Devtron dashboard, select `Global Configurations` from the left navigation pane.
 2. Select `External links`.
    
-   ![External links welcome page](https://devtron-public-asset.s3.us-east-2.amazonaws.com/external-tools/external-links-welcome.png)
+![External links welcome page](https://devtron-public-asset.s3.us-east-2.amazonaws.com/external-tools/external-links-welcome.png)
 
 3. Select **Add link**.
 4. On the `Add link` page, enter the following fields:
 
-    ![Create an external link](https://devtron-public-asset.s3.us-east-2.amazonaws.com/external-tools/add-external-link.png)
+![Create an external link](https://devtron-public-asset.s3.us-east-2.amazonaws.com/external-tools/add-external-link.png)
 
     <table>
     <row>


### PR DESCRIPTION
# Description

Fixing the image resizing in **Global Configurations > External links** page. The markdown styling resized the images. So removing the extra space.
Also adding the missing image captions in **Global Configurations > App Details** page.

## Type of change

- [x] This change requires a documentation update

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated documentation as required by this PR.


