### PR TITLE
fix : destination fix in notification for smtp and ses for custom recipients for create and update request

### DIFF
--- a/pkg/notifier/NotificationConfigBuilder.go
+++ b/pkg/notifier/NotificationConfigBuilder.go
@@ -22,7 +22,6 @@ import (
 	"github.com/devtron-labs/devtron/internal/sql/repository"
 	"github.com/devtron-labs/devtron/util/event"
 	"go.uber.org/zap"
-	"strings"
 	"time"
 )
 
@@ -170,17 +169,7 @@ func (impl NotificationConfigBuilderImpl) buildNotificationSetting(notificationS
 }
 
 func (impl NotificationConfigBuilderImpl) BuildNotificationSettingWithPipeline(teamId *int, envId *int, appId *int, pipelineId *int, pipelineType util.PipelineType, eventTypeId int, viewId int, providers []*Provider) (repository.NotificationSettings, error) {
-
-	for _, provider := range providers {
-		if len(provider.Recipient) > 0 {
-			if strings.Contains(provider.Recipient, "@") {
-				provider.Destination = util.SES
-			} else {
-				provider.Destination = util.Slack
-			}
-		}
-	}
-
+	
 	providersJson, err := json.Marshal(providers)
 	if err != nil {
 		impl.logger.Error(err)


### PR DESCRIPTION
# Description
In notification create and update request, destination is override. removed that part. now only destination being sent in API would be honoured. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactoring 

# How Has This Been Tested?
by hitting apis


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


