### PR TITLE
fix : able to trigger ci using git hash from another branch

### DIFF
--- a/pkg/pipeline/CiHandler.go
+++ b/pkg/pipeline/CiHandler.go
@@ -832,10 +832,13 @@ func (impl *CiHandlerImpl) BuildManualTriggerCommitHashesForSourceTypeBranchFix(
 		GitHash:            ciPipelineMaterial.GitCommit.Commit,
 		GitTag:             ciPipelineMaterial.GitTag,
 	}
-	gitCommitResponse, err := impl.gitSensorClient.GetCommitMetadata(commitMetadataRequest)
+	gitCommitResponse, err := impl.gitSensorClient.GetCommitMetadataForPipelineMaterial(commitMetadataRequest)
 	if err != nil {
-		impl.Logger.Errorw("err", "err", err)
+		impl.Logger.Errorw("err in fetching commit metadata", "commitMetadataRequest", commitMetadataRequest, "err", err)
 		return bean.GitCommit{}, err
+	}
+	if gitCommitResponse == nil {
+		return bean.GitCommit{}, errors.New("commit not found")
 	}
 
 	gitCommit := bean.GitCommit{


### PR DESCRIPTION
# Description
Currently CI can be triggered by giving githash from another branch which is a security issue. fixed that issue. 

Fixes  https://github.com/devtron-labs/devtron/issues/2131

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactoring 


# How Has This Been Tested?
By testing manual CI trigger API by giving another branch githash. it is giving error now. 
Happy case is also working. 

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


