### PR TITLE
fix: Pods of one rollout are showing in "Old" tab in resource tree in case of multiple rollouts

### DIFF
--- a/client/argocdServer/application/Application.go
+++ b/client/argocdServer/application/Application.go
@@ -91,10 +91,10 @@ type Result struct {
 
 type ResourceTreeResponse struct {
 	*v1alpha1.ApplicationTree
-	NewGenerationReplicaSet string                          `json:"newGenerationReplicaSet"`
-	Status                  string                          `json:"status"`
-	PodMetadata             []*PodMetadata                  `json:"podMetadata"`
-	Conditions              []v1alpha1.ApplicationCondition `json:"conditions"`
+	NewGenerationReplicaSets []string                        `json:"newGenerationReplicaSets"`
+	Status                   string                          `json:"status"`
+	PodMetadata              []*PodMetadata                  `json:"podMetadata"`
+	Conditions               []v1alpha1.ApplicationCondition `json:"conditions"`
 }
 
 type PodMetadata struct {
@@ -383,7 +383,7 @@ func (c ServiceClientImpl) ResourceTree(ctxt context.Context, query *application
 		return nil, err
 	}
 	responses := parseResult(resp, query, ctx, asc, err, c)
-	podMetadata, newReplicaSet := c.buildPodMetadata(resp, responses)
+	podMetadata, newReplicaSets := c.buildPodMetadata(resp, responses)
 
 	appQuery := application.ApplicationQuery{Name: query.ApplicationName}
 	app, err := asc.Watch(ctxt, &appQuery)
@@ -404,13 +404,13 @@ func (c ServiceClientImpl) ResourceTree(ctxt context.Context, query *application
 			}
 		}
 	}
-	return &ResourceTreeResponse{resp, newReplicaSet, status, podMetadata, conditions}, err
+	return &ResourceTreeResponse{resp, newReplicaSets, status, podMetadata, conditions}, err
 }
 
