### PR TITLE
fix: multiple commits in git-repo fix

### DIFF
--- a/internal/util/ChartService.go
+++ b/internal/util/ChartService.go
@@ -264,6 +264,8 @@ func (impl ChartTemplateServiceImpl) pushChartToGitRepo(gitOpsRepoName, referenc
 	}
 
 	dir := filepath.Join(clonedDir, referenceTemplate, version)
+	pushChartToGit := true
+
 	//if chart already exists don't overrides it by reference template
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		err = os.MkdirAll(dir, os.ModePerm)
@@ -287,30 +289,37 @@ func (impl ChartTemplateServiceImpl) pushChartToGitRepo(gitOpsRepoName, referenc
 				impl.logger.Errorw("error copying content in auto-healing", "err", err)
 				return err
 			}
+		} else {
+			// chart exists on git, hence not performing first commit
+			pushChartToGit = false
 		}
 	}
 
-	userEmailId, userName := impl.GetUserEmailIdAndNameForGitOpsCommit(userId)
-	commit, err := impl.gitFactory.gitService.CommitAndPushAllChanges(clonedDir, "first commit", userName, userEmailId)
-	if err != nil {
-		impl.logger.Errorw("error in pushing git", "err", err)
-		impl.logger.Warn("re-trying, taking pull and then push again")
-		err = impl.GitPull(clonedDir, repoUrl, gitOpsRepoName)
-		if err != nil {
-			return err
-		}
-		err = dirCopy.Copy(tempReferenceTemplateDir, dir)
-		if err != nil {
-			impl.logger.Errorw("error copying dir", "err", err)
-			return err
-		}
-		commit, err = impl.gitFactory.gitService.CommitAndPushAllChanges(clonedDir, "first commit", userName, userEmailId)
+	// if push needed, then only push
+	if pushChartToGit {
+		userEmailId, userName := impl.GetUserEmailIdAndNameForGitOpsCommit(userId)
+		commit, err := impl.gitFactory.gitService.CommitAndPushAllChanges(clonedDir, "first commit", userName, userEmailId)
 		if err != nil {
 			impl.logger.Errorw("error in pushing git", "err", err)
-			return err
+			impl.logger.Warn("re-trying, taking pull and then push again")
+			err = impl.GitPull(clonedDir, repoUrl, gitOpsRepoName)
+			if err != nil {
+				return err
+			}
+			err = dirCopy.Copy(tempReferenceTemplateDir, dir)
+			if err != nil {
+				impl.logger.Errorw("error copying dir", "err", err)
+				return err
+			}
+			commit, err = impl.gitFactory.gitService.CommitAndPushAllChanges(clonedDir, "first commit", userName, userEmailId)
+			if err != nil {
+				impl.logger.Errorw("error in pushing git", "err", err)
+				return err
+			}
 		}
+		impl.logger.Debugw("template committed", "url", repoUrl, "commit", commit)
 	}
-	impl.logger.Debugw("template committed", "url", repoUrl, "commit", commit)
+
 	defer impl.CleanDir(clonedDir)
 	return nil
 }


### PR DESCRIPTION
# Description
When cd is triggered, currently 2 commits are pushed to git repo (gitops). 
1)  Chart
2) Release file
Chart should be pushed only if chart is not present on git i.e. first commit should be conditional. 


Fixes  https://github.com/devtron-labs/devtron/issues/2060

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactoring 

# How Has This Been Tested?
By checking gitops repo content on : 
1) first cd trigger
2) multiple cd trigger
3) cd trigger after changing chart version in env override. 

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


