### PR TITLE
fix: Performance optimisation while getting the Data from DB for chart versions for a particular chart

### DIFF
--- a/pkg/appStore/discover/repository/AppStoreApplicationVersionRepository.go
+++ b/pkg/appStore/discover/repository/AppStoreApplicationVersionRepository.go
@@ -165,11 +165,9 @@ func (impl AppStoreApplicationVersionRepositoryImpl) FindVersionsByAppStoreId(id
 	var appStoreApplicationVersions []*AppStoreApplicationVersion
 	err := impl.dbConnection.
 		Model(&appStoreApplicationVersions).
-		Column("app_store_application_version.*", "AppStore", "AppStore.ChartRepo").
-		Join("inner join app_store aps on aps.id = app_store_application_version.app_store_id").
-		Join("inner join chart_repo as cr on cr.id = aps.chart_repo_id").
-		Where("aps.id = ?", id).
-		Order("app_store_application_version.created DESC").
+		Column("app_store_application_version.id", "app_store_application_version.version").
+		Where("app_store_id = ?", id).
+		Order("created DESC").
 		Select()
 	return appStoreApplicationVersions, err
 }

--- a/scripts/sql/66_app_store_application_version_index.down.sql
+++ b/scripts/sql/66_app_store_application_version_index.down.sql
@@ -1,0 +1,2 @@
+---- DROP index
+DROP INDEX IF EXISTS public.app_store_application_version_app_store_id_IX;

--- a/scripts/sql/66_app_store_application_version_index.up.sql
+++ b/scripts/sql/66_app_store_application_version_index.up.sql
@@ -1,0 +1,2 @@
+--- Create index on app_store_id in app_store_application_version
+CREATE INDEX IF NOT EXISTS app_store_application_version_app_store_id_IX ON public.app_store_application_version USING btree(app_store_id);


### PR DESCRIPTION
# Description
Performance issue fix while getting the Data from DB for chart versions for a particular chart : 
1) DB query optimised
2) Index created in DB. earlier query plan was using Seq scan which was slow. hence created index to use Index scan

Fixes  https://github.com/devtron-labs/devtron/issues/2109

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactoring 


# How Has This Been Tested?
by checking the performance of the API

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


