### PR TITLE
enforcer invalidate & cache dump API exposed

### DIFF
--- a/api/user/UserRouter.go
+++ b/api/user/UserRouter.go
@@ -69,4 +69,8 @@ func (router UserRouterImpl) InitUserRouter(userAuthRouter *mux.Router) {
 		HandlerFunc(router.userRestHandler.SyncOrchestratorToCasbin).Methods("GET")
 	userAuthRouter.Path("/update/trigger/terminal").
 		HandlerFunc(router.userRestHandler.UpdateTriggerPolicyForTerminalAccess).Methods("PUT")
+	userAuthRouter.Path("/role/cache").
+		HandlerFunc(router.userRestHandler.GetRoleCacheDump).Methods("GET")
+	userAuthRouter.Path("/role/cache/invalidate").
+		HandlerFunc(router.userRestHandler.InvalidateRoleCache).Methods("GET")
 }

--- a/pkg/user/casbin/Adapter.go
+++ b/pkg/user/casbin/Adapter.go
@@ -62,6 +62,7 @@ func Create() *casbin.SyncedEnforcer {
 	}
 	e = auth
 	err = e.LoadPolicy()
+	log.Println("casbin Policies Loaded Successfully")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/user/casbin/rbac.go
+++ b/pkg/user/casbin/rbac.go
@@ -339,6 +339,9 @@ func (e *EnforcerImpl) InvalidateCompleteCache() {
 }
 
 func (e *EnforcerImpl) GetCacheDump() string {
+	if e.Cache == nil {
+		return "not-enabled"
+	}
 	items := e.Cache.Items()
 	cacheData, err := json.Marshal(items)
 	if err != nil {

--- a/pkg/user/casbin/rbac.go
+++ b/pkg/user/casbin/rbac.go
@@ -18,6 +18,7 @@
 package casbin
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/caarlos0/env"
 	"github.com/casbin/casbin"
@@ -43,6 +44,7 @@ type Enforcer interface {
 	InvalidateCache(emailId string) bool
 	InvalidateCompleteCache()
 	ReloadPolicy() error
+	GetCacheDump() string
 }
 
 func NewEnforcerImpl(
@@ -139,7 +141,10 @@ func (e *EnforcerImpl) enforceByEmailInBatchSync(wg *sync.WaitGroup, mutex *sync
 	start := time.Now()
 	batchResult := make(map[string]bool)
 	for _, resourceItem := range vals {
-		batchResult[resourceItem] = e.enforcerEnforce(strings.ToLower(emailId), resource, action, resourceItem)
+		data, err := e.enforcerEnforce(strings.ToLower(emailId), resource, action, resourceItem)
+		if err == nil {
+			batchResult[resourceItem] = data
+		}
 	}
 	duration := time.Since(start)
 	mutex.Lock()
@@ -333,6 +338,16 @@ func (e *EnforcerImpl) InvalidateCompleteCache() {
 	}
 }
 
+func (e *EnforcerImpl) GetCacheDump() string {
+	items := e.Cache.Items()
+	cacheData, err := json.Marshal(items)
+	if err != nil {
+		e.logger.Infow("error occurred while taking cache dump", "reason", err)
+		return ""
+	}
+	return string(cacheData)
+}
+
 // enforce is a helper to additionally check a default role and invoke a custom claims enforcement function
 func (e *EnforcerImpl) enforce(token string, resource string, action string, resourceItem string) bool {
 	// check the default role
@@ -346,15 +361,15 @@ func (e *EnforcerImpl) enforce(token string, resource string, action string, res
 func (e *EnforcerImpl) enforceAndUpdateCache(email string, resource string, action string, resourceItem string) bool {
 	cacheData := e.getEnforcerCacheLock(email)
 	cacheData.lock.Lock()
-	enforcedStatus := e.enforcerEnforce(email, resource, action, resourceItem)
 	defer cacheData.lock.Unlock()
+	enforcedStatus, err := e.enforcerEnforce(email, resource, action, resourceItem)
 	returnVal := atomic.AddInt64(&cacheData.enforceReqCounter, -1)
-	if cacheData.cacheCleaningFlag {
+	if cacheData.cacheCleaningFlag || err != nil {
 		if returnVal == 0 {
 			cacheData.cacheCleaningFlag = false
 		}
 		e.logger.Debugw("not updating enforcer status for cache", "email", email, "resource", resource,
-			"action", action, "resourceItem", resourceItem, "enforceReqCounter", cacheData.enforceReqCounter)
+			"action", action, "resourceItem", resourceItem, "enforceReqCounter", cacheData.enforceReqCounter, "err", err == nil)
 		return enforcedStatus
 	}
 	enforceData := e.getCacheData(email, resource, action)
@@ -363,7 +378,7 @@ func (e *EnforcerImpl) enforceAndUpdateCache(email string, resource string, acti
 	return enforcedStatus
 }
 
-func (e *EnforcerImpl) enforcerEnforce(email string, resource string, action string, resourceItem string) bool {
+func (e *EnforcerImpl) enforcerEnforce(email string, resource string, action string, resourceItem string) (bool, error) {
 	//e.enforcerRWLock.RLock()
 	//defer e.enforcerRWLock.RUnlock()
 	response, err := e.SyncedEnforcer.EnforceSafe(email, resource, action, resourceItem)
@@ -371,7 +386,7 @@ func (e *EnforcerImpl) enforcerEnforce(email string, resource string, action str
 		e.logger.Errorw("error occurred while enforcing safe", "email", email,
 			"resource", resource, "action", action, "resourceItem", resourceItem, "reason", err)
 	}
-	return response
+	return response, err
 }
 
 func (e *EnforcerImpl) verifyTokenAndGetEmail(tokenString string) (string, bool) {

--- a/pkg/user/casbin/rbac_test.go
+++ b/pkg/user/casbin/rbac_test.go
@@ -1,6 +1,7 @@
 package casbin
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/patrickmn/go-cache"
 	"math/rand"
@@ -32,6 +33,29 @@ func TestEnforcerCache(t *testing.T) {
 		invalidateCache_123(lock, cache123)
 	})
 
+	t.Run("CacheDump", func(t *testing.T) {
+		for i := 0; i < 100_000; i++ {
+			emailId := GetRandomStringOfGivenLength(rand.Intn(50)) + "@yopmail.com"
+			getAndSet(lock, emailId, cache123)
+			cache123.GetWithExpiration(emailId)
+			//result, expiration, b := cache123.GetWithExpiration(emailId)
+			//fmt.Println("result", result, "expiration", expiration, "found", b)
+		}
+		//invalidateCache_123(lock, cache123)
+
+		fmt.Println("dump: ", GetCacheDump(cache123))
+	})
+
+}
+
+func GetCacheDump(cache *cache.Cache) string {
+	items := cache.Items()
+	cacheData, err := json.Marshal(items)
+	if err != nil {
+		fmt.Println("error occurred while taking cache dump", "reason", err)
+		return ""
+	}
+	return string(cacheData)
 }
 
 func GetRandomStringOfGivenLength(length int) string {


### PR DESCRIPTION
# Description

Error from Enforcer is getting diluted and its response is getting updated in Cache, which should not be the idle behavior. Along with this, we have exposed 2 APIs invalidate & cacheDump which can only be accessed by SuperAdmin Users.

Fixes #2072 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles
* [ ] I have added all the required unit/api test cases



