### PR TITLE
App Level Security Policy Override Issue

### DIFF
--- a/internal/sql/repository/security/CvePolicyControle.go
+++ b/internal/sql/repository/security/CvePolicyControle.go
@@ -166,9 +166,17 @@ func (impl *CvePolicyRepositoryImpl) GetAppEnvPolicies(clusterId int, environmen
 		Relation("CveStore").
 		WhereGroup(func(q *orm.Query) (*orm.Query, error) {
 			q = q.WhereOr("cluster_id = ?", clusterId).
-				WhereOr("env_id = ?", environmentId).
+				WhereOrGroup(func(sq *orm.Query) (*orm.Query, error) {
+					sq = sq.Where("env_id = ?", environmentId).Where("app_id is null")
+					return sq, nil
+				}).
+				//WhereOr("env_id = ?", environmentId).
 				WhereOr("global = true").
-				WhereOr("app_id = ?", appId)
+				WhereOrGroup(func(sq *orm.Query) (*orm.Query, error) {
+					sq = sq.Where("app_id = ?", appId).Where("env_id = ?", environmentId)
+					return sq, nil
+				})
+			//WhereOr("app_id = ?", appId)
 			return q, nil
 		}).
 		Where("deleted = false").


### PR DESCRIPTION
# Description

When we update security policy for an application of a particular env, it updates the property for a particular app and env id but it is showing value for all the environments.

Fixes #2349 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Updated policy for a particular env, while fetching details showing the value of that env only.
- [x] Deploy application containing blocked policy at critical level.


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles
* [ ] I have added all the required unit/api test cases



