### PR TITLE
Fix: Chart update failed in case missing gitops repo, just added logs to make

### DIFF
--- a/pkg/appStore/deployment/service/InstalledAppService.go
+++ b/pkg/appStore/deployment/service/InstalledAppService.go
@@ -184,7 +184,10 @@ func (impl InstalledAppServiceImpl) UpdateInstalledApp(ctx context.Context, inst
 	argocdAppName := installedApp.App.AppName + "-" + installedApp.Environment.Name
 	gitOpsRepoName := installedApp.GitOpsRepoName
 	if len(gitOpsRepoName) == 0 {
-		gitOpsRepoName = impl.appStoreDeploymentFullModeService.GetGitOpsRepoName(installAppVersionRequest)
+		gitOpsRepoName, err = impl.appStoreDeploymentFullModeService.GetGitOpsRepoName(installAppVersionRequest)
+		if err != nil {
+			return nil, err
+		}
 	}
 	installAppVersionRequest.GitOpsRepoName = gitOpsRepoName
 	var installedAppVersion *repository2.InstalledAppVersions

--- a/pkg/util/TokenCache.go
+++ b/pkg/util/TokenCache.go
@@ -46,10 +46,11 @@ func NewTokenCache(logger *zap.SugaredLogger, aCDAuthConfig *ACDAuthConfig, user
 }
 func (impl *TokenCache) BuildACDSynchContext() (acdContext context.Context, err error) {
 	token, found := impl.cache.Get("token")
+	impl.logger.Debugw("building acd context", "token", token, "found", found)
 	if !found {
 		token, err := impl.userAuthService.HandleLogin(impl.aCDAuthConfig.ACDUsername, impl.aCDAuthConfig.ACDPassword)
 		if err != nil {
-			impl.logger.Errorw("error while acd login", "err", err)
+			impl.logger.Errorw("error while acd login", "ACDUsername", impl.aCDAuthConfig.ACDUsername, "ACDPassword", impl.aCDAuthConfig.ACDPassword, "err", err)
 			return nil, err
 		}
 		impl.cache.Set("token", token, cache.NoExpiration)


### PR DESCRIPTION
# Description

- Chart update failed when gitops repo not found
- Issue occurs here because of invalid credential for acd login. while building context to find out the gitops repo.   

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Just added logs, tested and fixed at oss client side.


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles
* [ ] I have added all the required unit/api test cases



