### PR TITLE
fix malformed struct tag in `DockerArtifactStore` struct

### DIFF
--- a/internal/sql/repository/DockerArtifactStoreRepository.go
+++ b/internal/sql/repository/DockerArtifactStoreRepository.go
@@ -33,7 +33,7 @@ type RegistryType string
 
 type DockerArtifactStore struct {
 	tableName          struct{}     `sql:"docker_artifact_store" json:",omitempty"  pg:",discard_unknown_columns"`
-	Id                 string       `sql:"id,pk" json:"id,,omitempty"`
+	Id                 string       `sql:"id,pk" json:"id,omitempty"`
 	PluginId           string       `sql:"plugin_id,notnull" json:"pluginId,omitempty"`
 	RegistryURL        string       `sql:"registry_url" json:"registryUrl,omitempty"`
 	RegistryType       RegistryType `sql:"registry_type,notnull" json:"registryType,omitempty"`


### PR DESCRIPTION
# Description

Just fix a malformed struct tag in `DockerArtifactStore` struct.
The issue was found by [revive](https://github.com/mgechev/revive)

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update




