### PR TITLE
fix: generic handling for module status in future scope

### DIFF
--- a/pkg/module/ModuleService.go
+++ b/pkg/module/ModuleService.go
@@ -145,6 +145,8 @@ func (impl ModuleServiceImpl) handleModuleNotFoundStatus(moduleName string) (Mod
 			}
 		}
 		cicdVersion := cicdModule.Version
+		// if cicd was installed on or before our integration release (v0.5.3) then assume all futuristic legacy module as installed
+		// if cice was installed after integration release (v0.5.3) and any module/integration comes after that then mark that module installed only if cicd was installed before that module introduction
 		if cicdVersion <= LegacyModuleSupportAssumptionCicdModuleVersion || (len(baseMinVersionSupported) > 0 && cicdVersion < baseMinVersionSupported) {
 			return impl.saveModuleAsInstalled(moduleName)
 		}

--- a/pkg/module/ModuleService.go
+++ b/pkg/module/ModuleService.go
@@ -146,7 +146,7 @@ func (impl ModuleServiceImpl) handleModuleNotFoundStatus(moduleName string) (Mod
 		}
 		cicdVersion := cicdModule.Version
 		// if cicd was installed on or before our integration release (v0.5.3) then assume all futuristic legacy module as installed
-		// if cice was installed after integration release (v0.5.3) and any module/integration comes after that then mark that module installed only if cicd was installed before that module introduction
+		// if cicd was installed after integration release (v0.5.3) and any module/integration comes after that then mark that module installed only if cicd was installed before that module introduction
 		if cicdVersion <= LegacyModuleSupportAssumptionCicdModuleVersion || (len(baseMinVersionSupported) > 0 && cicdVersion < baseMinVersionSupported) {
 			return impl.saveModuleAsInstalled(moduleName)
 		}

--- a/pkg/module/ModuleService.go
+++ b/pkg/module/ModuleService.go
@@ -109,7 +109,9 @@ func (impl ModuleServiceImpl) handleModuleNotFoundStatus(moduleName string) (Mod
 		impl.logger.Errorw("Error in getting module metadata", "moduleName", moduleName, "err", err)
 		return ModuleStatusNotInstalled, err
 	}
-	isLegacyModule := gjson.Get(string(moduleMetaData), "result.isIncludedInLegacyFullPackage").Bool()
+	moduleMetaDataStr := string(moduleMetaData)
+	isLegacyModule := gjson.Get(moduleMetaDataStr, "result.isIncludedInLegacyFullPackage").Bool()
+	baseMinVersionSupported := gjson.Get(moduleMetaDataStr, "result.baseMinVersionSupported").String()
 
 	// for enterprise user
 	if impl.serverEnvConfig.DevtronInstallationType == serverBean.DevtronInstallationTypeEnterprise {
@@ -143,7 +145,7 @@ func (impl ModuleServiceImpl) handleModuleNotFoundStatus(moduleName string) (Mod
 			}
 		}
 		cicdVersion := cicdModule.Version
-		if cicdVersion <= LegacyModuleSupportAssumptionCicdModuleVersion {
+		if cicdVersion <= LegacyModuleSupportAssumptionCicdModuleVersion || (len(baseMinVersionSupported) > 0 && cicdVersion <= baseMinVersionSupported) {
 			return impl.saveModuleAsInstalled(moduleName)
 		}
 	}

--- a/pkg/module/ModuleService.go
+++ b/pkg/module/ModuleService.go
@@ -145,7 +145,7 @@ func (impl ModuleServiceImpl) handleModuleNotFoundStatus(moduleName string) (Mod
 			}
 		}
 		cicdVersion := cicdModule.Version
-		if cicdVersion <= LegacyModuleSupportAssumptionCicdModuleVersion || (len(baseMinVersionSupported) > 0 && cicdVersion <= baseMinVersionSupported) {
+		if cicdVersion <= LegacyModuleSupportAssumptionCicdModuleVersion || (len(baseMinVersionSupported) > 0 && cicdVersion < baseMinVersionSupported) {
 			return impl.saveModuleAsInstalled(moduleName)
 		}
 	}


### PR DESCRIPTION
# Description

If any new module extracted out from cicd, then for that module, handling status as installed if cicd was installed before introducing that

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
By checking the status of futuristic modules


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] I have tested it for all user roles
* [ ] I have added all the required unit/api test cases



