### PR TITLE
fix : description can be empty while creating/updating api-token

### DIFF
--- a/api/apiToken/ApiTokenRestHandler.go
+++ b/api/apiToken/ApiTokenRestHandler.go
@@ -117,10 +117,6 @@ func (impl ApiTokenRestHandlerImpl) CreateApiToken(w http.ResponseWriter, r *htt
 		common.WriteJsonResp(w, errors.New("name cannot be blank in the request"), nil, http.StatusBadRequest)
 		return
 	}
-	if len(*request.Description) == 0 {
-		common.WriteJsonResp(w, errors.New("description cannot be blank in the request"), nil, http.StatusBadRequest)
-		return
-	}
 
 	// service call
 	res, err := impl.apiTokenService.CreateApiToken(request, userId)
@@ -170,10 +166,6 @@ func (impl ApiTokenRestHandlerImpl) UpdateApiToken(w http.ResponseWriter, r *htt
 	if err != nil {
 		impl.logger.Errorw("validation err in UpdateApiToken", "err", err, "request", request)
 		common.WriteJsonResp(w, err, nil, http.StatusBadRequest)
-		return
-	}
-	if len(*request.Description) == 0 {
-		common.WriteJsonResp(w, errors.New("description cannot be blank in the request"), nil, http.StatusBadRequest)
 		return
 	}
 


### PR DESCRIPTION
# Description
description can be empty while creating/updating api-token

Fixes  https://github.com/devtron-labs/devtron/issues/1893

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactoring 

# How Has This Been Tested?
By hitting api-token create/update with description empty and non-empty

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


