### PR TITLE
Docs: Fixing table spacing in External links page

### DIFF
--- a/docs/user-guide/global-configurations/external-links.md
+++ b/docs/user-guide/global-configurations/external-links.md
@@ -30,7 +30,7 @@ Before you begin, configure an application in the Devtron dashboard.
 
 ![Create an external link](https://devtron-public-asset.s3.us-east-2.amazonaws.com/external-tools/add-external-link.png)
 
-    <table>
+<table>
     <row>
         <th>Field name</th>
         <th>Description</th>
@@ -74,9 +74,9 @@ Before you begin, configure an application in the Devtron dashboard.
             <code>https://www.grafana.com/grafana/devtroncd/demo-app/details/24/prod/191/details/my-pod-name</code>
         </td>
     </tr>
-    </table>
+</table>
 
-    > Tip: To add multiple links, select **+ Add another** at the top-left corner.
+> Tip: To add multiple links, select **+ Add another** at the top-left corner.
 
 5. Select **Save**.
 


### PR DESCRIPTION
# Description

Fixing table rendering in **Global Configurations > External links** page.

## Type of change

- [x] This change requires a documentation update

# Checklist:

* [x] I've updated documentation as required by this PR.