-func (c ServiceClientImpl) buildPodMetadata(resp *v1alpha1.ApplicationTree, responses []*Result) (podMetaData []*PodMetadata, newReplicaSet string) {
-	rolloutManifest := make(map[string]interface{})
+func (c ServiceClientImpl) buildPodMetadata(resp *v1alpha1.ApplicationTree, responses []*Result) (podMetaData []*PodMetadata, newReplicaSets []string) {
+	rolloutManifests := make([]map[string]interface{}, 0)
 	statefulSetManifest := make(map[string]interface{})
-	deploymentManifest := make(map[string]interface{})
+	deploymentManifests := make([]map[string]interface{}, 0)
 	daemonSetManifest := make(map[string]interface{})
 	replicaSetManifests := make([]map[string]interface{}, 0)
 	podManifests := make([]map[string]interface{}, 0)
@@ -419,15 +419,19 @@ func (c ServiceClientImpl) buildPodMetadata(resp *v1alpha1.ApplicationTree, resp
 	var parentWorkflow []string
 	for _, response := range responses {
 		if response != nil && response.Response != nil && response.Request.Kind == "Rollout" {
-			err := json.Unmarshal([]byte(response.Response.Manifest), &rolloutManifest)
+			manifest := make(map[string]interface{})
+			err := json.Unmarshal([]byte(response.Response.Manifest), &manifest)
 			if err != nil {
 				c.logger.Error(err)
 			}
+			rolloutManifests = append(rolloutManifests, manifest)
 		} else if response != nil && response.Response != nil && response.Request.Kind == "Deployment" {
-			err := json.Unmarshal([]byte(response.Response.Manifest), &deploymentManifest)
+			manifest := make(map[string]interface{})
+			err := json.Unmarshal([]byte(response.Response.Manifest), &manifest)
 			if err != nil {
 				c.logger.Error(err)
 			}
+			deploymentManifests = append(deploymentManifests, manifest)
 		} else if response != nil && response.Response != nil && response.Request.Kind == "StatefulSet" {
 			err := json.Unmarshal([]byte(response.Response.Manifest), &statefulSetManifest)
 			if err != nil {
@@ -468,12 +472,22 @@ func (c ServiceClientImpl) buildPodMetadata(resp *v1alpha1.ApplicationTree, resp
 	}
 	newPodNames := make(map[string]bool, 0)
 	// for rollout we compare pod hash
-	if _, ok := rolloutManifest["kind"]; ok {
-		newReplicaSet = c.getRolloutNewReplicaSetName(rolloutManifest, replicaSetManifests)
+	for _, rolloutManifest := range rolloutManifests {
+		if _, ok := rolloutManifest["kind"]; ok {
+			newReplicaSet := c.getRolloutNewReplicaSetName(rolloutManifest, replicaSetManifests)
+			if len(newReplicaSet) > 0 {
+				newReplicaSets = append(newReplicaSets, newReplicaSet)
+			}
+		}
 	}
 
-	if _, ok := deploymentManifest["kind"]; ok {
-		newReplicaSet = c.getDeploymentNewReplicaSetName(deploymentManifest, replicaSetManifests)
+	for _, deploymentManifest := range deploymentManifests {
+		if _, ok := deploymentManifest["kind"]; ok {
+			newReplicaSet := c.getDeploymentNewReplicaSetName(deploymentManifest, replicaSetManifests)
+			if len(newReplicaSet) > 0 {
+				newReplicaSets = append(newReplicaSets, newReplicaSet)
+			}
+		}
 	}
 
 	if _, ok := statefulSetManifest["kind"]; ok {
@@ -504,8 +518,8 @@ func (c ServiceClientImpl) buildPodMetadata(resp *v1alpha1.ApplicationTree, resp
 
 	//podMetaData := make([]*PodMetadata, 0)
 	duplicateCheck := make(map[string]bool)
-	if newReplicaSet != "" {
-		results := buildPodMetadataFromReplicaSet(resp, newReplicaSet, replicaSetManifests)
+	if len(newReplicaSets) > 0 {
+		results := buildPodMetadataFromReplicaSet(resp, newReplicaSets, replicaSetManifests)
 		for _, meta := range results {
 			duplicateCheck[meta.Name] = true
 			podMetaData = append(podMetaData, meta)
@@ -876,7 +890,7 @@ func getPodInitContainers(resource map[string]interface{}) []*string {
 	return containers
 }
 
-func buildPodMetadataFromReplicaSet(resp *v1alpha1.ApplicationTree, newReplicaSet string, replicaSetManifests []map[string]interface{}) (podMetadata []*PodMetadata) {
+func buildPodMetadataFromReplicaSet(resp *v1alpha1.ApplicationTree, newReplicaSets []string, replicaSetManifests []map[string]interface{}) (podMetadata []*PodMetadata) {
 	replicaSets := make(map[string]map[string]interface{})
 	for _, replicaSet := range replicaSetManifests {
 		replicaSets[getResourceName(replicaSet)] = replicaSet
@@ -890,7 +904,13 @@ func buildPodMetadataFromReplicaSet(resp *v1alpha1.ApplicationTree, newReplicaSe
 				}
 			}
 			if parentName != "" {
-				isNew := parentName == newReplicaSet
+				isNew := false
+				for _, newReplicaSet := range newReplicaSets {
+					if parentName == newReplicaSet {
+						isNew = true
+						break
+					}
+				}
 				replicaSet := replicaSets[parentName]
 				containers, intContainers := getReplicaSetContainers(replicaSet)
 				metadata := PodMetadata{Name: node.Name, UID: node.UID, Containers: containers, InitContainers: intContainers, IsNew: isNew}

--- a/client/argocdServer/application/Application.go
+++ b/client/argocdServer/application/Application.go
@@ -423,15 +423,17 @@ func (c ServiceClientImpl) buildPodMetadata(resp *v1alpha1.ApplicationTree, resp
 			err := json.Unmarshal([]byte(response.Response.Manifest), &manifest)
 			if err != nil {
 				c.logger.Error(err)
+			}else{
+				rolloutManifests = append(rolloutManifests, manifest)
 			}
-			rolloutManifests = append(rolloutManifests, manifest)
 		} else if response != nil && response.Response != nil && response.Request.Kind == "Deployment" {
 			manifest := make(map[string]interface{})
 			err := json.Unmarshal([]byte(response.Response.Manifest), &manifest)
 			if err != nil {
 				c.logger.Error(err)
+			}else{
+				deploymentManifests = append(deploymentManifests, manifest)
 			}
-			deploymentManifests = append(deploymentManifests, manifest)
 		} else if response != nil && response.Response != nil && response.Request.Kind == "StatefulSet" {
 			err := json.Unmarshal([]byte(response.Response.Manifest), &statefulSetManifest)
 			if err != nil {
@@ -519,7 +521,7 @@ func (c ServiceClientImpl) buildPodMetadata(resp *v1alpha1.ApplicationTree, resp
 	//podMetaData := make([]*PodMetadata, 0)
 	duplicateCheck := make(map[string]bool)
 	if len(newReplicaSets) > 0 {
-		results := buildPodMetadataFromReplicaSet(resp, newReplicaSets, replicaSetManifests)
+		results := c.buildPodMetadataFromReplicaSet(resp, newReplicaSets, replicaSetManifests)
 		for _, meta := range results {
 			duplicateCheck[meta.Name] = true
 			podMetaData = append(podMetaData, meta)
@@ -890,7 +892,7 @@ func getPodInitContainers(resource map[string]interface{}) []*string {
 	return containers
 }
 
-func buildPodMetadataFromReplicaSet(resp *v1alpha1.ApplicationTree, newReplicaSets []string, replicaSetManifests []map[string]interface{}) (podMetadata []*PodMetadata) {
+func (c ServiceClientImpl) buildPodMetadataFromReplicaSet(resp *v1alpha1.ApplicationTree, newReplicaSets []string, replicaSetManifests []map[string]interface{}) (podMetadata []*PodMetadata) {
 	replicaSets := make(map[string]map[string]interface{})
 	for _, replicaSet := range replicaSetManifests {
 		replicaSets[getResourceName(replicaSet)] = replicaSet


### PR DESCRIPTION
# Description
In case of multiple rollouts | deployments, pods of one rollout or deployment are showing in "Old" tab on app details page. They should be shown in "New" tab as they are new pods.

Fixes  https://github.com/devtron-labs/devtron/issues/1913

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactoring 

# How Has This Been Tested?
app detail resource tree test (specially pods and its old/new status) for multiple rollouts, multiple deployments, single rollout, single deployment

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


