### PR TITLE
fix: ci pipeline deletion bug fix

### DIFF
--- a/internal/sql/repository/appWorkflow/AppWorkflowRepository.go
+++ b/internal/sql/repository/appWorkflow/AppWorkflowRepository.go
@@ -225,6 +225,7 @@ func (impl AppWorkflowRepositoryImpl) FindWFCDMappingByCIPipelineId(ciPipelineId
 
 	err := impl.dbConnection.Model(&appWorkflowsMapping).
 		Where("parent_id = ?", ciPipelineId).
+		Where("parent_type = ?", CIPIPELINE).
 		Where("type = ?", CDPIPELINE).
 		Where("active = ?", true).
 		Select()
@@ -236,6 +237,7 @@ func (impl AppWorkflowRepositoryImpl) FindWFCDMappingByCIPipelineIds(ciPipelineI
 
 	err := impl.dbConnection.Model(&appWorkflowsMapping).
 		Where("parent_id in (?) ", pg.In(ciPipelineIds)).
+		Where("parent_type = ?", CIPIPELINE).
 		Where("type = ?", CDPIPELINE).
 		Where("active = ?", true).
 		Select()


### PR DESCRIPTION
# Description

Ci pipeline deletion throws error that cd pipeline exists when there a cd pipeline with id = ciPipelineId and has a children cd. This makes the check of having children pass even when there is none. Updated the query to check children of ci pipeline independent of other pipelines.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles
* [ ] I have added all the required unit/api test cases



