### PR TITLE
CodeIgniter Docker File

### DIFF
--- a/Codeigniter/Dockerfile.txt
+++ b/Codeigniter/Dockerfile.txt
@@ -1,0 +1,55 @@
+
+################################# Build Container ###############################
+
+
+
+FROM php:5.6-apache
+
+RUN apt-get update && apt-get install -y git-core cron \
+  libjpeg-dev libmcrypt-dev libpng-dev libpq-dev \
+  && rm -rf /var/lib/apt/lists/* \
+  && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
+  && docker-php-ext-install gd mcrypt mysqli opcache pdo pdo_mysql zip
+
+# Recommended opcache settings - https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+    echo 'opcache.memory_consumption=128'; \
+    echo 'opcache.interned_strings_buffer=8'; \
+    echo 'opcache.max_accelerated_files=4000'; \
+    echo 'opcache.revalidate_freq=2'; \
+    echo 'opcache.fast_shutdown=1'; \
+    echo 'opcache.enable_cli=1'; \
+  } > /usr/local/etc/php/conf.d/docker-ci-opcache.ini
+
+RUN { \
+    echo 'log_errors=on'; \
+    echo 'display_errors=off'; \
+    echo 'upload_max_filesize=32M'; \
+    echo 'post_max_size=32M'; \
+    echo 'memory_limit=128M'; \
+    echo 'date.timezone="UTC"'; \
+  } > /usr/local/etc/php/conf.d/docker-ci-php.ini
+
+RUN { \
+    echo '<FilesMatch "^\.">'; \
+    echo '    Order allow,deny'; \
+    echo '    Deny from all'; \
+    echo '</FilesMatch>'; \
+    echo '<DirectoryMatch "^\.|\/\.">'; \
+    echo '    Order allow,deny'; \
+    echo '    Deny from all'; \
+    echo '</DirectoryMatch>'; \
+  } > /etc/apache2/conf-available/docker-ci-php.conf
+
+RUN a2enconf docker-ci-php
+
+RUN a2enmod rewrite
+
+COPY --chown=www-data:www-data ./CodeIgniter_1.7.3 /usr/src/CodeIgniter_1.7.3
+
+RUN ln -s /usr/src/CodeIgniter_1.7.3/system /var/www/codeigniter
+
+COPY docker-entrypoint /usr/local/bin/
+
+ENTRYPOINT ["docker-entrypoint"]
+CMD ["apache2-foreground"]


### PR DESCRIPTION
CodeIgniter Docker File

# Description

CodeIgniter Docker File 

Fixes # (issue)

## Type of change


- [ ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Start a container using the latest image, mapping your local port 80 to the container's port 80:

$ docker run -p 80:80 --name codeigniter aspendigital/codeigniter:latest
# `CTRL-C` to stop
$ docker rm codeigniter  # Destroys the container
If there is a port conflict, you will receive an error message from the Docker daemon. Try mapping to an open local port (-p 8080:80) or shut down the container or server that is on the desired port.

Visit http://localhost/ using your browser.
Hit CTRL-C to stop the container. Running a container in the foreground will send log outputs to your terminal.
Run the container in the background by passing the -d option:

$ docker run -p 80:80 --name codeigniter -d aspendigital/codeigniter:latest
$ docker stop codeigniter  # Stops the container. To restart `docker start codeigniter`
$ docker rm codeigniter  # Destroys the container


