### PR TITLE
fix: New pod goes into terminating state for sometime before getting up again

### DIFF
--- a/api/router/ApplicationRouter.go
+++ b/api/router/ApplicationRouter.go
@@ -90,9 +90,6 @@ func (r ApplicationRouterImpl) initApplicationRouter(router *mux.Router) {
 	router.Path("/{name}").
 		Methods("GET").
 		HandlerFunc(r.handler.Get)
-	router.Path("/{name}/sync").
-		Methods("POST").
-		HandlerFunc(r.handler.Sync)
 	router.Path("/{appName}/operation").
 		Methods("DELETE").
 		HandlerFunc(r.handler.TerminateOperation)

--- a/pkg/app/AppService.go
+++ b/pkg/app/AppService.go
@@ -849,7 +849,7 @@ func (impl AppServiceImpl) TriggerRelease(overrideRequest *bean.ValuesOverrideRe
 			} else {
 				impl.logger.Debug("argo-cd failed to update, ignoring it")
 			}
-			impl.synchCD(pipeline, ctx, overrideRequest, envOverride)
+			//	impl.synchCD(pipeline, ctx, overrideRequest, envOverride)
 		}
 
 		deploymentStatus := &repository.DeploymentStatus{

--- a/pkg/appStore/deployment/fullMode/AppStoreDeploymentFullModeService.go
+++ b/pkg/appStore/deployment/fullMode/AppStoreDeploymentFullModeService.go
@@ -262,7 +262,7 @@ func (impl AppStoreDeploymentFullModeServiceImpl) AppStoreDeployOperationACD(ins
 		return nil, err
 	}
 	//STEP 6: Force Sync ACD - works like trigger deployment
-	impl.SyncACD(installAppVersionRequest.ACDAppName, ctx)
+	//impl.SyncACD(installAppVersionRequest.ACDAppName, ctx)
 
 	return installAppVersionRequest, nil
 }

--- a/pkg/appStore/deployment/tool/gitops/AppStoreDeploymentArgoCdService.go
+++ b/pkg/appStore/deployment/tool/gitops/AppStoreDeploymentArgoCdService.go
@@ -231,7 +231,7 @@ func (impl AppStoreDeploymentArgoCdServiceImpl) RollbackRelease(ctx context.Cont
 		return installedApp, false, nil
 	}
 	//ACD sync operation
-	impl.appStoreDeploymentFullModeService.SyncACD(installedApp.ACDAppName, ctx)
+	//impl.appStoreDeploymentFullModeService.SyncACD(installedApp.ACDAppName, ctx)
 	return installedApp, true, nil
 }
 
@@ -402,7 +402,7 @@ func (impl AppStoreDeploymentArgoCdServiceImpl) UpdateInstalledApp(ctx context.C
 	installAppVersionRequest.Environment = environment
 
 	//ACD sync operation
-	impl.appStoreDeploymentFullModeService.SyncACD(installAppVersionRequest.ACDAppName, ctx)
+	//impl.appStoreDeploymentFullModeService.SyncACD(installAppVersionRequest.ACDAppName, ctx)
 
 	return installAppVersionRequest, nil
 }
@@ -429,7 +429,7 @@ func (impl AppStoreDeploymentArgoCdServiceImpl) patchAcdApp(ctx context.Context,
 		impl.Logger.Errorw("error in creating argo app ", "name", installAppVersionRequest.ACDAppName, "patch", string(reqbyte), "err", err)
 		return nil, err
 	}
-	impl.appStoreDeploymentFullModeService.SyncACD(installAppVersionRequest.ACDAppName, ctx)
+	//impl.appStoreDeploymentFullModeService.SyncACD(installAppVersionRequest.ACDAppName, ctx)
 	return installAppVersionRequest, nil
 }
 


### PR DESCRIPTION
# Description

With the updated argo stack, users are faced with the issue in which new pod after a deployment goes into terminating state for a while and the old pod(of the old replicaset) gets up again. It takes a while before the new revision is applied stably. 

Fixes #2186 

In orhestrator, we used to invoke the api for manual trigger to remove any lags, which in some cases caused the revision to revert back(as argo apps are auto sync enabled and revision is not updated by auto sync).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test case A
- [ ] Test case B


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles
* [ ] I have added all the required unit/api test cases



