### PR TITLE
[FIX] Changed Argocd clusterrolebinding namespaces to devtroncd

### DIFF
--- a/manifests/yamls/argocd.yaml
+++ b/manifests/yamls/argocd.yaml
@@ -2751,7 +2751,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-application-controller
-  namespace: argocd
+  namespace: devtroncd
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -2768,7 +2768,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-server
-  namespace: argocd
+  namespace: devtroncd
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
# Description

Fixed default namespaces of serviceAccounts in argocd.yaml which were getting binded to clusterrolebindings from argocd to devtroncd

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested on multiple devtron clusters


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles
* [ ] I have added all the required unit/api test cases



