### PR TITLE
fix : generic module status handling : eg - security module handling security.enabled and security.clair.enabled

### DIFF
--- a/pkg/module/ModuleService.go
+++ b/pkg/module/ModuleService.go
@@ -237,10 +237,16 @@ func (impl ModuleServiceImpl) HandleModuleAction(userId int32, moduleName string
 		impl.logger.Errorw("error in getting modules with installed status ", "err", err)
 		return nil, err
 	}
-	extraValues[moduleUtil.BuildModuleEnableKey(moduleName)] = true
+	moduleEnableKeys := moduleUtil.BuildAllModuleEnableKeys(moduleName)
+	for _, moduleEnableKey := range moduleEnableKeys {
+		extraValues[moduleEnableKey] = true
+	}
 	for _, alreadyInstalledModuleName := range alreadyInstalledModuleNames {
 		if alreadyInstalledModuleName != moduleName {
-			extraValues[moduleUtil.BuildModuleEnableKey(alreadyInstalledModuleName)] = true
+			alreadyInstalledModuleEnableKeys := moduleUtil.BuildAllModuleEnableKeys(alreadyInstalledModuleName)
+			for _, alreadyInstalledModuleEnableKey := range alreadyInstalledModuleEnableKeys {
+				extraValues[alreadyInstalledModuleEnableKey] = true
+			}
 		}
 	}
 	extraValuesYamlUrl := util2.BuildDevtronBomUrl(impl.serverEnvConfig.DevtronBomUrl, moduleActionRequest.Version)

--- a/pkg/module/util/ModuleUtil.go
+++ b/pkg/module/util/ModuleUtil.go
@@ -19,7 +19,18 @@ package moduleUtil
 
 import (
 	"fmt"
+	"strings"
 )
+
+func BuildAllModuleEnableKeys(moduleName string) []string {
+	var keys []string
+	keys = append(keys, BuildModuleEnableKey(moduleName))
+	if strings.Contains(moduleName, ".") {
+		parent := strings.Split(moduleName, ".")[0]
+		keys = append(keys, BuildModuleEnableKey(parent))
+	}
+	return keys
+}
 
 func BuildModuleEnableKey(moduleName string) string {
 	return fmt.Sprintf("%s.%s", moduleName, "enabled")

--- a/pkg/server/ServerService.go
+++ b/pkg/server/ServerService.go
@@ -143,7 +143,10 @@ func (impl ServerServiceImpl) HandleServerAction(userId int32, serverActionReque
 		return nil, err
 	}
 	for _, alreadyInstalledModuleName := range alreadyInstalledModuleNames {
-		extraValues[moduleUtil.BuildModuleEnableKey(alreadyInstalledModuleName)] = true
+		alreadyInstalledModuleEnableKeys := moduleUtil.BuildAllModuleEnableKeys(alreadyInstalledModuleName)
+		for _, alreadyInstalledModuleEnableKey := range alreadyInstalledModuleEnableKeys {
+			extraValues[alreadyInstalledModuleEnableKey] = true
+		}
 	}
 	extraValuesYamlUrl := util2.BuildDevtronBomUrl(impl.serverEnvConfig.DevtronBomUrl, serverActionRequest.Version)
 	updateResponse, err := impl.helmAppService.UpdateApplicationWithChartInfoWithExtraValues(context.Background(), devtronHelmAppIdentifier, chartRepository, extraValues, extraValuesYamlUrl, true)


### PR DESCRIPTION
# Description

If any module has multiple implementation, for eg : security has two impl (clair, trivy), then in that case while updating helm release security.enabled and security.clair.enabled should be true

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
By checking the status of futuristic modules


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] I have tested it for all user roles
* [ ] I have added all the required unit/api test cases



