### PR TITLE
Update PipelineBuilder.go limit to 10

### DIFF
--- a/pkg/pipeline/PipelineBuilder.go
+++ b/pkg/pipeline/PipelineBuilder.go
@@ -1748,7 +1748,7 @@ func (impl PipelineBuilderImpl) GetArtifactsForCdStage(cdPipelineId int, parentI
 	var ciArtifactsResponse bean.CiArtifactResponse
 	var err error
 	artifactMap := make(map[int]int)
-	limit := 30
+	limit := 10
 	ciArtifacts, artifactMap, err = impl.BuildArtifactsForCdStage(cdPipelineId, stage, ciArtifacts, artifactMap, false, limit, parentCdId)
 	if err != nil && err != pg.ErrNoRows {
 		impl.logger.Errorw("error in getting artifacts for child cd stage", "err", err, "stage", stage)


### PR DESCRIPTION
Updated limit from 30 to 10 in PipelineBuilder.go

# Description

Changed line number 1751 from PipelineBuilder.go to change limit from 30 to 10. Currently when we open select image in deployment pipeline we should all the images which have been built using the system, we need to restrict it to 10

fixes: #1593 
