### PR TITLE
fix: limiting resources for app sync manual job

### DIFF
--- a/pkg/chartRepo/ChartRepositoryService.go
+++ b/pkg/chartRepo/ChartRepositoryService.go
@@ -380,7 +380,7 @@ func (impl *ChartRepositoryServiceImpl) TriggerChartSyncManual() error {
 		return err
 	}
 
-	manualAppSyncJobByteArr := manualAppSyncJobByteArr(impl.serverEnvConfig.AppSyncImage, impl.serverEnvConfig.AppSyncJobResources)
+	manualAppSyncJobByteArr := manualAppSyncJobByteArr(impl.serverEnvConfig.AppSyncImage, impl.serverEnvConfig.AppSyncJobResourcesObj)
 
 	err = impl.K8sUtil.DeleteAndCreateJob(manualAppSyncJobByteArr, impl.aCDAuthConfig.ACDConfigMapNamespace, defaultClusterConfig)
 	if err != nil {

--- a/pkg/chartRepo/ChartRepositoryService.go
+++ b/pkg/chartRepo/ChartRepositoryService.go
@@ -380,7 +380,7 @@ func (impl *ChartRepositoryServiceImpl) TriggerChartSyncManual() error {
 		return err
 	}
 
-	manualAppSyncJobByteArr := manualAppSyncJobByteArr(impl.serverEnvConfig.AppSyncImage)
+	manualAppSyncJobByteArr := manualAppSyncJobByteArr(impl.serverEnvConfig.AppSyncImage, impl.serverEnvConfig.LimitAppSyncJobResource)
 
 	err = impl.K8sUtil.DeleteAndCreateJob(manualAppSyncJobByteArr, impl.aCDAuthConfig.ACDConfigMapNamespace, defaultClusterConfig)
 	if err != nil {

--- a/pkg/chartRepo/ChartRepositoryService.go
+++ b/pkg/chartRepo/ChartRepositoryService.go
@@ -380,7 +380,7 @@ func (impl *ChartRepositoryServiceImpl) TriggerChartSyncManual() error {
 		return err
 	}
 
-	manualAppSyncJobByteArr := manualAppSyncJobByteArr(impl.serverEnvConfig.AppSyncImage, impl.serverEnvConfig.LimitAppSyncJobResource)
+	manualAppSyncJobByteArr := manualAppSyncJobByteArr(impl.serverEnvConfig.AppSyncImage, impl.serverEnvConfig.AppSyncJobResources)
 
 	err = impl.K8sUtil.DeleteAndCreateJob(manualAppSyncJobByteArr, impl.aCDAuthConfig.ACDConfigMapNamespace, defaultClusterConfig)
 	if err != nil {

--- a/pkg/chartRepo/ManualAppSyncYaml.go
+++ b/pkg/chartRepo/ManualAppSyncYaml.go
@@ -7,17 +7,17 @@ import (
 )
 
 type AppSyncConfig struct {
-	DbConfig                sql.Config
-	DockerImage             string
-	LimitAppSyncJobResource bool
+	DbConfig            sql.Config
+	DockerImage         string
+	AppSyncJobResources string
 }
 
-func manualAppSyncJobByteArr(dockerImage string, limitAppSyncJobResource bool) []byte {
+func manualAppSyncJobByteArr(dockerImage string, appSyncJobResources string) []byte {
 	cfg, _ := sql.GetConfig()
 	configValues := AppSyncConfig{
-		DbConfig:                sql.Config{Addr: cfg.Addr, Database: cfg.Database, User: cfg.User, Password: cfg.Password},
-		DockerImage:             dockerImage,
-		LimitAppSyncJobResource: limitAppSyncJobResource,
+		DbConfig:            sql.Config{Addr: cfg.Addr, Database: cfg.Database, User: cfg.User, Password: cfg.Password},
+		DockerImage:         dockerImage,
+		AppSyncJobResources: appSyncJobResources,
 	}
 	temp := template.New("manualAppSyncJobByteArr")
 	temp, _ = temp.Parse(`{"apiVersion": "batch/v1",
@@ -33,17 +33,8 @@ func manualAppSyncJobByteArr(dockerImage string, limitAppSyncJobResource bool) [
           {
             "name": "chart-sync",
             "image": "{{.DockerImage}}",
-			{{if .LimitAppSyncJobResource}}
-			"resources": {
-              "limits" : {
-                "cpu" : "50m",
-                "memory": "200Mi"
-              },
-              "requests" : {
-                "cpu" : "50m",
-                "memory": "200Mi"
-              }
-            },
+			{{if .AppSyncJobResources}}
+			"resources": {{.AppSyncJobResources}},
             {{end}}
             "env": [
               {

--- a/pkg/chartRepo/ManualAppSyncYaml.go
+++ b/pkg/chartRepo/ManualAppSyncYaml.go
@@ -7,17 +7,17 @@ import (
 )
 
 type AppSyncConfig struct {
-	DbConfig            sql.Config
-	DockerImage         string
-	AppSyncJobResources string
+	DbConfig               sql.Config
+	DockerImage            string
+	AppSyncJobResourcesObj string
 }
 
-func manualAppSyncJobByteArr(dockerImage string, appSyncJobResources string) []byte {
+func manualAppSyncJobByteArr(dockerImage string, appSyncJobResourcesObj string) []byte {
 	cfg, _ := sql.GetConfig()
 	configValues := AppSyncConfig{
-		DbConfig:            sql.Config{Addr: cfg.Addr, Database: cfg.Database, User: cfg.User, Password: cfg.Password},
-		DockerImage:         dockerImage,
-		AppSyncJobResources: appSyncJobResources,
+		DbConfig:               sql.Config{Addr: cfg.Addr, Database: cfg.Database, User: cfg.User, Password: cfg.Password},
+		DockerImage:            dockerImage,
+		AppSyncJobResourcesObj: appSyncJobResourcesObj,
 	}
 	temp := template.New("manualAppSyncJobByteArr")
 	temp, _ = temp.Parse(`{"apiVersion": "batch/v1",
@@ -33,8 +33,8 @@ func manualAppSyncJobByteArr(dockerImage string, appSyncJobResources string) []b
           {
             "name": "chart-sync",
             "image": "{{.DockerImage}}",
-			{{if .AppSyncJobResources}}
-			"resources": {{.AppSyncJobResources}},
+			{{if .AppSyncJobResourcesObj}}
+			"resources": {{.AppSyncJobResourcesObj}},
             {{end}}
             "env": [
               {

--- a/pkg/server/config/ServerEnvConfig.go
+++ b/pkg/server/config/ServerEnvConfig.go
@@ -20,7 +20,7 @@ type ServerEnvConfig struct {
 	DevtronModulesIdentifierInHelmValues string `env:"DEVTRON_MODULES_IDENTIFIER_IN_HELM_VALUES" envDefault:"installer.modules"`
 	DevtronBomUrl                        string `env:"DEVTRON_BOM_URL" envDefault:"https://raw.githubusercontent.com/devtron-labs/devtron/%s/charts/devtron/devtron-bom.yaml"`
 	AppSyncImage                         string `env:"APP_SYNC_IMAGE" envDefault:"quay.io/devtron/chart-sync:1227622d-132-3775"`
-	AppSyncJobResources                  string `env:"APP_SYNC_JOB_RESOURCES"`
+	AppSyncJobResourcesObj               string `env:"APP_SYNC_JOB_RESOURCES_OBJ"`
 	ModuleMetaDataApiUrl                 string `env:"MODULE_METADATA_API_URL" envDefault:"https://api.devtron.ai/module?name=%s"`
 }
 

--- a/pkg/server/config/ServerEnvConfig.go
+++ b/pkg/server/config/ServerEnvConfig.go
@@ -20,6 +20,7 @@ type ServerEnvConfig struct {
 	DevtronModulesIdentifierInHelmValues string `env:"DEVTRON_MODULES_IDENTIFIER_IN_HELM_VALUES" envDefault:"installer.modules"`
 	DevtronBomUrl                        string `env:"DEVTRON_BOM_URL" envDefault:"https://raw.githubusercontent.com/devtron-labs/devtron/%s/charts/devtron/devtron-bom.yaml"`
 	AppSyncImage                         string `env:"APP_SYNC_IMAGE" envDefault:"quay.io/devtron/chart-sync:1227622d-132-3775"`
+	LimitAppSyncJobResource              bool   `env:"LIMIT_APP_SYNC_JOB_RESOURCE" envDefault:"false"`
 	ModuleMetaDataApiUrl                 string `env:"MODULE_METADATA_API_URL" envDefault:"https://api.devtron.ai/module?name=%s"`
 }
 

--- a/pkg/server/config/ServerEnvConfig.go
+++ b/pkg/server/config/ServerEnvConfig.go
@@ -20,7 +20,7 @@ type ServerEnvConfig struct {
 	DevtronModulesIdentifierInHelmValues string `env:"DEVTRON_MODULES_IDENTIFIER_IN_HELM_VALUES" envDefault:"installer.modules"`
 	DevtronBomUrl                        string `env:"DEVTRON_BOM_URL" envDefault:"https://raw.githubusercontent.com/devtron-labs/devtron/%s/charts/devtron/devtron-bom.yaml"`
 	AppSyncImage                         string `env:"APP_SYNC_IMAGE" envDefault:"quay.io/devtron/chart-sync:1227622d-132-3775"`
-	LimitAppSyncJobResource              bool   `env:"LIMIT_APP_SYNC_JOB_RESOURCE" envDefault:"false"`
+	AppSyncJobResources                  string `env:"APP_SYNC_JOB_RESOURCES"`
 	ModuleMetaDataApiUrl                 string `env:"MODULE_METADATA_API_URL" envDefault:"https://api.devtron.ai/module?name=%s"`
 }
 


### PR DESCRIPTION
# Description

Fixing app sync manual job resource limit based on some environment variable.
APP_SYNC_JOB_RESOURCES_OBJ={"limits" :{"cpu" : "50m","memory": "200Mi"},"requests" : {"cpu" : "50m","memory": "200Mi"}}
In cm-
APP_SYNC_JOB_RESOURCES_OBJ: '{"limits" :{"cpu" : "50m","memory": "200Mi"},"requests"
    : {"cpu" : "50m","memory": "200Mi"}}'

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
By generating the manifest for both cases- variable true and false


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles
* [ ] I have added all the required unit/api test cases



