### PR TITLE
feat: reference chart with env from secretKeyRef

### DIFF
--- a/contrib-chart/reference-chart_4-14-0/.helmignore
+++ b/contrib-chart/reference-chart_4-14-0/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/contrib-chart/reference-chart_4-14-0/.image_descriptor_template.json
+++ b/contrib-chart/reference-chart_4-14-0/.image_descriptor_template.json
@@ -1,0 +1,1 @@
+{"server":{"deployment":{"image_tag":"{{.Tag}}","image":"{{.Name}}"}},"pipelineName": "{{.PipelineName}}","releaseVersion":"{{.ReleaseVersion}}","deploymentType": "{{.DeploymentType}}", "app": "{{.App}}", "env": "{{.Env}}", "appMetrics": {{.AppMetrics}}}

--- a/contrib-chart/reference-chart_4-14-0/Chart.yaml
+++ b/contrib-chart/reference-chart_4-14-0/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: reference-chart_4-14-0
+version: 4.14.0

--- a/contrib-chart/reference-chart_4-14-0/README.md
+++ b/contrib-chart/reference-chart_4-14-0/README.md
@@ -1,0 +1,630 @@
+
+# Rollout Deployment Chart - v4.14
+
+## 1. Yaml File -
+
+### Container Ports
+
+This defines ports on which application services will be exposed to other services
+
+```yaml
+ContainerPort:
+  - envoyPort: 8799
+    idleTimeout:
+    name: app
+    port: 8080
+    servicePort: 80
+    supportStreaming: true
+    useHTTP2: true
+```
+
+| Key | Description |
+| :--- | :--- |
+| `envoyPort` | envoy port for the container. |
+| `idleTimeout` | the duration of time that a connection is idle before the connection is terminated. |
+| `name` | name of the port. |
+| `port` | port for the container. |
+| `servicePort` | port of the corresponding kubernetes service. |
+| `supportStreaming` | Used for high performance protocols like grpc where timeout needs to be disabled. |
+| `useHTTP2` | Envoy container can accept HTTP2 requests. |
+
+### EnvVariables
+```yaml
+EnvVariables: []
+```
+To set environment variables for the containers that run in the Pod.
+
+### Env Variables from specific secret key
+```yaml
+EnvVariablesFromSecretKey:
+  - name: ENV_NAME
+    secretName: testSecret
+    secretKey: testKey # a key from the secret
+```
+Defines environment variables from a specific secret key
+
+### Liveness Probe
+
+If this check fails, kubernetes restarts the pod. This should return error code in case of non-recoverable error.
+
+```yaml
+LivenessProbe:
+  Path: ""
+  port: 8080
+  initialDelaySeconds: 20
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 5
+  failureThreshold: 3
+  httpHeaders:
+    - name: Custom-Header
+      value: abc
+  scheme: ""
+  tcp: true
+```
+
+| Key | Description |
+| :--- | :--- |
+| `Path` | It define the path where the liveness needs to be checked. |
+| `initialDelaySeconds` | It defines the time to wait before a given container is checked for liveliness. |
+| `periodSeconds` | It defines the time to check a given container for liveness. |
+| `successThreshold` | It defines the number of successes required before a given container is said to fulfil the liveness probe. |
+| `timeoutSeconds` | It defines the time for checking timeout. |
+| `failureThreshold` | It defines the maximum number of failures that are acceptable before a given container is not considered as live. |
+| `httpHeaders` | Custom headers to set in the request. HTTP allows repeated headers,You can override the default headers by defining .httpHeaders for the probe. |
+| `scheme` | Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.
+| `tcp` | The kubelet will attempt to open a socket to your container on the specified port. If it can establish a connection, the container is considered healthy. |
+
+
+### MaxUnavailable
+
+```yaml
+  MaxUnavailable: 0
+```
+The maximum number of pods that can be unavailable during the update process. The value of "MaxUnavailable: " can be an absolute number or percentage of the replicas count. The default value of "MaxUnavailable: " is 25%.
+
+### MaxSurge
+
+```yaml
+MaxSurge: 1
+```
+The maximum number of pods that can be created over the desired number of pods. For "MaxSurge: " also, the value can be an absolute number or percentage of the replicas count.
+The default value of "MaxSurge: " is 25%.
+
+### Min Ready Seconds
+
+```yaml
+MinReadySeconds: 60
+```
+This specifies the minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available. This defaults to 0 (the Pod will be considered available as soon as it is ready).
+
+### Readiness Probe
+
+If this check fails, kubernetes stops sending traffic to the application. This should return error code in case of errors which can be recovered from if traffic is stopped.
+
+```yaml
+ReadinessProbe:
+  Path: ""
+  port: 8080
+  initialDelaySeconds: 20
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 5
+  failureThreshold: 3
+  httpHeaders:
+    - name: Custom-Header
+      value: abc
+  scheme: ""
+  tcp: true
+```
+
+| Key | Description |
+| :--- | :--- |
+| `Path` | It define the path where the readiness needs to be checked. |
+| `initialDelaySeconds` | It defines the time to wait before a given container is checked for readiness. |
+| `periodSeconds` | It defines the time to check a given container for readiness. |
+| `successThreshold` | It defines the number of successes required before a given container is said to fulfill the readiness probe. |
+| `timeoutSeconds` | It defines the time for checking timeout. |
+| `failureThreshold` | It defines the maximum number of failures that are acceptable before a given container is not considered as ready. |
+| `httpHeaders` | Custom headers to set in the request. HTTP allows repeated headers,You can override the default headers by defining .httpHeaders for the probe. |
+| `scheme` | Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.
+| `tcp` | The kubelet will attempt to open a socket to your container on the specified port. If it can establish a connection, the container is considered healthy. |
+
+### Autoscaling
+
+This is connected to HPA and controls scaling up and down in response to request load.
+
+```yaml
+autoscaling:
+  enabled: false
+  MinReplicas: 1
+  MaxReplicas: 2
+  TargetCPUUtilizationPercentage: 90
+  TargetMemoryUtilizationPercentage: 80
+  extraMetrics: []
+```
+
+| Key | Description |
+| :--- | :--- |
+| `enabled` | Set true to enable autoscaling else set false.|
+| `MinReplicas` | Minimum number of replicas allowed for scaling. |
+| `MaxReplicas` | Maximum number of replicas allowed for scaling. |
+| `TargetCPUUtilizationPercentage` | The target CPU utilization that is expected for a container. |
+| `TargetMemoryUtilizationPercentage` | The target memory utilization that is expected for a container. |
+| `extraMetrics` | Used to give external metrics for autoscaling. |
+
+### Fullname Override
+
+```yaml
+fullnameOverride: app-name
+```
+`fullnameOverride` replaces the release fullname created by default by devtron, which is used to construct Kubernetes object names. By default, devtron uses {app-name}-{environment-name} as release fullname.
+
+### Image
+
+```yaml
+image:
+  pullPolicy: IfNotPresent
+```
+
+Image is used to access images in kubernetes, pullpolicy is used to define the instances calling the image, here the image is pulled when the image is not present,it can also be set as "Always".
+
+### imagePullSecrets
+
+`imagePullSecrets` contains the docker credentials that are used for accessing a registry.
+
+```yaml
+imagePullSecrets:
+  - regcred
+```
+regcred is the secret that contains the docker credentials that are used for accessing a registry. Devtron will not create this secret automatically, you'll have to create this secret using dt-secrets helm chart in the App store or create one using kubectl. You can follow this documentation Pull an Image from a Private Registry [https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) .
+
+### Ingress
+
+This allows public access to the url, please ensure you are using right nginx annotation for nginx class, its default value is nginx
+
+```yaml
+ingress:
+  enabled: false
+  # For K8s 1.19 and above use ingressClassName instead of annotation kubernetes.io/ingress.class:
+  className: nginx
+  annotations: {}
+  hosts:
+      - host: example1.com
+        paths:
+            - /example
+      - host: example2.com
+        paths:
+            - /example2
+            - /example2/healthz
+  tls: []
+```
+Legacy deployment-template ingress format
+
+```yaml
+ingress:
+  enabled: false
+  # For K8s 1.19 and above use ingressClassName instead of annotation kubernetes.io/ingress.class:
+  ingressClassName: nginx-internal
+  annotations: {}
+  path: ""
+  host: ""
+  tls: []
+```
+
+| Key | Description |
+| :--- | :--- |
+| `enabled` | Enable or disable ingress |
+| `annotations` | To configure some options depending on the Ingress controller |
+| `path` | Path name |
+| `host` | Host name |
+| `tls` | It contains security details |
+
+### Ingress Internal
+
+This allows private access to the url, please ensure you are using right nginx annotation for nginx class, its default value is nginx
+
+```yaml
+ingressInternal:
+  enabled: false
+  # For K8s 1.19 and above use ingressClassName instead of annotation kubernetes.io/ingress.class:
+  ingressClassName: nginx-internal
+  annotations: {}
+  hosts:
+      - host: example1.com
+        paths:
+            - /example
+      - host: example2.com
+        paths:
+            - /example2
+            - /example2/healthz
+  tls: []
+```
+
+| Key | Description |
+| :--- | :--- |
+| `enabled` | Enable or disable ingress |
+| `annotations` | To configure some options depending on the Ingress controller |
+| `path` | Path name |
+| `host` | Host name |
+| `tls` | It contains security details |
+
+### Init Containers
+```yaml
+initContainers: 
+  - reuseContainerImage: true
+    volumeMounts:
+     - mountPath: /etc/ls-oms
+       name: ls-oms-cm-vol
+   command:
+     - flyway
+     - -configFiles=/etc/ls-oms/flyway.conf
+     - migrate
+
+  - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+        command: ["/usr/local/bin/nginx"]
+        args: ["-g", "daemon off;"]
+```
+Specialized containers that run before app containers in a Pod. Init containers can contain utilities or setup scripts not present in an app image. One can use base image inside initContainer by setting the reuseContainerImage flag to `true`.
+
+### Pause For Seconds Before Switch Active
+```yaml
+pauseForSecondsBeforeSwitchActive: 30
+```
+To wait for given period of time before switch active the container.
+
+### Resources
+
+These define minimum and maximum RAM and CPU available to the application.
+
+```yaml
+resources:
+  limits:
+    cpu: "1"
+    memory: "200Mi"
+  requests:
+    cpu: "0.10"
+    memory: "100Mi"
+```
+
+Resources are required to set CPU and memory usage.
+
+#### Limits
+
+Limits make sure a container never goes above a certain value. The container is only allowed to go up to the limit, and then it is restricted.
+
+#### Requests
+
+Requests are what the container is guaranteed to get.
+
+### Service
+
+This defines annotations and the type of service, optionally can define name also.
+
+```yaml
+  service:
+    type: ClusterIP
+    annotations: {}
+```
+
+### Volumes
+
+```yaml
+volumes:
+  - name: log-volume
+    emptyDir: {}
+  - name: logpv
+    persistentVolumeClaim:
+      claimName: logpvc
+```
+
+It is required when some values need to be read from or written to an external disk.
+
+### Volume Mounts
+
+```yaml
+volumeMounts:
+  - mountPath: /var/log/nginx/
+    name: log-volume 
+  - mountPath: /mnt/logs
+    name: logpvc
+    subPath: employee  
+```
+
+It is used to provide mounts to the volume.
+
+### Affinity and anti-affinity
+
+```yaml
+Spec:
+  Affinity:
+    Key:
+    Values:
+```
+
+Spec is used to define the desire state of the given container.
+
+Node Affinity allows you to constrain which nodes your pod is eligible to schedule on, based on labels of the node.
+
+Inter-pod affinity allow you to constrain which nodes your pod is eligible to be scheduled based on labels on pods.
+
+#### Key
+
+Key part of the label for node selection, this should be same as that on node. Please confirm with devops team.
+
+#### Values
+
+Value part of the label for node selection, this should be same as that on node. Please confirm with devops team.
+
+### Tolerations
+
+```yaml
+tolerations:
+ - key: "key"
+   operator: "Equal"
+   value: "value"
+   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+```
+
+Taints are the opposite, they allow a node to repel a set of pods.
+
+A given pod can access the given node and avoid the given taint only if the given pod satisfies a given taint.
+
+Taints and tolerations are a mechanism which work together that allows you to ensure that pods are not placed on inappropriate nodes. Taints are added to nodes, while tolerations are defined in the pod specification. When you taint a node, it will repel all the pods except those that have a toleration for that taint. A node can have one or many taints associated with it.
+
+### Arguments
+
+```yaml
+args:
+  enabled: false
+  value: []
+```
+
+This is used to give arguments to command.
+
+### Command
+
+```yaml
+command:
+  enabled: false
+  value: []
+```
+
+It contains the commands for the server.
+
+| Key | Description |
+| :--- | :--- |
+| `enabled` | To enable or disable the command. |
+| `value` | It contains the commands. |
+
+
+### Containers
+Containers section can be used to run side-car containers along with your main container within same pod. Containers running within same pod can share volumes and IP Address and can address each other @localhost.
+
+```yaml
+    containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+        command: ["/usr/local/bin/nginx"]
+        args: ["-g", "daemon off;"]
+```
+
+### Prometheus
+
+```yaml
+  prometheus:
+    release: monitoring
+```
+
+It is a kubernetes monitoring tool and the name of the file to be monitored as monitoring in the given case.It describes the state of the prometheus.
+
+### rawYaml
+
+```yaml
+rawYaml: 
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: my-service
+    spec:
+      selector:
+        app: MyApp
+      ports:
+        - protocol: TCP
+          port: 80
+          targetPort: 9376
+      type: ClusterIP
+```
+Accepts an array of Kubernetes objects. You can specify any kubernetes yaml here and it will be applied when your app gets deployed.
+
+### Grace Period
+
+```yaml
+GracePeriod: 30
+```
+Kubernetes waits for the specified time called the termination grace period before terminating the pods. By default, this is 30 seconds. If your pod usually takes longer than 30 seconds to shut down gracefully, make sure you increase the `GracePeriod`.
+
+A Graceful termination in practice means that your application needs to handle the SIGTERM message and begin shutting down when it receives it. This means saving all data that needs to be saved, closing down network connections, finishing any work that is left, and other similar tasks.
+
+There are many reasons why Kubernetes might terminate a perfectly healthy container. If you update your deployment with a rolling update, Kubernetes slowly terminates old pods while spinning up new ones. If you drain a node, Kubernetes terminates all pods on that node. If a node runs out of resources, Kubernetes terminates pods to free those resources. It’s important that your application handle termination gracefully so that there is minimal impact on the end user and the time-to-recovery is as fast as possible.
+
+
+### Server
+
+```yaml
+server:
+  deployment:
+    image_tag: 1-95a53
+    image: ""
+```
+
+It is used for providing server configurations.
+
+#### Deployment
+
+It gives the details for deployment.
+
+| Key | Description |
+| :--- | :--- |
+| `image_tag` | It is the image tag |
+| `image` | It is the URL of the image |
+
+### Service Monitor
+
+```yaml
+servicemonitor:
+      enabled: true
+      path: /abc
+      scheme: 'http'
+      interval: 30s
+      scrapeTimeout: 20s
+      metricRelabelings:
+        - sourceLabels: [namespace]
+          regex: '(.*)'
+          replacement: myapp
+          targetLabel: target_namespace
+```
+
+It gives the set of targets to be monitored.
+
+### Db Migration Config
+
+```yaml
+dbMigrationConfig:
+  enabled: false
+```
+
+It is used to configure database migration.
+
+
+### KEDA Autoscaling
+[KEDA](https://keda.sh) is a Kubernetes-based Event Driven Autoscaler. With KEDA, you can drive the scaling of any container in Kubernetes based on the number of events needing to be processed. KEDA can be installed into any Kubernetes cluster and can work alongside standard Kubernetes components like the Horizontal Pod Autoscaler(HPA).
+
+Example for autosccaling with KEDA using Prometheus metrics is given below:
+```yaml
+kedaAutoscaling:
+  enabled: true
+  minReplicaCount: 1
+  maxReplicaCount: 2
+  idleReplicaCount: 0
+  pollingInterval: 30
+  advanced:
+    restoreToOriginalReplicaCount: true
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 300
+          policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 15
+  triggers: 
+    - type: prometheus
+      metadata:
+        serverAddress:  http://<prometheus-host>:9090
+        metricName: http_request_total
+        query: envoy_cluster_upstream_rq{appId="300", cluster_name="300-0", container="envoy",}
+        threshold: "50"
+  triggerAuthentication:
+    enabled: false
+    name:
+    spec: {}
+  authenticationRef: {}
+```
+Example for autosccaling with KEDA based on kafka is given below :
+```yaml
+kedaAutoscaling:
+  enabled: true
+  minReplicaCount: 1
+  maxReplicaCount: 2
+  idleReplicaCount: 0
+  pollingInterval: 30
+  advanced: {}
+  triggers: 
+    - type: kafka
+      metadata:
+        bootstrapServers: b-2.kafka-msk-dev.example.c2.kafka.ap-southeast-1.amazonaws.com:9092,b-3.kafka-msk-dev.example.c2.kafka.ap-southeast-1.amazonaws.com:9092,b-1.kafka-msk-dev.example.c2.kafka.ap-southeast-1.amazonaws.com:9092
+        topic: Orders-Service-ESP.info
+        lagThreshold: "100"
+        consumerGroup: oders-remove-delivered-packages
+        allowIdleConsumers: "true"
+  triggerAuthentication:
+    enabled: true
+    name: keda-trigger-auth-kafka-credential
+    spec:
+      secretTargetRef:
+        - parameter: sasl
+          name: keda-kafka-secrets
+          key: sasl
+        - parameter: username
+          name: keda-kafka-secrets
+          key: username
+  authenticationRef: 
+    name: keda-trigger-auth-kafka-credential
+```
+
+### Security Context
+A security context defines privilege and access control settings for a Pod or Container.
+
+To add a security context for main container:
+```yaml
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+```
+
+To add a security context on pod level:
+```yaml
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 3000
+  fsGroup: 2000
+```
+
+### Topology Spread Constraints
+You can use topology spread constraints to control how Pods are spread across your cluster among failure-domains such as regions, zones, nodes, and other user-defined topology domains. This can help to achieve high availability as well as efficient resource utilization.
+
+```yaml
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: zone
+    whenUnsatisfiable: DoNotSchedule
+    autoLabelSelector: true
+    customLabelSelector: {}
+```
+
+### Deployment Metrics
+
+It gives the realtime metrics of the deployed applications
+
+| Key | Description |
+| :--- | :--- |
+| `Deployment Frequency` | It shows how often this app is deployed to production |
+| `Change Failure Rate` | It shows how often the respective pipeline fails. |
+| `Mean Lead Time` | It shows the average time taken to deliver a change to production. |
+| `Mean Time to Recovery` | It shows the average time taken to fix a failed pipeline. |
+
+## 2. Show application metrics
+
+If you want to see application metrics like different HTTP status codes metrics, application throughput, latency, response time. Enable the Application metrics from below the deployment template Save button. After enabling it, you should be able to see all metrics on App detail page. By default it remains disabled.
+![](../../../.gitbook/assets/deployment_application_metrics%20%282%29.png)
+
+Once all the Deployment template configurations are done, click on `Save` to save your deployment configuration. Now you are ready to create [Workflow](workflow/) to do CI/CD.
+
+### Helm Chart Json Schema 
+
+Helm Chart [json schema](../../../scripts/devtron-reference-helm-charts/reference-chart_4-11-0/schema.json) is used to validate the deployment template values.
+
+### Other Validations in Json Schema
+
+The values of CPU and Memory in limits must be greater than or equal to in requests respectively. Similarly, In case of envoyproxy, the values of limits are greater than or equal to requests as mentioned below.
+```
+resources.limits.cpu >= resources.requests.cpu
+resources.limits.memory >= resources.requests.memory
+envoyproxy.resources.limits.cpu >= envoyproxy.resources.requests.cpu
+envoyproxy.resources.limits.memory >= envoyproxy.resources.requests.memory
+```

--- a/contrib-chart/reference-chart_4-14-0/app-values.yaml
+++ b/contrib-chart/reference-chart_4-14-0/app-values.yaml
@@ -1,0 +1,293 @@
+# Mandatory configs
+replicaCount: 1
+MinReadySeconds: 60
+GracePeriod: 30
+image:
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  #name: "service-1234567890"
+  loadBalancerSourceRanges: []
+  # loadBalancerSourceRanges: 
+  #    - 1.2.3.4/32
+  #    - 1.2.5.6/23
+  annotations: {}
+    # test1: test2
+    # test3: test4
+ContainerPort:
+  - name: app
+    port: 8080
+    servicePort: 80
+    envoyPort: 8799
+    useHTTP2: false
+    supportStreaming: false
+    idleTimeout: 1800s
+#    servicemonitor:
+#      enabled: true
+#      path: /abc
+#      scheme: 'http'
+#      interval: 30s
+#      scrapeTimeout: 20s
+#      metricRelabelings:
+#        - sourceLabels: [namespace]
+#          regex: '(.*)'
+#          replacement: myapp
+#          targetLabel: target_namespace
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits:
+    cpu: 1
+    memory: 200Mi
+  requests:
+    cpu: 0.10
+    memory: 100Mi
+
+# Optional configs
+LivenessProbe:
+  Path: ""
+  port: 8080
+  scheme: ""
+  httpHeaders: []
+#    - name: Custom-Header
+#      value: abc
+  tcp: false
+  command: []
+  initialDelaySeconds: 20
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+ReadinessProbe:
+  Path: ""
+  port: 8080
+  scheme: ""
+  httpHeaders: []
+#    - name: Custom-Header
+#      value: abc
+  tcp: false
+  command: []
+  initialDelaySeconds: 20
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+ingress:
+  enabled: false
+  className: ""
+  labels: {}
+  annotations: {}
+#    nginx.ingress.kubernetes.io/force-ssl-redirect: 'false'
+#    nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+#    kubernetes.io/ingress.class: nginx
+#    nginx.ingress.kubernetes.io/rewrite-target: /$2
+#    nginx.ingress.kubernetes.io/canary: "true"
+#    nginx.ingress.kubernetes.io/canary-weight: "10"
+
+  hosts:
+    - host: chart-example1.local
+      pathType: "ImplementationSpecific"
+      paths:
+        - /example1
+    - host: chart-example2.local
+      pathType: "ImplementationSpecific"
+      paths:
+        - /example2
+        - /example2/healthz
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+ingressInternal:
+  enabled: false
+  className: ""
+  annotations: {}
+ #    kubernetes.io/ingress.class: nginx
+ #    kubernetes.io/tls-acme: "true"
+ #    nginx.ingress.kubernetes.io/canary: "true"
+ #    nginx.ingress.kubernetes.io/canary-weight: "10"
+
+  hosts:
+    - host: chart-example1.internal
+      pathType: "ImplementationSpecific"
+      paths:
+        - /example1
+    - host: chart-example2.internal
+      pathType: "ImplementationSpecific"
+      paths:
+        - /example2
+        - /example2/healthz
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+command:
+  workingDir: {}
+  enabled: false
+  value: []
+    
+args: 
+  enabled: false
+  value:
+    - /bin/sh
+    - -c
+    - touch /tmp/healthy; sleep 30; rm -rf /tmp/healthy; sleep 600
+
+#For adding custom labels to pods
+
+podLabels: {}
+#  customKey: customValue
+podAnnotations: {}
+#  customKey: customValue
+
+rawYaml: []
+
+topologySpreadConstraints: []
+
+initContainers: []
+  ## Additional init containers to run before the Scheduler pods.
+  ## for example, be used to run a sidecar that chown Logs storage .
+  #- name: volume-mount-hack
+  #  image: busybox
+  #  command: ["sh", "-c", "chown -R 1000:1000 logs"]
+  #  volumeMounts:
+  #    - mountPath: /usr/local/airflow/logs
+  #      name: logs-data
+
+containers: []
+  ## Additional containers to run along with application pods.
+  ## for example, be used to run a sidecar that chown Logs storage .
+  #- name: volume-mount-hack
+  #  image: busybox
+  #  command: ["sh", "-c", "chown -R 1000:1000 logs"]
+  #  volumeMounts:
+  #    - mountPath: /usr/local/airflow/logs
+  #      name: logs-data
+
+volumeMounts: []
+#     - name: log-volume
+#       mountPath: /var/log
+
+volumes: []
+#     - name: log-volume
+#       emptyDir: {}
+
+dbMigrationConfig:
+  enabled: false
+
+tolerations: []
+
+podSecurityContext: {}
+
+containerSecurityContext: {}
+
+Spec:
+  Affinity:
+    Key:
+    #  Key: kops.k8s.io/instancegroup
+    Values:
+
+autoscaling:
+  enabled: false
+  MinReplicas: 1
+  MaxReplicas: 2
+  TargetCPUUtilizationPercentage: 70
+  TargetMemoryUtilizationPercentage: 80
+  annotations: {}
+  labels: {}
+  behavior: {}
+#    scaleDown:
+#      stabilizationWindowSeconds: 300
+#      policies:
+#      - type: Percent
+#        value: 100
+#        periodSeconds: 15
+#    scaleUp:
+#      stabilizationWindowSeconds: 0
+#      policies:
+#      - type: Percent
+#        value: 100
+#        periodSeconds: 15
+#      - type: Pods
+#        value: 4
+#        periodSeconds: 15
+#      selectPolicy: Max
+
+  extraMetrics: []
+#    - external:
+#        metricName: pubsub.googleapis.com|subscription|num_undelivered_messages
+#        metricSelector:
+#          matchLabels:
+#            resource.labels.subscription_id: echo-read
+#        targetAverageValue: "2"
+#      type: External
+#
+
+kedaAutoscaling:
+  enabled: false
+  envSourceContainerName: "" # Optional. Default: .spec.template.spec.containers[0]
+  minReplicaCount: 1 
+  maxReplicaCount: 2
+  advanced: {}
+  triggers: []
+  triggerAuthentication:
+    enabled: false
+    name: ""
+    spec: {}
+  authenticationRef: {}
+
+prometheus:
+  release: monitoring
+
+server:
+  deployment:
+    image_tag: 1-95af053
+    image: ""
+
+servicemonitor:
+  additionalLabels: {}
+
+envoyproxy:
+  image: quay.io/devtron/envoy:v1.14.1
+  configMapName: ""
+  resources:
+    limits:
+      cpu: 50m
+      memory: 50Mi
+    requests:
+      cpu: 50m
+      memory: 50Mi
+
+## Pods Service Account
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## @param serviceAccount.create Enable creation of ServiceAccount for pods
+  ##  
+  create: false
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the `.Chart.Name .fullname` template
+  name: ""
+  ## @param serviceAccount.annotations Annotations for service account. Evaluated as a template.
+  ## Only used if `create` is `true`.
+  ##  
+  annotations: {}
+
+imagePullSecrets: []
+  # - test1
+  # - test2
+hostAliases: []
+#   - ip: "127.0.0.1"
+#     hostnames:
+#     - "foo.local"
+#     - "bar.local"
+#   - ip: "10.1.2.3"
+#     hostnames:
+#     - "foo.remote"
+#     - "bar.remote"

--- a/contrib-chart/reference-chart_4-14-0/env-values.yaml
+++ b/contrib-chart/reference-chart_4-14-0/env-values.yaml
@@ -1,0 +1,66 @@
+replicaCount: 1
+MaxSurge: 1
+MaxUnavailable: 0
+GracePeriod: 30
+pauseForSecondsBeforeSwitchActive: 30
+waitForSecondsBeforeScalingDown: 30
+
+Spec:
+ Affinity:
+  key: ""
+  Values: nodes
+
+autoscaling:
+  enabled: false
+  MinReplicas: 1
+  MaxReplicas: 2
+  TargetCPUUtilizationPercentage: 90
+  TargetMemoryUtilizationPercentage: 80
+  behavior: {}
+#    scaleDown:
+#      stabilizationWindowSeconds: 300
+#      policies:
+#      - type: Percent
+#        value: 100
+#        periodSeconds: 15
+#    scaleUp:
+#      stabilizationWindowSeconds: 0
+#      policies:
+#      - type: Percent
+#        value: 100
+#        periodSeconds: 15
+#      - type: Pods
+#        value: 4
+#        periodSeconds: 15
+#      selectPolicy: Max
+  extraMetrics: []
+#    - external:
+#        metricName: pubsub.googleapis.com|subscription|num_undelivered_messages
+#        metricSelector:
+#          matchLabels:
+#            resource.labels.subscription_id: echo-read
+#        targetAverageValue: "2"
+#      type: External
+#
+secret:
+ enabled: false
+ data: {}
+#   my_own_secret: S3ViZXJuZXRlcyBXb3Jrcw==
+
+EnvVariables: []
+#  - name: FLASK_ENV
+#    value: qa
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+   limits:
+    cpu: "0.05"
+    memory: 50Mi
+   requests:
+    cpu: "0.01"
+    memory: 10Mi
+
+

--- a/contrib-chart/reference-chart_4-14-0/pipeline-values.yaml
+++ b/contrib-chart/reference-chart_4-14-0/pipeline-values.yaml
@@ -1,0 +1,24 @@
+deployment:
+  strategy:
+    blueGreen:
+      autoPromotionSeconds: 30
+      scaleDownDelaySeconds: 30
+      previewReplicaCount: 1
+      autoPromotionEnabled: false
+    rolling:
+      maxSurge: "25%"
+      maxUnavailable: 1
+    canary:
+      maxSurge: "25%"
+      maxUnavailable: 1
+      steps:
+        - setWeight: 25
+        - pause:
+            duration: 15 # 1 min
+        - setWeight: 50
+        - pause:
+            duration: 15 # 1 min
+        - setWeight: 75
+        - pause:
+            duration: 15 # 1 min
+    recreate: {}

--- a/contrib-chart/reference-chart_4-14-0/release-values.yaml
+++ b/contrib-chart/reference-chart_4-14-0/release-values.yaml
@@ -1,0 +1,14 @@
+server:
+ deployment:
+   image_tag: IMAGE_TAG
+   image: IMAGE_REPO
+   enabled: false
+dbMigrationConfig:
+  enabled: false
+
+pauseForSecondsBeforeSwitchActive: 0
+waitForSecondsBeforeScalingDown: 0
+autoPromotionSeconds: 30
+
+#used for deployment algo selection
+orchestrator.deploymant.algo: 1 

--- a/contrib-chart/reference-chart_4-14-0/schema.json
+++ b/contrib-chart/reference-chart_4-14-0/schema.json
@@ -1,0 +1,812 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "ContainerPort": {
+      "type": "array",
+      "description": "defines ports on which application services will be exposed to other services",
+      "title": "Container Port",
+      "items": {
+        "type": "object",
+        "properties": {
+          "envoyPort": {
+            "type": "integer",
+            "description": "envoy port for the container",
+            "title": "Envoy Port"
+          },
+          "idleTimeout": {
+            "type": "string",
+            "description": "duration of time for which a connection is idle before the connection is terminated",
+            "title": "Idle Timeout"
+          },
+          "name": {
+            "type": "string",
+            "description": "name of the port",
+            "title": "Name"
+          },
+          "port": {
+            "type": "integer",
+            "description": "Port",
+            "title": "port for the container"
+          },
+          "servicePort": {
+            "type": "integer",
+            "description": "port of the corresponding kubernetes service",
+            "title": "Service Port"
+          },
+          "supportStreaming": {
+            "type": "boolean",
+            "description": "field to enable/disable timeout for high performance protocols like grpc",
+            "title": "Support Streaming"
+          },
+          "useHTTP2": {
+            "type": "boolean",
+            "description": " field for setting if envoy container can accept(or not) HTTP2 requests",
+            "title": "Use HTTP2"
+          }
+        }
+      }
+    },
+    "EnvVariables": {
+      "type": "array",
+      "items": {},
+      "description": "contains environment variables needed by the containers",
+      "title": "Environment Variables"
+    },
+    "EnvVariablesFromSecretKey": {
+      "type": "array",
+      "items": {},
+      "description": "Define environment variable from specific secret key",
+      "title": "Environment Variables From Secret Key"
+    },
+    "GracePeriod": {
+      "type": "integer",
+      "description": "time for which Kubernetes waits before terminating the pods",
+      "title": "Grace Period"
+    },
+    "LivenessProbe": {
+      "type": "object",
+      "description": "used by the kubelet to know when to restart a container",
+      "title": "Liveness Probe",
+      "properties": {
+        "Path": {
+          "type": "string",
+          "description": "defines the path where the liveness needs to be checked",
+          "title": "Path"
+        },
+        "command": {
+          "type": "array",
+          "items": {},
+          "description": "commands executed to perform a probe",
+          "title": "Command"
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "description": "defines the maximum number of failures that are acceptable before a given container is not considered as live",
+          "title": "Failure Threshold"
+        },
+        "httpHeaders": {
+          "type": "array",
+          "items": {},
+          "description": "used to override the default headers by defining .httpHeaders for the probe",
+          "title": "HTTP headers"
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "description": "defines the time to wait before a given container is checked for liveness",
+          "title": "Initial Delay Seconds"
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "description": "defines the time to check a given container for liveness",
+          "title": "Period Seconds"
+        },
+        "port": {
+          "type": "integer",
+          "description": "port to access on the container",
+          "title": "Port"
+        },
+        "scheme": {
+          "type": "string",
+          "description": "Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.",
+          "title": "Scheme"
+        },
+        "successThreshold": {
+          "type": "integer",
+          "description": "defines the number of successes required before a given container is said to fulfil the liveness probe",
+          "title": "Success Threshold"
+        },
+        "tcp": {
+          "type": "boolean",
+          "description": "If enabled, the kubelet will attempt to open a socket to container. If connection is established, the container is considered healthy",
+          "title": "TCP"
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "description": "defines the time for checking timeout",
+          "title": "Timeout Seconds"
+        }
+      }
+    },
+    "MaxSurge": {
+      "type": "integer",
+      "description": "maximum number of pods that can be created over the desired number of pods",
+      "title": "Maximum Surge"
+    },
+    "MaxUnavailable": {
+      "type": "integer",
+      "description": "maximum number of pods that can be unavailable during the update process",
+      "title": "Maximum Unavailable"
+    },
+    "MinReadySeconds": {
+      "type": "integer",
+      "description": "minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available",
+      "title": "Minimum Ready Seconds"
+    },
+    "ReadinessProbe": {
+      "type": "object",
+      "description": "kubelet uses readiness probes to know when a container is ready to start accepting traffic",
+      "title": "Readiness Probe",
+      "properties": {
+        "Path": {
+          "type": "string",
+          "description": "defines the path where the readiness needs to be checked",
+          "title": "Path"
+        },
+        "command": {
+          "type": "array",
+          "items": {},
+          "description": "commands executed to perform a probe",
+          "title": "Command"
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "description": "defines the maximum number of failures that are acceptable before a given container is not considered as ready",
+          "title": "Failure Threshold"
+        },
+        "httpHeader": {
+          "type": "array",
+          "items": {},
+          "description": "used to override the default headers by defining .httpHeaders for the probe",
+          "title": "HTTP headers"
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "description": "defines the time to wait before a given container is checked for readiness",
+          "title": "Initial Delay Seconds"
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "description": "defines the time to check a given container for readiness",
+          "title": "Period Seconds"
+        },
+        "port": {
+          "type": "integer",
+          "description": "port to access on the container",
+          "title": "Port"
+        },
+        "scheme": {
+          "type": "string",
+          "description": "Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.",
+          "title": "Scheme"
+        },
+        "successThreshold": {
+          "type": "integer",
+          "description": "defines the number of successes required before a given container is said to fulfil the readiness probe",
+          "title": "Success Threshold"
+        },
+        "tcp": {
+          "type": "boolean",
+          "description": "If enabled, the kubelet will attempt to open a socket to container. If connection is established, the container is considered healthy",
+          "title": "TCP"
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "description": "defines the time for checking timeout",
+          "title": "Timeout Seconds"
+        }
+      }
+    },
+    "Spec": {
+      "type": "object",
+      "description": "used to define the desire state of the given container",
+      "title": "Spec",
+      "properties": {
+        "Affinity": {
+          "type": "object",
+          "description": "Node/Inter-pod Affinity allows you to constrain which nodes your pod is eligible to schedule on, based on labels of the node/pods",
+          "title": "Affinity",
+          "properties": {
+            "Key": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string",
+                  "description": "Key part of the label for node/pod selection",
+                  "title": "Key"
+                }
+              ]
+            },
+            "Values": {
+              "type": "string",
+              "description": "Value part of the label for node/pod selection",
+              "title": "Values"
+            },
+            "key": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "args": {
+      "type": "object",
+      "description": " used to give arguments to command",
+      "title": "Arguments",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "used for enabling/disabling aruguments",
+          "title": "Enabled"
+        },
+        "value": {
+          "type": "array",
+          "description": "values of the arguments",
+          "title": "Value",
+          "items": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "autoscaling": {
+      "type": "object",
+      "description": "connected to HPA and controls scaling up and down in response to request load",
+      "title": "Autoscaling",
+      "properties": {
+        "MaxReplicas": {
+          "type": "integer",
+          "description": "Maximum number of replicas allowed for scaling",
+          "title": "Maximum Replicas"
+        },
+        "MinReplicas": {
+          "type": "integer",
+          "description": "Minimum number of replicas allowed for scaling",
+          "title": "Minimum Replicas"
+        },
+        "TargetCPUUtilizationPercentage": {
+          "type": "integer",
+          "description": "The target CPU utilization that is expected for a container",
+          "title": "TargetCPUUtilizationPercentage"
+        },
+        "TargetMemoryUtilizationPercentage": {
+          "type": "integer",
+          "description": "The target memory utilization that is expected for a container",
+          "title": "TargetMemoryUtilizationPercentage"
+        },
+        "behavior": {
+          "type": "object",
+          "description": "describes behavior and scaling policies for that behavior",
+          "title": "Behavior"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "used for enabling/disabling autoscaling",
+          "title": "Enabled"
+        },
+        "extraMetrics": {
+          "type": "array",
+          "items": {},
+          "description": "used to give external metrics for autoscaling",
+          "title": "Extra Metrics"
+        }
+      }
+    },
+    "command": {
+      "type": "object",
+      "description": "contains the commands for the server",
+      "title": "Command",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "used for enabling/disabling commands"
+        },
+        "value": {
+          "type": "array",
+          "items": {},
+          "description": "contains the commands",
+          "title": "Value"
+        }
+      }
+    },
+    "containerSecurityContext": {
+      "type": "object",
+      "description": " defines privilege and access control settings for a Container",
+      "title": "Container Security Context"
+    },
+    "containers": {
+      "type": "array",
+      "items": {},
+      "description": " used to run side-car containers along with the main container within same pod"
+    },
+    "dbMigrationConfig": {
+      "type": "object",
+      "description": "used to configure database migration",
+      "title": "Db Migration Config",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "used for enabling/disabling the config",
+          "title": "Enabled"
+        }
+      }
+    },
+    "envoyproxy": {
+      "type": "object",
+      "description": "envoy is attached as a sidecar to the application container to collect metrics like 4XX, 5XX, throughput and latency",
+      "title": "Envoy Proxy",
+      "properties": {
+        "configMapName": {
+          "type": "string",
+          "description": "configMap containing configuration for Envoy",
+          "title": "ConfigMap"
+        },
+        "image": {
+          "type": "string",
+          "description": "image of envoy to be used"
+        },
+        "resources": {
+          "type": "object",
+          "description": "minimum and maximum RAM and CPU available to the application",
+          "title": "Resources",
+          "properties": {
+            "limits": {
+              "type": "object",
+              "description": "the maximum values a container can reach",
+              "title": "Limits",
+              "properties": {
+                "cpu": {
+                  "type": "string",
+                  "format": "cpu",
+                  "description": "limit of CPU",
+                  "title": "CPU"
+                },
+                "memory": {
+                  "type": "string",
+                  "format": "memory",
+                  "description": "limit of memory",
+                  "title": "Memory"
+                }
+              }
+            },
+            "requests": {
+              "type": "object",
+              "description": "request is what the container is guaranteed to get",
+              "title": "Requests",
+              "properties": {
+                "cpu": {
+                  "type": "string",
+                  "format": "cpu",
+                  "description": "request value of CPU",
+                  "title": "CPU"
+                },
+                "memory": {
+                  "type": "string",
+                  "format": "memory",
+                  "description": "request value of memory",
+                  "title": "Memory"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "description": "used to access images in kubernetes",
+      "title": "Image",
+      "properties": {
+        "pullPolicy": {
+          "type": "string",
+          "description": "used to define the instances calling the image",
+          "title": "Pull Policy",
+          "enum": [
+            "IfNotPresent",
+            "Always"
+          ]
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {},
+      "description": "contains the docker credentials that are used for accessing a registry",
+      "title": "Image PullSecrets"
+    },
+    "ingress": {
+      "type": "object",
+      "description": "allows public access to URLs",
+      "title": "Ingress",
+      "properties": {
+        "annotations": {
+          "type": "object",
+          "description": "used to configure some options depending on the Ingress controller",
+          "title": "Annotations"
+        },
+        "className": {
+          "type": "string",
+          "description": "name of ingress class, a reference to an IngressClass resource that contains additional configuration including the name of the controller",
+          "title": "Ingress class name",
+          "default": "nginx"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "used to enable or disable ingress",
+          "title": "Enabled"
+        },
+        "hosts": {
+          "type": "array",
+          "description": "list of hosts in ingress",
+          "title": "Hosts",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "host": {
+                  "type": "string",
+                  "description": "host URL",
+                  "title": "Host"
+                },
+                "pathType": {
+                  "type": "string",
+                  "description": "type of path",
+                  "title": "PathType"
+                },
+                "paths": {
+                  "type": "array",
+                  "description": "list of paths for a given host",
+                  "title": "Paths",
+                  "items": [
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "tls": {
+          "type": "array",
+          "items": {},
+          "description": "contains security details - private key and certificate",
+          "title": "TLS"
+        }
+      }
+    },
+    "ingressInternal": {
+      "type": "object",
+      "description": "allows private access to the URLs",
+      "properties": {
+        "annotations": {
+          "type": "object",
+          "description": "used to configure some options depending on the Ingress controller",
+          "title": "Annotations"
+        },
+        "className": {
+          "type": "string",
+          "description": "name of ingress class, a reference to an IngressClass resource that contains additional configuration including the name of the controller",
+          "title": "Ingress class name",
+          "default": "nginx-internal"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "used to enable or disable ingress",
+          "title": "Enabled"
+        },
+        "hosts": {
+          "type": "array",
+          "description": "list of hosts in ingress",
+          "title": "Hosts",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "host": {
+                  "type": "string",
+                  "description": "host URL",
+                  "title": "Host"
+                },
+                "pathType": {
+                  "type": "string",
+                  "description": "type of path",
+                  "title": "PathType"
+                },
+                "paths": {
+                  "type": "array",
+                  "description": "list of paths for a given host",
+                  "title": "Paths",
+                  "items": [
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "tls": {
+          "type": "array",
+          "items": {},
+          "description": "contains security details - private key and certificate",
+          "title": "TLS"
+        }
+      }
+    },
+    "initContainers": {
+      "type": "array",
+      "items": {},
+      "description": "specialized containers that run before app containers in a Pod, can contain utilities or setup scripts not present in an app image",
+      "title": "Init Containers"
+    },
+    "kedaAutoscaling": {
+      "type": "object",
+      "description": "Kubernetes-based event driven autoscaler. With KEDA, one can drive the scaling of any container in Kubernetes based on the no. of events needing to be processed",
+      "title": "KEDA Autoscaling",
+      "properties": {
+        "advanced": {
+          "type": "object"
+        },
+        "authenticationRef": {
+          "type": "object"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "envSourceContainerName": {
+          "type": "string"
+        },
+        "maxReplicaCount": {
+          "type": "integer"
+        },
+        "minReplicaCount": {
+          "type": "integer"
+        },
+        "triggerAuthentication": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            },
+            "spec": {
+              "type": "object"
+            }
+          }
+        },
+        "triggers": {
+          "type": "array",
+          "items": {}
+        }
+      }
+    },
+    "pauseForSecondsBeforeSwitchActive": {
+      "type": "integer",
+      "description": "tell how much to wait for given period of time before switch active the container",
+      "title": "Pause For Seconds Before SwitchActive"
+    },
+    "podAnnotations": {
+      "type": "object",
+      "description": "used to attach metadata and configs in Kubernetes",
+      "title": "Pod Annotations"
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "key/value pairs that are attached to pods, are intended to be used to specify identifying attributes of objects that are meaningful and relevant to users, but do not directly imply semantics to the core system",
+      "title": "Pod Labels"
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "description": "defines privilege and access control settings for a Pod or Container",
+      "title": "Pod Security Context"
+    },
+    "prometheus": {
+      "type": "object",
+      "description": "a kubernetes monitoring tool",
+      "title": "Prometheus",
+      "properties": {
+        "release": {
+          "type": "string",
+          "description": "name of the file to be monitored, describes the state of prometheus"
+        }
+      }
+    },
+    "rawYaml": {
+      "type": "array",
+      "items": {},
+      "description": "Accepts an array of Kubernetes objects. One can specify any kubernetes yaml here & it will be applied when a app gets deployed.",
+      "title": "Raw YAML"
+    },
+    "replicaCount": {
+      "type": "integer",
+      "description": "count of Replicas of pod",
+      "title": "REplica Count"
+    },
+    "resources": {
+      "type": "object",
+      "description": "minimum and maximum RAM and CPU available to the application",
+      "title": "Resources",
+      "properties": {
+        "limits": {
+          "type": "object",
+          "description": "the maximum values a container can reach",
+          "title": "Limits",
+          "properties": {
+            "cpu": {
+              "type": "string",
+              "format": "cpu",
+              "description": "limit of CPU",
+              "title": "CPU"
+            },
+            "memory": {
+              "type": "string",
+              "format": "memory",
+              "description": "limit of memory",
+              "title": "Memory"
+            }
+          }
+        },
+        "requests": {
+          "type": "object",
+          "description": "request is what the container is guaranteed to get",
+          "title": "Requests",
+          "properties": {
+            "cpu": {
+              "type": "string",
+              "format": "cpu",
+              "description": "request value of CPU",
+              "title": "CPU"
+            },
+            "memory": {
+              "type": "string",
+              "format": "memory",
+              "description": "request value of memory",
+              "title": "Memory"
+            }
+          }
+        }
+      }
+    },
+    "secret": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object"
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "server": {
+      "type": "object",
+      "description": "used for providing server configurations.",
+      "title": "Server",
+      "properties": {
+        "deployment": {
+          "type": "object",
+          "description": "gives the details for deployment",
+          "title": "Deployment",
+          "properties": {
+            "image": {
+              "type": "string",
+              "description": "URL of the image",
+              "title": "Image"
+            },
+            "image_tag": {
+              "type": "string",
+              "description": "tag of the image",
+              "title": "Image Tag"
+            }
+          }
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "description": "defines annotations and the type of service",
+      "title": "Service",
+      "properties": {
+        "annotations": {
+          "type": "object",
+          "title": "Annotations",
+          "description": "annotations of service"
+        },
+        "type": {
+          "type": "string",
+          "description": "type of service",
+          "title": "Type",
+          "enum": [
+            "ClusterIP",
+            "LoadBalancer",
+            "NodePort",
+            "ExternalName"
+          ]
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "description": "defines service account for pods",
+      "title": "Service Account",
+      "properties": {
+        "annotations": {
+          "type": "object",
+          "title": "Annotations",
+          "description": "annotations of service account"
+        },
+        "name": {
+          "type": "string",
+          "description": "name of service account",
+          "title": "Name"
+        },
+        "create": {
+          "type": "boolean"
+        }
+      }
+    },
+    "servicemonitor": {
+      "type": "object",
+      "description": "gives the set of targets to be monitored",
+      "title": "Service Monitor",
+      "properties": {
+        "additionalLabels": {
+          "type": "object"
+        }
+      }
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {},
+      "description": "a mechanism which work together with Taints which ensures that pods are not placed on inappropriate nodes",
+      "title": "Tolerations"
+    },
+    "topologySpreadConstraints": {
+      "type": "array",
+      "items": {},
+      "description": "used to control how Pods are spread across a cluster among failure-domains such as regions, zones, nodes, and other user-defined topology domains",
+      "title": "Topology Spread Constraints"
+    },
+    "volumeMounts": {
+      "type": "array",
+      "items": {},
+      "description": "used to provide mounts to the volume",
+      "title": "Volume Mounts"
+    },
+    "volumes": {
+      "type": "array",
+      "items": {},
+      "description": "required when some values need to be read from or written to an external disk",
+      "title": "Volumes"
+    },
+    "waitForSecondsBeforeScalingDown": {
+      "type": "integer",
+      "description": "Wait for given period of time before scaling down the container",
+      "title": "Wait For Seconds Before Scaling Down"
+    }
+  }
+}

--- a/contrib-chart/reference-chart_4-14-0/secrets-test-values.yaml
+++ b/contrib-chart/reference-chart_4-14-0/secrets-test-values.yaml
@@ -1,0 +1,25 @@
+{
+  "ConfigSecrets":
+    {
+      "enabled": true,
+      "secrets":
+        [
+          {
+            "data": { "standard_key": "c3RhbmRhcmQtdmFsdWU=" },
+            "external": false,
+            "externalType": "",
+            "mountPath": "/test",
+            "name": "normal-secret",
+            "type": "volume",
+          },
+          {
+            "data": { "secret_key": "U0VDUkVUIERBVEE=" },
+            "external": true,
+            "externalType": "AWSSecretsManager",
+            "mountPath": "",
+            "name": "external-secret-3",
+            "type": "environment",
+          },
+        ],
+    },
+}

--- a/contrib-chart/reference-chart_4-14-0/templates/NOTES.txt
+++ b/contrib-chart/reference-chart_4-14-0/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range $.Values.ingress.paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include ".Chart.Name .fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ include ".Chart.Name .fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include ".Chart.Name .fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include ".Chart.Name .name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+{{- end }}

--- a/contrib-chart/reference-chart_4-14-0/templates/_helpers.tpl
+++ b/contrib-chart/reference-chart_4-14-0/templates/_helpers.tpl
@@ -1,0 +1,142 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define ".Chart.Name .name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create service name
+*/}}
+{{- define ".servicename" -}}
+{{- if .Values.service.name -}}
+{{- .Values.service.name | trunc 63 | trimSuffix "-" -}}
+{{- else if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 55 | trimSuffix "-" -}}-service
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 55 | trimSuffix "-" -}}-service
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 55 | trimSuffix "-" -}}-service
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create preview service name
+*/}}
+{{- define ".previewservicename" -}}
+{{- if .Values.service.name -}}
+{{- .Values.service.name | trunc 55 | trimSuffix "-" -}}-preview
+{{- else if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 47 | trimSuffix "-" -}}-preview-service
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 47 | trimSuffix "-" -}}-preview-service
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 47 | trimSuffix "-" -}}-preview-service
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define ".Chart.Name .fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define ".Chart.Name .chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define ".Chart.Name .color" -}}
+{{- $active0 := (index .Values.server.deployment 0).enabled -}}
+{{/*
+{{- $active1 := (index .Values.server.deployment 1).enabled -}}
+*/}}
+{{- $active1 := include "safeenabledcheck" . -}}
+{{- $active := and $active0 $active1 -}}
+{{- $active -}}
+{{- end -}}
+
+{{- define "safeenabledcheck" -}}
+{{- if (eq (len .Values.server.deployment) 2) -}}
+  {{- if (index .Values.server.deployment 1).enabled -}}
+    {{- $active := true -}}
+    {{- $active -}}
+  {{- else -}}
+    {{-  $active := false -}}
+    {{- $active -}}
+  {{- end -}}
+{{- else -}}
+  {{- $active := false -}}
+  {{- $active -}}
+{{- end -}}
+{{- end -}}
+
+
+{{- define "isCMVolumeExists" -}}
+  {{- $isCMVolumeExists := false -}}
+    {{- if .Values.ConfigMaps.enabled }}
+      {{- range .Values.ConfigMaps.maps }}
+        {{- if eq .type "volume"}}
+          {{- $isCMVolumeExists = true}}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- $isCMVolumeExists -}}
+{{- end -}}
+
+{{- define "isSecretVolumeExists" -}}
+  {{- $isSecretVolumeExists := false -}}
+    {{- if .Values.ConfigSecrets.enabled }}
+      {{- range .Values.ConfigSecrets.secrets }}
+        {{- if eq .type "volume"}}
+          {{- $isSecretVolumeExists = true}}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- $isSecretVolumeExists -}}
+{{- end -}}
+
+
+
+
+{{- define "serviceMonitorEnabled" -}}
+   {{- $SMenabled := false -}}
+   {{- range .Values.ContainerPort }}
+       {{- if .servicemonitor }}
+             {{- if and .servicemonitor.enabled }}
+                 {{- $SMenabled = true -}}
+             {{- end }}
+       {{- end }}
+   {{- end }}
+   {{- $SMenabled -}}
+{{- end -}}
+
+{{/* Create the name of the service account to use */}}
+{{- define "serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include ".Chart.Name .fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/contrib-chart/reference-chart_4-14-0/templates/configmap.yaml
+++ b/contrib-chart/reference-chart_4-14-0/templates/configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.ConfigMaps.enabled }}
+  {{- range .Values.ConfigMaps.maps }}
+    {{if eq .external false}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: 2019-08-12T18:38:34Z
+  name: {{ .name}}-{{ $.Values.app }}
+data:
+{{ toYaml .data | trim | indent 2 }}
+    {{- end}}
+  {{- end}}
+{{- end }}

--- a/contrib-chart/reference-chart_4-14-0/templates/deployment.yaml
+++ b/contrib-chart/reference-chart_4-14-0/templates/deployment.yaml
@@ -1,0 +1,440 @@
+  {{- $hasCMEnvExists := false -}}
+  {{- $hasCMVolumeExists := false -}}
+  {{- if .Values.ConfigMaps.enabled }}
+  {{- range .Values.ConfigMaps.maps }}
+  {{- if eq .type "volume"}}
+  {{- $hasCMVolumeExists = true}}
+  {{- end }}
+  {{- if eq .type "environment"}}
+  {{- $hasCMEnvExists = true}}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+
+  {{- $hasSecretEnvExists := false -}}
+  {{- $hasSecretVolumeExists := false -}}
+  {{- if .Values.ConfigSecrets.enabled }}
+  {{- range .Values.ConfigSecrets.secrets }}
+  {{- if eq .type "volume"}}
+  {{- $hasSecretVolumeExists = true}}
+  {{- end }}
+  {{- if eq .type "environment"}}
+  {{- $hasSecretEnvExists = true}}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+
+
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: {{ include ".Chart.Name .fullname" $ }}
+  labels:
+    app: {{ template ".Chart.Name .name" $ }}
+    chart: {{ template ".Chart.Name .chart" $ }}
+    release: {{ $.Release.Name }}
+    releaseVersion: {{ $.Values.releaseVersion | quote }}
+    pipelineName: {{ .Values.pipelineName }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template ".Chart.Name .name" $ }}
+      release: {{ $.Release.Name }}
+  replicas: {{ $.Values.replicaCount }}
+  minReadySeconds: {{ $.Values.MinReadySeconds }}
+  template:
+    metadata:
+    {{- if .Values.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+    {{- end }}
+      labels:
+        app: {{ template ".Chart.Name .name" $ }}
+        appId: {{ $.Values.app | quote }}
+        envId: {{ $.Values.env | quote }}
+        release: {{ $.Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+    spec:
+{{- if $.Values.podExtraSpecs }}	
+{{ toYaml .Values.podExtraSpecs | indent 6 }}	
+{{- end }}
+      terminationGracePeriodSeconds: {{ $.Values.GracePeriod }}
+      restartPolicy: Always
+{{- if $.Values.hostAliases }}
+      hostAliases:
+{{ toYaml .Values.hostAliases | indent 8 }}
+{{- end }}
+{{- if and $.Values.Spec.Affinity.Key $.Values.Spec.Affinity.Values }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ $.Values.Spec.Affinity.Key  }}
+                operator: In
+                values:
+                - {{ $.Values.Spec.Affinity.Values | default "nodes"  }}
+{{- end }}
+{{- if $.Values.serviceAccountName }}
+      serviceAccountName: {{ $.Values.serviceAccountName }}
+{{- else  }}
+      serviceAccountName: {{ template "serviceAccountName" . }}
+{{- end }}
+  {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+  {{- end }}
+{{- if $.Values.imagePullSecrets}}
+      imagePullSecrets:
+  {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+  {{- end }}
+{{- end}}
+{{- if $.Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{- range $.Values.topologySpreadConstraints }}
+      - maxSkew: {{ .maxSkew }}
+        topologyKey: {{ .topologyKey }}
+        whenUnsatisfiable: {{ .whenUnsatisfiable }}
+        labelSelector:
+          matchLabels:
+          {{- if and .autoLabelSelector .customLabelSelector }}
+{{ toYaml .customLabelSelector | indent 12 }}
+          {{- else if .autoLabelSelector }}
+            app: {{ template ".Chart.Name .name" $ }}
+            appId: {{ $.Values.app | quote }}
+            envId: {{ $.Values.env | quote }}
+            release: {{ $.Release.Name }}
+          {{- else if .customLabelSelector }}
+{{ toYaml .customLabelSelector | indent 12 }}
+          {{- end }}
+{{- end }}
+{{- end }}
+{{- if $.Values.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
+{{- end }}
+{{- if $.Values.initContainers}}
+      initContainers:
+{{- range $i, $c := .Values.initContainers }}
+{{- if .reuseContainerImage}}
+        - name: {{ $.Chart.Name }}-init-{{ add1 $i }}
+          image: "{{ $.Values.server.deployment.image }}:{{ $.Values.server.deployment.image_tag }}"
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+{{- if .command}}
+          command:
+{{ toYaml .command | indent 12 -}}
+{{- end}}
+{{- if .resources}}
+          resources:
+{{ toYaml .resources | indent 12 -}}
+{{- end}}
+{{- if .volumeMounts}}
+          volumeMounts:
+{{ toYaml .volumeMounts | indent 12 -}}
+{{- end}}
+{{- else}}
+{{ toYaml $.Values.initContainers | indent 8 -}}
+{{- end}}
+{{- end}}
+{{- end}}
+      containers:
+{{- if $.Values.appMetrics }}
+        - name: envoy
+          image: {{ $.Values.envoyproxy.image | default "envoyproxy/envoy:v1.14.1"}}
+          resources:
+{{ toYaml $.Values.envoyproxy.resources | trim | indent 12 }}
+          ports:
+            - containerPort: 9901
+              protocol: TCP
+              name: envoy-admin
+              {{- range $index, $element := .Values.ContainerPort }}
+            - name: {{ $element.name}}
+              containerPort: {{ $element.envoyPort | default (add 8790 $index) }}
+              protocol: TCP
+              {{- end }}
+          command: ["/usr/local/bin/envoy"]
+          args: ["-c", "/etc/envoy-config/envoy-config.json", "-l", "info", "--log-format", "[METADATA][%Y-%m-%d %T.%e][%t][%l][%n] %v"]
+          volumeMounts:
+            - name: {{ $.Values.envoyproxy.configMapName | default "envoy-config-volume" }}
+              mountPath: /etc/envoy-config/
+{{- end}}
+{{- if $.Values.containers }}
+{{ toYaml $.Values.containers | indent 8 -}}
+{{- end}}
+        - name: {{ $.Chart.Name }}
+          image: "{{ .Values.server.deployment.image }}:{{ .Values.server.deployment.image_tag }}"
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+{{- if and $.Values.containerSecurityContext $.Values.privileged }}
+          securityContext:
+            privileged: true
+{{ toYaml .Values.containerSecurityContext | indent 12 }}
+{{- else if $.Values.privileged }}
+          securityContext:
+            privileged: true
+{{- else if $.Values.containerSecurityContext }}
+          securityContext:
+{{ toYaml .Values.containerSecurityContext | indent 12 }}
+{{- end }}
+{{- if $.Values.containerExtraSpecs }}	
+{{ toYaml .Values.containerExtraSpecs | indent 10 }}	
+{{- end }}
+          ports:
+          {{- range $.Values.ContainerPort }}
+            - name: {{ .name}}
+              containerPort: {{ .port  }}
+              protocol: TCP
+          {{- end}}
+{{- if and $.Values.command.enabled $.Values.command.workingDir }}
+          workingDir: {{ $.Values.command.workingDir }}
+{{- end}}
+{{- if and $.Values.command.value $.Values.command.enabled}}
+          command:
+{{ toYaml $.Values.command.value | indent 12 -}}
+{{- end}}
+{{- if and $.Values.args.value $.Values.args.enabled}}
+          args:
+{{ toYaml $.Values.args.value | indent 12 -}}
+{{- end }}
+          env:
+            - name: CONFIG_HASH
+              value: {{ include (print $.Chart.Name "/templates/configmap.yaml") . | sha256sum }}
+            - name: SECRET_HASH
+              value: {{ include (print $.Chart.Name "/templates/secret.yaml") . | sha256sum }}
+            - name: DEVTRON_APP_NAME
+              value: {{ template ".Chart.Name .name" $ }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          {{- range $.Values.EnvVariablesFromFieldPath }}
+            - name: {{ .name }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: {{ .fieldPath }}
+          {{- end}}
+          {{- range $.Values.EnvVariablesFromSecretKey }}
+            - name: {{ .name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{.secretName}}
+                  key: {{ .secretKey }}
+          {{- end}}
+          {{- range $.Values.EnvVariables }}
+            - name: {{ .name}}
+              value: {{ .value | quote }}
+          {{- end}}
+          {{- if or (and ($hasCMEnvExists) (.Values.ConfigMaps.enabled)) (and ($hasSecretEnvExists) (.Values.ConfigSecrets.enabled)) }}
+          envFrom:
+          {{- if .Values.ConfigMaps.enabled }}
+          {{- range .Values.ConfigMaps.maps }}
+          {{- if eq .type "environment" }}
+          - configMapRef:
+              {{- if eq .external true }}
+              name: {{ .name }}
+              {{- else if eq .external false }}
+              name: {{ .name}}-{{ $.Values.app }}
+              {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.ConfigSecrets.enabled }}
+          {{- range .Values.ConfigSecrets.secrets }}
+          {{- if eq .type "environment" }}
+          - secretRef:
+              {{if eq .external true}}
+              name: {{ .name }}
+              {{else if eq .external false}}
+              name: {{ .name}}-{{ $.Values.app }}
+              {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+
+{{- if or $.Values.LivenessProbe.Path $.Values.LivenessProbe.command $.Values.LivenessProbe.tcp }}
+          livenessProbe:
+{{- if $.Values.LivenessProbe.Path }}
+            httpGet:
+              path: {{ $.Values.LivenessProbe.Path  }}
+              port: {{ $.Values.LivenessProbe.port }}
+            {{- if $.Values.LivenessProbe.httpHeaders }}
+              httpHeaders:
+              {{- range $.Values.LivenessProbe.httpHeaders}}
+                - name: {{.name}}
+                  value: {{.value}}
+              {{- end}}
+	    {{- end }}
+{{- end }}
+{{- if $.Values.LivenessProbe.command }}
+            exec:
+              command:
+{{ toYaml .Values.LivenessProbe.command | indent 16 }}
+{{- end}}
+{{- if and $.Values.LivenessProbe.tcp }}
+            tcpSocket:
+              port: {{ $.Values.LivenessProbe.port }}
+{{- end}}
+            initialDelaySeconds: {{ $.Values.LivenessProbe.initialDelaySeconds  }}
+            periodSeconds: {{ $.Values.LivenessProbe.periodSeconds  }}
+            successThreshold: {{ $.Values.LivenessProbe.successThreshold  }}
+            timeoutSeconds: {{ $.Values.LivenessProbe.timeoutSeconds  }}
+            failureThreshold: {{ $.Values.LivenessProbe.failureThreshold  }}
+{{- end }}
+{{- if or $.Values.ReadinessProbe.Path  $.Values.ReadinessProbe.command $.Values.ReadinessProbe.tcp }}
+          readinessProbe:
+{{- if $.Values.ReadinessProbe.Path }}
+            httpGet:
+              path: {{ $.Values.ReadinessProbe.Path  }}
+              port: {{ $.Values.ReadinessProbe.port }}
+            {{- if $.Values.ReadinessProbe.httpHeaders }}
+              httpHeaders:
+              {{- range $.Values.ReadinessProbe.httpHeaders}}
+                - name: {{.name}}
+                  value: {{.value}}
+              {{- end}}
+	    {{- end }}
+{{- end }}
+{{- if $.Values.ReadinessProbe.command }}
+            exec:
+              command:
+{{ toYaml .Values.ReadinessProbe.command | indent 16 }}
+{{- end}}
+{{- if and $.Values.ReadinessProbe.tcp }}
+            tcpSocket:
+              port: {{ $.Values.ReadinessProbe.port }}
+{{- end}}
+            initialDelaySeconds: {{ $.Values.ReadinessProbe.initialDelaySeconds  }}
+            periodSeconds: {{ $.Values.ReadinessProbe.periodSeconds  }}
+            successThreshold: {{ $.Values.ReadinessProbe.successThreshold  }}
+            timeoutSeconds: {{ $.Values.ReadinessProbe.timeoutSeconds  }}
+            failureThreshold: {{ $.Values.ReadinessProbe.failureThreshold  }}
+{{- end }}
+          resources:
+{{ toYaml $.Values.resources | trim | indent 12 }}
+
+          volumeMounts:
+{{- with .Values.volumeMounts }}
+{{ toYaml . | trim | indent 12 }}
+{{- end }}
+          {{- if .Values.ConfigMaps.enabled }}
+          {{- range .Values.ConfigMaps.maps }}
+          {{- if eq .type "volume"}}
+          {{- $cmName := .name -}}
+          {{- $cmMountPath := .mountPath -}}
+          {{- if eq .subPath false }}
+            - name: {{ $cmName | replace "." "-"}}-vol
+              mountPath: {{ $cmMountPath }}
+	  
+          {{- else }}
+          {{- range $k, $v := .data }}
+            - name: {{ $cmName | replace "." "-"}}-vol
+              mountPath: {{ $cmMountPath }}/{{ $k}}
+              subPath: {{ $k}}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+
+          {{- if .Values.ConfigSecrets.enabled }}
+          {{- range .Values.ConfigSecrets.secrets }}
+          {{- if eq .type "volume"}}
+          {{- $cmName := .name -}}
+          {{- $cmMountPath := .mountPath -}}
+          {{- if eq .subPath false }}
+            - name: {{ $cmName | replace "." "-"}}-vol
+              mountPath: {{ $cmMountPath }}
+	      
+          {{- else }}
+          {{- range $k, $v := .data }}
+            - name: {{ $cmName | replace "." "-"}}-vol
+              mountPath: {{ $cmMountPath}}/{{ $k}}
+              subPath: {{ $k}}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- if and (eq (len .Values.volumes) 0) (or (eq (.Values.ConfigSecrets.enabled) true) (eq (.Values.ConfigMaps.enabled) true)) (eq ($hasCMVolumeExists) false) (eq ($hasSecretVolumeExists) false) }} []{{- end }}
+          {{- if and (eq (len .Values.volumeMounts) 0) (eq (.Values.ConfigSecrets.enabled) false) (eq (.Values.ConfigMaps.enabled) false) }} []{{- end }}
+
+      volumes:
+  {{- if $.Values.appMetrics }}
+        - name: envoy-config-volume
+          configMap:
+            name: sidecar-config-{{ template ".Chart.Name .name" $ }}
+  {{- end }}
+{{- with .Values.volumes }}
+{{ toYaml . | trim | indent 8 }}
+{{- end }}
+      {{- if .Values.ConfigMaps.enabled }}
+      {{- range .Values.ConfigMaps.maps }}
+      {{- if eq .type "volume"}}
+        - name: {{ .name | replace "." "-"}}-vol
+          configMap:
+            {{- if eq .external true }}
+            name: {{ .name }}
+            {{- else if eq .external false }}
+            name: {{ .name}}-{{ $.Values.app }}
+            {{- end }}
+            {{- if eq (len .filePermission) 0 }}
+            {{- else }}
+            defaultMode: {{ .filePermission}}
+            {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
+
+      {{- if .Values.ConfigSecrets.enabled }}
+      {{- range .Values.ConfigSecrets.secrets }}
+      {{- if eq .type "volume"}}
+        - name: {{ .name | replace "." "-"}}-vol
+          secret:
+            {{- if eq .external true }}
+            secretName: {{ .name }}
+            {{- else if eq .external false }}
+            secretName: {{ .name}}-{{ $.Values.app }}
+            {{- end }}
+            {{- if eq (len .filePermission) 0 }}
+            {{- else }}
+            defaultMode: {{ .filePermission}}
+            {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- if and (eq (len .Values.volumes) 0) (or (eq (.Values.ConfigSecrets.enabled) true) (eq (.Values.ConfigMaps.enabled) true)) (eq ($hasCMVolumeExists) false) (eq ($hasSecretVolumeExists) false) (eq (.Values.appMetrics) false) }} []{{- end }}
+      {{- if and (eq (len .Values.volumes) 0) (eq (.Values.ConfigSecrets.enabled) false) (eq (.Values.ConfigMaps.enabled) false) (eq (.Values.appMetrics) false) }} []{{- end }}
+
+  revisionHistoryLimit: 3
+##  pauseForSecondsBeforeSwitchActive: {{ $.Values.pauseForSecondsBeforeSwitchActive }}
+#  waitForSecondsBeforeScalingDown: {{ $.Values.waitForSecondsBeforeScalingDown }}
+  strategy:
+    {{- if eq .Values.deploymentType "BLUE-GREEN" }}
+    blueGreen: # A new field that used to provide configurable options for a BlueGreenUpdate strategy
+      previewService: {{ template ".previewservicename" . }} # Reference to a service that can serve traffic to a new image before it receives the active traffic
+      activeService: {{ template ".servicename" . }} # Reference to a service that serves end-user traffic to the replica set
+      autoPromotionSeconds: {{ $.Values.deployment.strategy.blueGreen.autoPromotionSeconds  }}
+      scaleDownDelaySeconds: {{ $.Values.deployment.strategy.blueGreen.scaleDownDelaySeconds }}
+      previewReplicaCount: {{ $.Values.deployment.strategy.blueGreen.previewReplicaCount  }}
+      autoPromotionEnabled: {{ $.Values.deployment.strategy.blueGreen.autoPromotionEnabled  }}
+    {{- else if eq .Values.deploymentType "ROLLING" }}
+    canary:
+      stableService: {{ template ".servicename" . }} # Reference to a service that serves end-user traffic to the replica set
+      maxSurge: {{ $.Values.deployment.strategy.rolling.maxSurge }}
+      maxUnavailable: {{ $.Values.deployment.strategy.rolling.maxUnavailable }}
+    {{- else if eq .Values.deploymentType "RECREATE" }}
+    recreate:
+      activeService: {{ template ".servicename" . }} # Reference to a service that serves end-user traffic to the replica set
+    {{- else if eq .Values.deploymentType "CANARY" }}
+    canary:
+      stableService: {{ template ".servicename" . }} # Reference to a service that serves end-user traffic to the replica set
+      maxSurge: {{ $.Values.deployment.strategy.canary.maxSurge }}
+      maxUnavailable: {{ $.Values.deployment.strategy.canary.maxUnavailable }}
+      steps:
+{{ toYaml .Values.deployment.strategy.canary.steps | indent 8 }}
+    {{- end }}

--- a/contrib-chart/reference-chart_4-14-0/templates/generic.yaml
+++ b/contrib-chart/reference-chart_4-14-0/templates/generic.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.rawYaml }}
+---
+{{ toYaml . }}
+  {{- end -}}

--- a/contrib-chart/reference-chart_4-14-0/templates/hpa.yaml
+++ b/contrib-chart/reference-chart_4-14-0/templates/hpa.yaml
@@ -1,0 +1,57 @@
+{{- if $.Values.autoscaling.enabled }}
+{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: autoscaling/v2beta2
+{{- else }}
+apiVersion: autoscaling/v2beta1
+{{- end }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template ".Chart.Name .fullname" $ }}-hpa
+  {{- if .Values.autoscaling.annotations }}
+  annotations:
+{{ toYaml .Values.autoscaling.annotations | indent 4 }}
+  {{- end }}
+  {{- if .Values.autoscaling.labels }}
+  labels:
+{{ toYaml .Values.autoscaling.labels | indent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
+    name: {{ include ".Chart.Name .fullname" $ }}
+  minReplicas: {{ $.Values.autoscaling.MinReplicas  }}
+  maxReplicas: {{ $.Values.autoscaling.MaxReplicas }}
+  metrics:
+  {{- if $.Values.autoscaling.TargetMemoryUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
+      target:
+        type: Utilization
+        averageUtilization: {{ $.Values.autoscaling.TargetMemoryUtilizationPercentage }}
+      {{- else }}
+      targetAverageUtilization: {{ $.Values.autoscaling.TargetMemoryUtilizationPercentage }}
+      {{- end }}
+  {{- end }}
+  {{- if $.Values.autoscaling.TargetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: cpu
+      {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
+      target:
+        type: Utilization
+        averageUtilization: {{ $.Values.autoscaling.TargetCPUUtilizationPercentage }}
+      {{- else }}
+      targetAverageUtilization: {{ $.Values.autoscaling.TargetCPUUtilizationPercentage }}
+      {{- end }}
+  {{- end }}
+    {{- if and $.Values.autoscaling.extraMetrics (semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion) }}
+  {{- toYaml $.Values.autoscaling.extraMetrics | nindent 2 }}
+    {{- end}}
+  {{- if and $.Values.autoscaling.behavior (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  behavior:
+    {{- toYaml $.Values.autoscaling.behavior | nindent 4 }}
+  {{- end }}
+  {{- end }}

--- a/contrib-chart/reference-chart_4-14-0/templates/ingress.yaml
+++ b/contrib-chart/reference-chart_4-14-0/templates/ingress.yaml
@@ -1,0 +1,163 @@
+{{ $svcName := include ".servicename" . }}
+{{ $svcPort := (index .Values.ContainerPort 0).servicePort }}
+{{- if $.Values.ingress.enabled -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- if and .Values.ingressInternal.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingressInternal.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingressInternal.annotations "kubernetes.io/ingress.class" .Values.ingressInternal.className}}
+  {{- end }}
+{{- end }}
+{{- end }}
+---
+{{ if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ template ".Chart.Name .fullname" . }}-ingress
+  namespace: {{ $.Values.NameSpace }}
+  labels:
+    app: {{ template ".Chart.Name .name" . }}
+    appId: {{ $.Values.app | quote }}
+    envId: {{ $.Values.env | quote }}
+    chart: {{ template ".Chart.Name .chart" . }}
+    release: {{ .Release.Name }}
+    {{- if .Values.ingress.labels }}
+{{ toYaml .Values.ingress.labels | indent 4 }}
+    {{- end }}
+{{- if .Values.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+{{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+  {{- if or .Values.ingress.host .Values.ingress.path }}
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            {{- if and .Values.ingress.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ $.Values.ingress.pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $svcName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $svcName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+  {{- end }}
+  {{- range .Values.ingress.hosts }}
+    {{ $outer := . -}}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ $outer.pathType | quote }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $svcName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $svcName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+        {{- end }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end }}
+{{- if $.Values.ingressInternal.enabled }}
+---
+{{ if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{ else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{ else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ template ".Chart.Name .fullname" . }}-ingress-internal
+  namespace: {{ $.Values.NameSpace }}
+  labels:
+    app: {{ template ".Chart.Name .name" . }}
+    appId: {{ $.Values.app | quote }}
+    envId: {{ $.Values.env | quote }}
+    chart: {{ template ".Chart.Name .chart" . }}
+    release: {{ .Release.Name }}
+{{- if .Values.ingressInternal.annotations }}
+  annotations:
+{{ toYaml .Values.ingressInternal.annotations | indent 4 }}
+{{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingressInternal.className }}
+  {{- end }}
+  rules:
+  {{- if or .Values.ingressInternal.host .Values.ingressInternal.path }}
+    - host: {{ .Values.ingressInternal.host }}
+      http:
+        paths:
+          - path: {{ .Values.ingressInternal.path }}
+            {{- if and .Values.ingressInternal.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ $.Values.ingressInternal.pathType | default "Prefix" | quote }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $svcName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $svcName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+  {{- end }}
+  {{- range .Values.ingressInternal.hosts }}
+    {{ $outer := . -}}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ $outer.pathType | quote }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $svcName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $svcName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+        {{- end }}
+  {{- end }}
+  {{- if .Values.ingressInternal.tls }}
+  tls:
+{{ toYaml .Values.ingressInternal.tls | indent 4 }}
+  {{- end -}}
+{{- end }}

--- a/contrib-chart/reference-chart_4-14-0/templates/keda-autoscaling.yaml
+++ b/contrib-chart/reference-chart_4-14-0/templates/keda-autoscaling.yaml
@@ -1,0 +1,48 @@
+{{- if $.Values.kedaAutoscaling.enabled }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ template ".Chart.Name .fullname" $ }}-keda
+spec:
+  scaleTargetRef:
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
+    name: {{ include ".Chart.Name .fullname" $ }}
+{{- if $.Values.kedaAutoscaling.envSourceContainerName }}
+    envSourceContainerName: {{ $.Values.kedaAutoscaling.envSourceContainerName }}
+{{- end }}
+{{- if $.Values.kedaAutoscaling.pollingInterval }}
+  pollingInterval: {{ $.Values.kedaAutoscaling.pollingInterval }}
+{{- end }}
+{{- if $.Values.kedaAutoscaling.cooldownPeriod }}
+  cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
+{{- end }}
+{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+  idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- end }}
+  minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}
+  maxReplicaCount: {{ $.Values.kedaAutoscaling.maxReplicaCount }}
+{{- if $.Values.kedaAutoscaling.fallback }}
+  fallback: 
+{{ toYaml $.Values.kedaAutoscaling.fallback | indent 4 }}
+{{- end }}
+{{- if $.Values.kedaAutoscaling.advanced }}
+  advanced: 
+{{ toYaml $.Values.kedaAutoscaling.advanced | indent 4 }}
+{{- end }}
+  triggers:
+{{ toYaml .Values.kedaAutoscaling.triggers | indent 2}}
+{{- if $.Values.kedaAutoscaling.authenticationRef }}
+    authenticationRef: 
+{{ toYaml $.Values.kedaAutoscaling.authenticationRef | indent 6 }}
+{{- end }}
+---
+{{- if $.Values.kedaAutoscaling.triggerAuthentication.enabled }}
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{ $.Values.kedaAutoscaling.triggerAuthentication.name }}
+spec:
+{{ toYaml $.Values.kedaAutoscaling.triggerAuthentication.spec | indent 2 }}
+{{- end }}
+{{- end }}

--- a/contrib-chart/reference-chart_4-14-0/templates/metrics-service-monitor.yaml
+++ b/contrib-chart/reference-chart_4-14-0/templates/metrics-service-monitor.yaml
@@ -1,0 +1,30 @@
+{{- if $.Values.appMetrics -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template ".Chart.Name .fullname" $ }}
+  labels:
+    app: {{ template ".Chart.Name .name" . }}
+    appId: {{ $.Values.app | quote }}
+    envId: {{ $.Values.env | quote }}
+    chart: {{ template ".Chart.Name .chart" . }}
+    release: {{ .Values.prometheus.release }}
+spec:
+  jobLabel: {{ template ".Chart.Name .name" $ }}
+  endpoints:
+    - port: envoy-admin
+      interval: 30s
+      path: /stats/prometheus
+  selector:
+    matchLabels:
+      app: {{ template ".Chart.Name .name" $ }}
+      appId: {{ $.Values.app | quote }}
+      envId: {{ $.Values.env | quote }}
+  namespaceSelector:
+    matchNames:
+      - {{.Release.Namespace}}
+  podTargetLabels:
+    - appId
+    - envId
+    - rollouts-pod-template-hash
+{{- end }}

--- a/contrib-chart/reference-chart_4-14-0/templates/poddisruptionbudget.yaml
+++ b/contrib-chart/reference-chart_4-14-0/templates/poddisruptionbudget.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.podDisruptionBudget }}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: policy/v1
+{{- else -}}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include ".Chart.Name .fullname" $ }}
+  labels:
+    app: {{ template ".Chart.Name .name" $ }}
+    appId: {{ $.Values.app | quote }}
+    envId: {{ $.Values.env | quote }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      appId: {{ $.Values.app | quote }}
+      envId: {{ $.Values.env | quote }}
+  {{- end }}

--- a/contrib-chart/reference-chart_4-14-0/templates/pre-sync-job.yaml
+++ b/contrib-chart/reference-chart_4-14-0/templates/pre-sync-job.yaml
@@ -1,0 +1,23 @@
+{{- if $.Values.dbMigrationConfig.enabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template ".Chart.Name .fullname" $ }}-migrator
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+#    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: migrator
+          image: 686244538589.dkr.ecr.us-east-2.amazonaws.com/migrator:0.0.1-rc14
+          env:
+            {{- range $.Values.dbMigrationConfig.envValues }}
+            - name: {{ .key}}
+              value: {{ .value  | quote }}
+            {{- end}}
+      restartPolicy: Never
+  backoffLimit: 0
+{{- end }}

--- a/contrib-chart/reference-chart_4-14-0/templates/prometheusrules.yaml
+++ b/contrib-chart/reference-chart_4-14-0/templates/prometheusrules.yaml
@@ -1,0 +1,22 @@
+{{- if  .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name:  {{ template ".Chart.Name .fullname" . }}
+  {{- if .Values.prometheusRule.namespace }}
+  namespace: {{ .Values.prometheusRule.namespace }}
+  {{- end }}
+  labels:
+    kind: Prometheus
+    chart: {{ template ".Chart.Name .chart" . }}
+    release: {{ .Values.prometheus.release }}
+  {{- if .Values.prometheusRule.additionalLabels }}
+{{ toYaml .Values.prometheusRule.additionalLabels | indent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.prometheusRule.rules }}
+  groups:
+    - name: {{ template ".Chart.Name .fullname" $ }}
+      rules: {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- end }}

--- a/contrib-chart/reference-chart_4-14-0/templates/secret.yaml
+++ b/contrib-chart/reference-chart_4-14-0/templates/secret.yaml
@@ -1,0 +1,57 @@
+{{- if $.Values.secret.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secret
+type: Opaque
+data:
+{{ toYaml $.Values.secret.data | indent 2 }}
+{{- end }}
+
+
+{{- if .Values.ConfigSecrets.enabled }}
+  {{- range .Values.ConfigSecrets.secrets }}
+  {{if eq .external false}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name}}-{{ $.Values.app }}
+type: Opaque
+data:
+{{ toYaml .data | trim | indent 2 }}
+{{- end}}
+  {{if eq .external true }}
+  {{if (or (eq .externalType "AWSSecretsManager") (eq .externalType "AWSSystemManager") (eq .externalType "HashiCorpVault"))}}
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .name}}
+spec:
+  {{- if .roleARN }}
+  roleArn: .roleARN
+  {{- end}}
+  {{- if eq .externalType "AWSSecretsManager"}}
+  backendType: secretsManager
+  {{- end}}
+  {{- if eq .externalType "AWSSystemManager"}}
+  backendType: systemManager
+  {{- end}}
+  {{- if eq .externalType "HashiCorpVault"}}
+  backendType: vault
+  {{- end}}
+  data:
+  {{- range .secretData }}
+  - key: {{.key}}
+    name: {{.name}}
+    {{- if .property }}
+    property: {{.property}}
+    {{- end}}
+    isBinary: {{.isBinary}}
+  {{- end}}
+  {{- end}}
+  {{- end}}
+  {{- end}}
+  {{- end}}

--- a/contrib-chart/reference-chart_4-14-0/templates/service.yaml
+++ b/contrib-chart/reference-chart_4-14-0/templates/service.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template ".servicename" . }}
+  labels:
+    app: {{ template ".Chart.Name .name" . }}
+    appId: {{ $.Values.app | quote }}
+    envId: {{ $.Values.env | quote }}
+    chart: {{ template ".Chart.Name .chart" . }}
+    release: {{ .Release.Name }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end}}
+spec:
+  type: {{ .Values.service.type | default "ClusterIP" }}
+{{- if (and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges )}}
+  loadBalancerSourceRanges: 
+ {{- range .Values.service.loadBalancerSourceRanges }}
+  - {{ . }}
+ {{- end }}
+{{- end }}
+  ports:
+    {{- range .Values.ContainerPort }}
+      {{- if .servicePort }}
+    - port: {{ .servicePort }}
+      {{- else }}
+    - port: {{ .port }}
+       {{- end }}
+      targetPort: {{ .name }}
+      protocol: TCP
+      name: {{ .name }}
+    {{- end }}
+      {{- if $.Values.appMetrics }}
+    - port: 9901
+      name: envoy-admin
+      {{- end }}
+  selector:
+    app: {{ template ".Chart.Name .name" . }}
+{{- if eq .Values.deploymentType "BLUE-GREEN" }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template ".previewservicename" . }}
+  labels:
+    app: {{ template ".Chart.Name .name" . }}
+    appId: {{ $.Values.app | quote }}
+    envId: {{ $.Values.env | quote }}
+    chart: {{ template ".Chart.Name .chart" . }}
+    release: {{ .Release.Name }}
+spec:
+  type: ClusterIP
+  ports:
+    {{- range .Values.ContainerPort }}
+      {{- if .servicePort }}
+      - port: {{ .servicePort }}
+        {{- else }}
+      - port: {{ .port }}
+        {{- end }}
+        targetPort: {{ .name }}
+        protocol: TCP
+        name: {{ .name }}
+      {{- end }}
+      {{- if $.Values.appMetrics }}
+      - port: 9901
+        name: envoy-admin
+      {{- end }}
+  selector:
+    app: {{ template ".Chart.Name .name" . }}
+{{- end }}

--- a/contrib-chart/reference-chart_4-14-0/templates/serviceaccount.yaml
+++ b/contrib-chart/reference-chart_4-14-0/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if $.Values.serviceAccount }}
+{{- if $.Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "serviceAccountName" . }}
+  {{- if .Values.podLabels }}
+  labels:
+{{ toYaml .Values.podLabels | indent 4 }}
+  {{- end }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+  {{- end }}
+{{- end -}}
+{{- end -}}

--- a/contrib-chart/reference-chart_4-14-0/templates/servicemonitor.yaml
+++ b/contrib-chart/reference-chart_4-14-0/templates/servicemonitor.yaml
@@ -1,0 +1,48 @@
+{{ $serviceMonitorEnabled := include "serviceMonitorEnabled" . }}
+{{- if eq "true" $serviceMonitorEnabled -}}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template ".Chart.Name .fullname" . }}-sm
+  labels:
+    kind: Prometheus
+    app: {{ template ".Chart.Name .name" . }}
+    appId: {{ $.Values.app | quote }}
+    envId: {{ $.Values.env | quote }}
+    chart: {{ template ".Chart.Name .chart" . }}
+    release: {{ .Values.prometheus.release }}
+    {{- if .Values.servicemonitor.additionalLabels }}
+{{ toYaml .Values.servicemonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    {{- range .Values.ContainerPort }}
+      {{- if  .servicemonitor }}
+        {{- if .servicemonitor.enabled}}
+          {{- if .servicePort }}
+    - port: {{ .name }}
+      {{- if .servicemonitor.path }}
+      path: {{ .servicemonitor.path}}
+      {{- end }}
+      {{- if .servicemonitor.scheme }}
+      scheme: {{ .servicemonitor.scheme}}
+      {{- end }}
+      {{- if .servicemonitor.interval }}
+      interval: {{ .servicemonitor.interval}}
+      {{- end }}
+      {{- if .servicemonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .servicemonitor.scrapeTimeout}}
+      {{- end }}
+      {{- if .servicemonitor.metricRelabelings}}
+      metricRelabelings:
+{{toYaml .servicemonitor.metricRelabelings | indent 8 }}
+      {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template ".Chart.Name .name" $ }}
+{{- end }}

--- a/contrib-chart/reference-chart_4-14-0/templates/sidecar-configmap.yaml
+++ b/contrib-chart/reference-chart_4-14-0/templates/sidecar-configmap.yaml
@@ -1,0 +1,169 @@
+{{- if .Values.appMetrics }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: 2019-08-12T18:38:34Z
+  name: sidecar-config-{{ template ".Chart.Name .name" $ }}
+data:
+  envoy-config.json: |
+    {
+      "stats_config": {
+        "use_all_default_tags": false,
+        "stats_tags": [
+          {
+            "tag_name": "cluster_name",
+            "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+          },
+          {
+            "tag_name": "tcp_prefix",
+            "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+          },
+          {
+            "tag_name": "response_code",
+            "regex": "_rq(_(\\d{3}))$"
+          },
+          {
+            "tag_name": "response_code_class",
+            "regex": ".*_rq(_(\\dxx))$"
+          },
+          {
+            "tag_name": "http_conn_manager_listener_prefix",
+            "regex": "^listener(?=\\.).*?\\.http\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+          },
+          {
+            "tag_name": "http_conn_manager_prefix",
+            "regex": "^http\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+          },
+          {
+            "tag_name": "listener_address",
+            "regex": "^listener\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+          },
+          {
+            "tag_name": "mongo_prefix",
+            "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
+          }
+        ],
+        "stats_matcher": {
+          "inclusion_list": {
+            "patterns": [
+              {
+              "regex": ".*_rq_\\dxx$"
+              },
+              {
+              "regex": ".*_rq_time$"
+              },
+              {
+              "regex": "cluster.*"
+              },
+            ]
+          }
+        }
+      },
+      "admin": {
+        "access_log_path": "/dev/null",
+        "address": {
+          "socket_address": {
+            "address": "0.0.0.0",
+            "port_value": 9901
+          }
+        }
+      },
+      "static_resources": {
+        "clusters": [
+    {{- range $index, $element := .Values.ContainerPort }}
+          {
+            "name": "{{ $.Values.app }}-{{ $index }}",
+            "type": "STATIC",
+            "connect_timeout": "0.250s",
+            "lb_policy": "ROUND_ROBIN",
+{{- if $element.idleTimeout }}
+            "common_http_protocol_options": {
+              "idle_timeout": {{ $element.idleTimeout | quote }}
+            },
+{{- end }}
+{{- if or $element.useHTTP2 $element.useGRPC }}
+            "http2_protocol_options": {},
+{{- end }}
+{{- if and (not $element.useGRPC) (not $element.supportStreaming) }}
+            "max_requests_per_connection": "1",
+{{- end }}
+            "load_assignment": {
+              "cluster_name": "9",
+              "endpoints": {
+                "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "protocol": "TCP",
+                        "address": "127.0.0.1",
+                        "port_value": {{ $element.port  }}
+                      }
+                    }
+                  }
+                }
+                ]
+              }
+            }
+          },
+    {{- end }}
+        ],
+        "listeners":[
+    {{- range $index, $element := .Values.ContainerPort }}
+          {
+            "address": {
+              "socket_address": {
+                "protocol": "TCP",
+                "address": "0.0.0.0",
+                "port_value": {{ $element.envoyPort | default (add 8790 $index) }}
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.filters.network.http_connection_manager",
+                    "config": {
+                      "codec_type": "AUTO",
+                      "stat_prefix": "stats",
+                      "route_config": {
+                        "virtual_hosts": [
+                          {
+                            "name": "backend",
+                            "domains": [
+                              "*"
+                            ],
+                            "routes": [
+                              {
+                                "match": {
+                                  "prefix": "/"
+                                },
+                                "route": {
+{{- if $element.supportStreaming }}
+                                  "timeout": "0s",
+{{- end }}
+{{- if and ($element.envoyTimeout) (not $element.supportStreaming) }}
+                                  "timeout": "{{ $element.envoyTimeout }}",
+{{- end }}
+                                  "cluster": "{{ $.Values.app }}-{{ $index }}"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "http_filters": {
+                        "name": "envoy.filters.http.router"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+    {{- end }}
+        ]
+      }
+    }
+---
+{{- end }}

--- a/contrib-chart/reference-chart_4-14-0/test_values.yaml
+++ b/contrib-chart/reference-chart_4-14-0/test_values.yaml
@@ -1,0 +1,431 @@
+# Default values for myapp.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+imagePullSecrets:
+  - test1
+  - test2
+replicaCount: 1
+MinReadySeconds: 5
+MaxSurge: 1
+MaxUnavailable: 0
+GracePeriod: 30
+ContainerPort:
+  - name: app
+    port: 8080
+    servicePort: 80
+    envoyTimeout: 15
+    envoyPort: 8799
+    useHTTP2: false
+    supportStreaming: false
+    idleTimeout: 1800s
+    servicemonitor:
+      enabled: true
+      path: /abc
+      scheme: 'http'
+      interval: 30s
+      scrapeTimeout: 20s
+      metricRelabelings:
+        - sourceLabels: [namespace]
+          regex: '(.*)'
+          replacement: myapp
+          targetLabel: target_namespace
+
+  - name: app1
+    port: 8090
+    servicePort: 8080
+    useGRPC: true
+    servicemonitor:
+      enabled: true
+  - name: app2
+    port: 8091
+    servicePort: 8081
+    useGRPC: true
+
+pauseForSecondsBeforeSwitchActive: 30
+waitForSecondsBeforeScalingDown: 30
+autoPromotionSeconds: 30
+
+Spec:
+  Affinity:
+    Key:
+    #  Key: kops.k8s.io/instancegroup
+    Values:
+
+
+image:
+  pullPolicy: IfNotPresent
+
+autoscaling:
+  enabled: true
+  MinReplicas: 1
+  MaxReplicas: 2
+  TargetCPUUtilizationPercentage: 90
+  TargetMemoryUtilizationPercentage: 80
+  behavior: {}
+#    scaleDown:
+#      stabilizationWindowSeconds: 300
+#      policies:
+#      - type: Percent
+#        value: 100
+#        periodSeconds: 15
+#    scaleUp:
+#      stabilizationWindowSeconds: 0
+#      policies:
+#      - type: Percent
+#        value: 100
+#        periodSeconds: 15
+#      - type: Pods
+#        value: 4
+#        periodSeconds: 15
+#      selectPolicy: Max
+
+  extraMetrics: []
+#    - external:
+#        metricName: pubsub.googleapis.com|subscription|num_undelivered_messages
+#        metricSelector:
+#          matchLabels:
+#            resource.labels.subscription_id: echo-read
+#        targetAverageValue: "2"
+#      type: External
+#
+
+secret:
+  enabled: false
+
+service:
+  type: ClusterIP
+  #  name: "1234567890123456789012345678901234567890123456789012345678901234567890"
+  annotations: {}
+    # test1: test2
+  # test3: test4
+
+server:
+  deployment:
+    image_tag: 1-95af053
+    image: ""
+deploymentType: "RECREATE"
+
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: zone
+    whenUnsatisfiable: DoNotSchedule
+    autoLabelSelector: true
+    customLabelSelector:
+      foo: bar
+
+EnvVariables:
+  - name: FLASK_ENV
+    value: qa
+
+LivenessProbe:
+  Path: /
+  port: 8080
+  initialDelaySeconds: 20
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 5
+  failureThreshold: 3
+  httpHeaders:
+    - name: Custom-Header
+      value: abc
+    - name: Custom-Header2
+      value: xyz
+
+ReadinessProbe:
+  Path: /
+  port: 8080
+  initialDelaySeconds: 20
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 5
+  failureThreshold: 3
+  httpHeaders:
+    - name: Custom-Header
+      value: abc
+
+prometheus:
+  release: monitoring
+
+servicemonitor:
+  additionalLabels: {}
+
+
+prometheusRule:
+  enabled: true
+  additionalLabels: {}
+  namespace: ""
+  rules:
+    # These are just examples rules, please adapt them to your needs
+    - alert: TooMany500s
+      expr: 100 * ( sum( nginx_ingress_controller_requests{status=~"5.+"} ) / sum(nginx_ingress_controller_requests) ) > 5
+      for: 1m
+      labels:
+        severity: critical
+      annotations:
+        description: Too many 5XXs
+        summary: More than 5% of the all requests did return 5XX, this require your attention
+    - alert: TooMany400s
+      expr: 100 * ( sum( nginx_ingress_controller_requests{status=~"4.+"} ) / sum(nginx_ingress_controller_requests) ) > 5
+      for: 1m
+      labels:
+        severity: critical
+      annotations:
+        description: Too many 4XXs
+        summary: More than 5% of the all requests did return 4XX, this require your attention
+
+
+ingress:
+  enabled: false
+  className: nginx
+  annotations: {}
+#    nginx.ingress.kubernetes.io/rewrite-target: /
+#    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+#    kubernetes.io/ingress.class: nginx
+#    kubernetes.io/tls-acme: "true"
+#    nginx.ingress.kubernetes.io/canary: "true"
+#    nginx.ingress.kubernetes.io/canary-weight: "10"
+  hosts:
+    - host: chart-example1.local
+      pathType: "ImplementationSpecific"
+      paths:
+        - /example1
+    - host: chart-example2.local
+      pathType: "ImplementationSpecific"
+      paths:
+        - /example2
+        - /example2/healthz
+  tls: []
+### Legacy Ingress Format ##
+#  host: abc.com
+#  path: "/"
+#  pathType: "ImplementationSpecific"
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+ingressInternal:
+  enabled: false
+  className: nginx-internal
+  annotations: {}
+ #    kubernetes.io/ingress.class: nginx
+ #    kubernetes.io/tls-acme: "true"
+ #    nginx.ingress.kubernetes.io/canary: "true"
+ #    nginx.ingress.kubernetes.io/canary-weight: "10"
+
+  hosts:
+    - host: chart-example1.internal
+      pathType: "ImplementationSpecific"
+      paths:
+        - /example1
+    - host: chart-example2.internal
+      pathType: "ImplementationSpecific"
+      paths:
+        - /example2
+        - /example2/healthz
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+dbMigrationConfig:
+  enabled: false
+
+command:
+  workingDir: /app
+  enabled: false
+  value: ["ls"]
+
+args:
+  enabled: false
+  value: []
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits:
+    cpu: 1
+    memory: 200Mi
+  requests:
+    cpu: 0.10
+    memory: 100Mi
+
+volumeMounts: []
+#     - name: log-volume
+#       mountPath: /var/log
+
+volumes: []
+#     - name: log-volume
+#       emptyDir: {}
+
+
+nodeSelector: {}
+
+
+#used for deployment algo selection
+orchestrator.deploymant.algo: 1
+
+ConfigMaps:
+  enabled: false
+  maps: []
+#  - name: config-map-1
+#    type: environment
+#    external: false
+#    data:
+#     key1: key1value-1
+#     key2: key2value-1
+#     key3: key3value-1
+#  - name: config-map-2
+#    type: volume
+#    external: false
+#    mountPath: /etc/config/2
+#    data:
+#     key1: |
+#      club : manchester utd
+#      nation : england
+#     key2: abc-2
+#     key3: abc-2
+#  - name: config-map-3
+#    type: environment
+#    external: true
+#    mountPath: /etc/config/3
+#    data: []
+#  - name: config-map-4
+#    type: volume
+#    external: true
+#    mountPath: /etc/config/4
+#    data: []
+
+
+ConfigSecrets:
+  enabled: false
+  secrets: []
+#  - name: config-secret-1
+#    type: environment
+#    external: false
+#    data:
+#     key1: key1value-1
+#     key2: key2value-1
+#     key3: key3value-1
+#  - name: config-secret-2
+#    type: volume
+#    external: false
+#    mountPath: /etc/config/2
+#    data:
+#     key1: |
+#      club : manchester utd
+#      nation : england
+#     key2: abc-2
+
+
+initContainers: []
+  ## Additional init containers to run before the Scheduler pods.
+  ## for example, be used to run a sidecar that chown Logs storage .
+  #- name: volume-mount-hack
+  #  image: busybox
+  #  command: ["sh", "-c", "chown -R 1000:1000 logs"]
+  #  volumeMounts:
+  #    - mountPath: /usr/local/airflow/logs
+#      name: logs-data
+
+containers: []
+  ## Additional init containers to run before the Scheduler pods.
+  ## for example, be used to run a sidecar that chown Logs storage .
+  #- name: volume-mount-hack
+  #  image: busybox
+  #  command: ["sh", "-c", "chown -R 1000:1000 logs"]
+  #  volumeMounts:
+  #    - mountPath: /usr/local/airflow/logs
+#      name: logs-data
+
+
+rawYaml: []
+# - apiVersion: v1
+#   kind: Service
+#   metadata:
+#    annotations:
+#    labels:
+#     app: sample-metrics-app
+#    name: sample-metrics-app
+#    namespace: default
+#   spec:
+#    ports:
+#     - name: web
+#       port: 80
+#       protocol: TCP
+#       targetPort: 8080
+#    selector:
+#     app: sample-metrics-app
+#    sessionAffinity: None
+#    type: ClusterIP
+# - apiVersion: v1
+#   kind: Service
+#   metadata:
+#    annotations:
+#    labels:
+#     app: sample-metrics-app
+#    name: sample-metrics-app
+#    namespace: default
+#   spec:
+#    ports:
+#     - name: web
+#       port: 80
+#       protocol: TCP
+#       targetPort: 8080
+#    selector:
+#     app: sample-metrics-app
+#    sessionAffinity: None
+#    type: ClusterIP
+
+# If you need to provide some extra specs for main container which are not included by default in deployment template
+# then provide them here
+containerExtraSpecs: {}
+
+# If you need to provide some extra specs for pod which are not included by default in deployment template
+# then provide them here
+podExtraSpecs: {}
+
+envoyproxy:
+  image: envoyproxy/envoy:v1.14.1
+  configMapName: ""
+  resources:
+    limits:
+      cpu: 50m
+      memory: 50Mi
+    requests:
+      cpu: 50m
+      memory: 50Mi
+
+podDisruptionBudget: {}
+  #  minAvailable: 1
+  #  maxUnavailable: 1
+
+  ## Node tolerations for server scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+##
+
+tolerations: []
+  #  - key: "key"
+  #    operator: "Equal|Exists"
+  #    value: "value"
+#    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+appMetrics: false
+serviceAccount:
+  ## @param serviceAccount.create Enable creation of ServiceAccount for pods
+  ##
+  create: false
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the `.Chart.Name .fullname` template
+  name: "test1"
+  ## @param serviceAccount.annotations Annotations for service account. Evaluated as a template.
+  ## Only used if `create` is `true`.
+  ##
+  annotations:
+     kubernetes.io/service-account.name: build-robot
+hostAliases: []
+#  - ip: "127.0.0.1"
+#    hostnames:
+#    - "foo.local"
+

--- a/contrib-chart/reference-chart_4-14-0/values.yaml
+++ b/contrib-chart/reference-chart_4-14-0/values.yaml
@@ -1,0 +1,461 @@
+# Default values for myapp.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+MinReadySeconds: 5
+MaxSurge: 1
+MaxUnavailable: 0
+GracePeriod: 30
+ContainerPort:
+  - name: app
+    port: 8080
+    servicePort: 80
+    envoyPort: 8799
+    envoyTimeout: 15s
+    useHTTP2: false
+    supportStreaming: false
+    idleTimeout: 1800s
+  #    servicemonitor:
+  #      enabled: true
+  #      path: /abc
+  #      scheme: 'http'
+  #      interval: 30s
+  #      scrapeTimeout: 20s
+  #      metricRelabelings:
+  #        - sourceLabels: [namespace]
+  #          regex: '(.*)'
+  #          replacement: myapp
+  #          targetLabel: target_namespace
+
+  - name: app1
+    port: 8090
+    servicePort: 8080
+    useGRPC: true
+
+pauseForSecondsBeforeSwitchActive: 30
+waitForSecondsBeforeScalingDown: 30
+autoPromotionSeconds: 30
+
+Spec:
+  Affinity:
+    Key:
+    #  Key: kops.k8s.io/instancegroup
+    Values:
+
+image:
+  pullPolicy: IfNotPresent
+
+autoscaling:
+  enabled: false
+  MinReplicas: 1
+  MaxReplicas: 2
+  TargetCPUUtilizationPercentage: 90
+  TargetMemoryUtilizationPercentage: 80
+  annotations: {}
+  labels: {}
+  behavior: {}
+  #    scaleDown:
+  #      stabilizationWindowSeconds: 300
+  #      policies:
+  #      - type: Percent
+  #        value: 100
+  #        periodSeconds: 15
+  #    scaleUp:
+  #      stabilizationWindowSeconds: 0
+  #      policies:
+  #      - type: Percent
+  #        value: 100
+  #        periodSeconds: 15
+  #      - type: Pods
+  #        value: 4
+  #        periodSeconds: 15
+  #      selectPolicy: Max
+  extraMetrics: []
+#    - external:
+#        metricName: pubsub.googleapis.com|subscription|num_undelivered_messages
+#        metricSelector:
+#          matchLabels:
+#            resource.labels.subscription_id: echo-read
+#        targetAverageValue: "2"
+#      type: External
+#
+
+kedaAutoscaling:
+  enabled: false
+  envSourceContainerName: "" # Optional. Default: .spec.template.spec.containers[0]
+  cooldownPeriod: 300 # Optional. Default: 300 seconds
+  minReplicaCount: 1
+  maxReplicaCount: 2
+  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
+  pollingInterval: 30 # Optional. Default: 30 seconds
+  # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
+  fallback:
+    {} # Optional. Section to specify fallback options
+    # failureThreshold: 3 # Mandatory if fallback section is included
+    # replicas: 6
+  advanced:
+    {}
+    # horizontalPodAutoscalerConfig: # Optional. Section to specify HPA related options
+    # behavior: # Optional. Use to modify HPA's scaling behavior
+    #   scaleDown:
+    #     stabilizationWindowSeconds: 300
+    #     policies:
+    #     - type: Percent
+    #       value: 100
+    #       periodSeconds: 15
+  triggers: []
+  triggerAuthentication:
+    enabled: false
+    name: ""
+    spec: {}
+  authenticationRef: {}
+
+secret:
+  enabled: false
+
+service:
+  type: ClusterIP
+  #  name: "1234567890123456789012345678901234567890123456789012345678901234567890"
+  annotations:
+    {}
+    # test1: test2
+    # test3: test4
+
+server:
+  deployment:
+    image_tag: 1-95af053
+    image: ""
+
+EnvVariablesFromFieldPath:
+  - name: POD_NAME
+    fieldPath: metadata.name
+
+EnvVariablesFromSecretKey: []
+#   - name: ENV_VARIABLE_NAME
+#     secretName: testSecret
+#     secretKey: testKey # one of the keys from `testSecret`
+
+EnvVariables: []
+
+LivenessProbe:
+  Path: /
+  port: 8080
+  initialDelaySeconds: 20
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 5
+  failureThreshold: 3
+  httpHeaders: []
+#    - name: Custom-Header
+#      value: abc
+
+ReadinessProbe:
+  Path: /
+  port: 8080
+  initialDelaySeconds: 20
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 5
+  failureThreshold: 3
+  httpHeaders: []
+#    - name: Custom-Header
+#      value: abc
+
+prometheus:
+  release: monitoring
+
+servicemonitor:
+  additionalLabels: {}
+
+prometheusRule:
+  enabled: false
+  additionalLabels: {}
+  namespace: ""
+#  rules:
+#    # These are just examples rules, please adapt them to your needs
+#    - alert: TooMany500s
+#      expr: 100 * ( sum( nginx_ingress_controller_requests{status=~"5.+"} ) / sum(nginx_ingress_controller_requests) ) > 5
+#      for: 1m
+#      labels:
+#        severity: critical
+#      annotations:
+#        description: Too many 5XXs
+#        summary: More than 5% of the all requests did return 5XX, this require your attention
+#    - alert: TooMany400s
+#      expr: 100 * ( sum( nginx_ingress_controller_requests{status=~"4.+"} ) / sum(nginx_ingress_controller_requests) ) > 5
+#      for: 1m
+#      labels:
+#        severity: critical
+#      annotations:
+#        description: Too many 4XXs
+#        summary: More than 5% of the all requests did return 4XX, this require your attention
+#
+
+ingress:
+  enabled: false
+  className: ""
+  labels: {}
+  annotations: {}
+  #    nginx.ingress.kubernetes.io/rewrite-target: /
+  #    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+  #    kubernetes.io/ingress.class: nginx
+  #    kubernetes.io/tls-acme: "true"
+  #    nginx.ingress.kubernetes.io/canary: "true"
+  #    nginx.ingress.kubernetes.io/canary-weight: "10"
+
+  hosts:
+    - host: chart-example1.local
+      pathType: "ImplementationSpecific"
+      paths:
+        - /example1
+    - host: chart-example2.local
+      pathType: "ImplementationSpecific"
+      paths:
+        - /example2
+        - /example2/healthz
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+ingressInternal:
+  enabled: false
+  className: ""
+  annotations: {}
+  #    kubernetes.io/ingress.class: nginx
+  #    kubernetes.io/tls-acme: "true"
+  #    nginx.ingress.kubernetes.io/canary: "true"
+  #    nginx.ingress.kubernetes.io/canary-weight: "10"
+
+  hosts:
+    - host: chart-example1.internal
+      pathType: "ImplementationSpecific"
+      paths:
+        - /example1
+    - host: chart-example2.internal
+      pathType: "ImplementationSpecific"
+      paths:
+        - /example2
+        - /example2/healthz
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+dbMigrationConfig:
+  enabled: false
+
+command:
+  enabled: false
+  value: []
+
+args:
+  enabled: false
+  value: []
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+
+volumeMounts: []
+#     - name: log-volume
+#       mountPath: /var/log
+
+volumes: []
+#     - name: log-volume
+#       emptyDir: {}
+
+nodeSelector: {}
+
+# If you need to provide some extra specs for pod which are not included by default in deployment template
+# then provide them here
+podExtraSpecs: {}
+
+# If you need to provide some extra specs for main container which are not included by default in deployment template
+# then provide them here
+containerExtraSpecs: {}
+
+#used for deployment algo selection
+orchestrator.deploymant.algo: 1
+
+ConfigMaps:
+  enabled: false
+  maps: []
+#  - name: config-map-1
+#    type: environment
+#    external: false
+#    data:
+#     key1: key1value-1
+#     key2: key2value-1
+#     key3: key3value-1
+#  - name: config-map-2
+#    type: volume
+#    external: false
+#    mountPath: /etc/config/2
+#    data:
+#     key1: |
+#      club : manchester utd
+#      nation : england
+#     key2: abc-2
+#     key3: abc-2
+#  - name: config-map-3
+#    type: environment
+#    external: true
+#    mountPath: /etc/config/3
+#    data: []
+#  - name: config-map-4
+#    type: volume
+#    external: true
+#    mountPath: /etc/config/4
+#    data: []
+
+ConfigSecrets:
+  enabled: false
+  secrets: []
+#  - name: config-secret-1
+#    type: environment
+#    external: false
+#    data:
+#     key1: key1value-1
+#     key2: key2value-1
+#     key3: key3value-1
+#  - name: config-secret-2
+#    type: volume
+#    external: false
+#    mountPath: /etc/config/2
+#    data:
+#     key1: |
+#      club : manchester utd
+#      nation : england
+#     key2: abc-2
+
+initContainers:
+  []
+  ## Additional init containers to run before the Scheduler pods.
+  ## for example, be used to run a sidecar that chown Logs storage .
+  #- name: volume-mount-hack
+  #  image: busybox
+  #  command: ["sh", "-c", "chown -R 1000:1000 logs"]
+  #  volumeMounts:
+  #    - mountPath: /usr/local/airflow/logs
+  #      name: logs-data
+  ## Uncomment below line ONLY IF you want to reuse the container image.
+  ## This will assign your application's docker image to init container.
+  #  reuseContainerImage: true
+
+containers:
+  []
+  ## Additional init containers to run before the Scheduler pods.
+  ## for example, be used to run a sidecar that chown Logs storage .
+  #- name: volume-mount-hack
+  #  image: busybox
+  #  command: ["sh", "-c", "chown -R 1000:1000 logs"]
+  #  volumeMounts:
+  #    - mountPath: /usr/local/airflow/logs
+  #      name: logs-data
+
+rawYaml: []
+# - apiVersion: v1
+#   kind: Service
+#   metadata:
+#    annotations:
+#    labels:
+#     app: sample-metrics-app
+#    name: sample-metrics-app
+#    namespace: default
+#   spec:
+#    ports:
+#     - name: web
+#       port: 80
+#       protocol: TCP
+#       targetPort: 8080
+#    selector:
+#     app: sample-metrics-app
+#    sessionAffinity: None
+#    type: ClusterIP
+# - apiVersion: v1
+#   kind: Service
+#   metadata:
+#    annotations:
+#    labels:
+#     app: sample-metrics-app
+#    name: sample-metrics-app
+#    namespace: default
+#   spec:
+#    ports:
+#     - name: web
+#       port: 80
+#       protocol: TCP
+#       targetPort: 8080
+#    selector:
+#     app: sample-metrics-app
+#    sessionAffinity: None
+#    type: ClusterIP
+
+topologySpreadConstraints:
+  []
+  # - maxSkew: 1
+  #   topologyKey: zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   autoLabelSelector: true
+  #   customLabelSelector: {}
+
+envoyproxy:
+  image: quay.io/devtron/envoy:v1.14.1
+  configMapName: ""
+  resources:
+    limits:
+      cpu: 50m
+      memory: 50Mi
+    requests:
+      cpu: 50m
+      memory: 50Mi
+
+podDisruptionBudget: {}
+#  minAvailable: 1
+#  maxUnavailable: 1
+
+## Node tolerations for server scheduling to nodes with taints
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+##
+
+podSecurityContext:
+  {}
+  # runAsUser: 1000
+  # runAsGroup: 3000
+  # fsGroup: 2000
+
+containerSecurityContext:
+  {}
+  # allowPrivilegeEscalation: false
+
+## Pods Service Account
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## @param serviceAccount.create Enable creation of ServiceAccount for pods
+  ##
+  create: false
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the `.Chart.Name .fullname` template
+  name: ""
+  ## @param serviceAccount.annotations Annotations for service account. Evaluated as a template.
+  ## Only used if `create` is `true`.
+  ##
+  annotations: {}
+
+tolerations:
+  []
+  #  - key: "key"
+  #    operator: "Equal|Exists"
+  #    value: "value"
+  #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+imagePullSecrets:
+  []
+  # - test1
+  # - test2


### PR DESCRIPTION
# Description

Added an option to create environment variables from specific key of a secret.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Add this to rollout deployment chart values and change values accordingly

```yaml
EnvVariablesFromSecretKey:
  - name: ENV_NAME
    secretName: testSecret
    secretKey: testKey # a key from the secret
```


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have tested it for all user roles
* [ ] I have added all the required unit/api test cases



