### PR TITLE
Autocomplete data config driven

### DIFF
--- a/api/bean/AutocompleteConfig.go
+++ b/api/bean/AutocompleteConfig.go
@@ -1,0 +1,5 @@
+package bean
+
+type Config struct {
+	IgnoreAuthCheck bool `env:"IGNORE_AUTOCOMPLETE_AUTH_CHECK" envDefault:"false"`
+}

--- a/api/cluster/EnvironmentRestHandler.go
+++ b/api/cluster/EnvironmentRestHandler.go
@@ -69,6 +69,7 @@ func NewEnvironmentRestHandlerImpl(svc request.EnvironmentService, logger *zap.S
 ) *EnvironmentRestHandlerImpl {
 	ignoreAuthCheck := os.Getenv(util.IgnoreAutocompleteAuthCheck)
 	ignoreAuthCheckValue, _ := strconv.ParseBool(ignoreAuthCheck)
+	logger.Infow("evironment rest handler initialized", "ignoreAuthCheckValue", ignoreAuthCheckValue)
 	return &EnvironmentRestHandlerImpl{
 		environmentClusterMappingsService: svc,
 		logger:                            logger,

--- a/api/team/TeamRestHandler.go
+++ b/api/team/TeamRestHandler.go
@@ -68,6 +68,7 @@ func NewTeamRestHandlerImpl(logger *zap.SugaredLogger,
 ) *TeamRestHandlerImpl {
 	ignoreAuthCheck := os.Getenv(util.IgnoreAutocompleteAuthCheck)
 	ignoreAuthCheckValue, _ := strconv.ParseBool(ignoreAuthCheck)
+	logger.Infow("team rest handler initialized", "ignoreAuthCheckValue", ignoreAuthCheckValue)
 	return &TeamRestHandlerImpl{
 		logger:               logger,
 		teamService:          teamService,

--- a/util/CommonConstant.go
+++ b/util/CommonConstant.go
@@ -30,5 +30,4 @@ const (
 	ConfigMapSecretUsageTypeEnvironment string = "environment"
 	ConfigMapSecretUsageTypeVolume      string = "volume"
 	YamlSeparator                       string = "---\n"
-	IgnoreAutocompleteAuthCheck         string = "IGNORE_AUTOCOMPLETE_AUTH_CHECK"
 )

--- a/util/CommonConstant.go
+++ b/util/CommonConstant.go
@@ -30,4 +30,5 @@ const (
 	ConfigMapSecretUsageTypeEnvironment string = "environment"
 	ConfigMapSecretUsageTypeVolume      string = "volume"
 	YamlSeparator                       string = "---\n"
+	IgnoreAutocompleteAuthCheck         string = "IGNORE_AUTOCOMPLETE_AUTH_CHECK"
 )


### PR DESCRIPTION
# Description

made auth config driven using a flag. user can set flag through config map, when flag is set auth is bypassed for autocomplete APIs of projects and environments.

Fixes #2283 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] To check whether flag is enabled or not, can check in logs


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles
* [ ] I have added all the required unit/api test cases



