### PR TITLE
fix: App deployment status is stuck at "Starting" sometime on build and history page for some apps

### DIFF
--- a/pkg/app/AppService.go
+++ b/pkg/app/AppService.go
@@ -246,7 +246,7 @@ func (impl AppServiceImpl) UpdateApplicationStatusAndCheckIsHealthy(app v1alpha1
 	isHealthy := false
 	repoUrl := app.Spec.Source.RepoURL
 	// backward compatibility for updating application status - if unable to find app check it in charts
-	chart, err := impl.chartRepository.FindByGirRepoUrl(repoUrl)
+	chart, err := impl.chartRepository.FindByGitRepoUrl(repoUrl)
 	if err != nil {
 		impl.logger.Errorw("error in fetching chart", "err", err, "chart", chart.ChartName)
 		return isHealthy, err

--- a/pkg/chartRepo/repository/ChartRepoRepository.go
+++ b/pkg/chartRepo/repository/ChartRepoRepository.go
@@ -65,7 +65,7 @@ type ChartRepository interface {
 	FindChartByAppIdAndRefId(appId int, chartRefId int) (chart *Chart, err error)
 	FindNoLatestChartForAppByAppId(appId int) ([]*Chart, error)
 	FindPreviousChartByAppId(appId int) (chart *Chart, err error)
-	FindByGirRepoUrl(gitRepoUrl string) (chart *Chart, err error)
+	FindByGitRepoUrl(gitRepoUrl string) (chart *Chart, err error)
 }
 
 func NewChartRepository(dbConnection *pg.DB) *ChartRepositoryImpl {
@@ -196,10 +196,15 @@ func (repositoryImpl ChartRepositoryImpl) FindById(id int) (chart *Chart, err er
 	return chart, err
 }
 
-func (repositoryImpl ChartRepositoryImpl) FindByGirRepoUrl(gitRepoUrl string) (chart *Chart, err error) {
+func (repositoryImpl ChartRepositoryImpl) FindByGitRepoUrl(gitRepoUrl string) (chart *Chart, err error) {
 	chart = &Chart{}
 	err = repositoryImpl.dbConnection.Model(chart).
-		Where("git_repo_url = ?", gitRepoUrl).Where("active=true").Where("latest=true").Select()
+		Join("INNER JOIN app ON app.id=app_id ").
+		Where("app.active = ?", true).
+		Where("chart.git_repo_url = ?", gitRepoUrl).
+		Where("chart.active = ?", true).
+		Where("chart.latest = ?", true).
+		Select()
 	return chart, err
 }
 


### PR DESCRIPTION
# Description
App deployment status is stuck at "Starting" sometime on build and history page for some apps.
Create an app with all the configurations. In "Charts" table it would insert an entry. Now delete that app and create app with same name with all the configurations. In "Charts" table it would again insert an entry. So "Charts" table would have two rows with active=true and latest=true and git_repo_url=<>'. This is creating the problem. So need to check app active state.

Fixes  https://github.com/devtron-labs/devtron/issues/1652

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactoring 

# How Has This Been Tested?
By hitting DB queries and manually

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


