### PR TITLE
fix: showing cicd module status as installing if devtron is installing with cicd module

### DIFF
--- a/pkg/module/Bean.go
+++ b/pkg/module/Bean.go
@@ -63,6 +63,7 @@ type ModuleStatus = string
 type ModuleName = string
 
 const BlobStorage = "blob-storage"
+const INSTALLER_MODULES_HELM_KEY = "installer.modules"
 
 const (
 	ModuleStatusNotInstalled  ModuleStatus = "notInstalled"

--- a/pkg/module/ModuleService.go
+++ b/pkg/module/ModuleService.go
@@ -33,6 +33,7 @@ import (
 	"github.com/go-pg/pg"
 	"github.com/tidwall/gjson"
 	"go.uber.org/zap"
+	"reflect"
 	"time"
 )
 
@@ -140,9 +141,24 @@ func (impl ModuleServiceImpl) handleModuleNotFoundStatus(moduleName string) (Mod
 		impl.logger.Errorw("Error in getting values yaml for devtron operator helm release", "moduleName", moduleName, "err", err)
 		return ModuleStatusNotInstalled, err
 	}
-	isEnabled := gjson.Get(releaseInfo.MergedValues, moduleUtil.BuildModuleEnableKey(moduleName)).Bool()
+	releaseValues := releaseInfo.MergedValues
+	isEnabled := gjson.Get(releaseValues, moduleUtil.BuildModuleEnableKey(moduleName)).Bool()
 	if isEnabled {
 		return impl.saveModuleAsInstalled(moduleName)
+	}
+
+	// check if cicd is in installing state
+	// if devtron is installed with cicd module, then cicd module should be shown as installing
+	if moduleName == ModuleNameCicd && util2.IsBaseStack() {
+		installerModulesIface := gjson.Get(releaseValues, INSTALLER_MODULES_HELM_KEY).Value()
+		if installerModulesIface != nil && reflect.TypeOf(installerModulesIface).Kind() == reflect.Slice {
+			installerModules := installerModulesIface.([]interface{})
+			for _, installerModule := range installerModules {
+				if installerModule == moduleName {
+					return impl.saveModule(moduleName, ModuleStatusInstalling)
+				}
+			}
+		}
 	}
 
 	// if module not enabled in helm for non enterprise-user
@@ -247,7 +263,7 @@ func (impl ModuleServiceImpl) HandleModuleAction(userId int32, moduleName string
 
 	extraValues := make(map[string]interface{})
 	extraValues["installer.release"] = moduleActionRequest.Version
-	extraValues["installer.modules"] = []interface{}{moduleName}
+	extraValues[INSTALLER_MODULES_HELM_KEY] = []interface{}{moduleName}
 	alreadyInstalledModuleNames, err := impl.moduleRepository.GetInstalledModuleNames()
 	if err != nil {
 		impl.logger.Errorw("error in getting modules with installed status ", "err", err)
@@ -291,16 +307,20 @@ func (impl ModuleServiceImpl) buildModuleMetaDataUrl(moduleName string) string {
 }
 
 func (impl ModuleServiceImpl) saveModuleAsInstalled(moduleName string) (ModuleStatus, error) {
+	return impl.saveModule(moduleName, ModuleStatusInstalled)
+}
+
+func (impl ModuleServiceImpl) saveModule(moduleName string, moduleStatus ModuleStatus) (ModuleStatus, error) {
 	module := &moduleRepo.Module{
 		Name:      moduleName,
 		Version:   impl.serverDataStore.CurrentVersion,
-		Status:    ModuleStatusInstalled,
+		Status:    moduleStatus,
 		UpdatedOn: time.Now(),
 	}
 	err := impl.moduleRepository.Save(module)
 	if err != nil {
-		impl.logger.Errorw("error in saving module with installed status ", "moduleName", moduleName, "err", err)
+		impl.logger.Errorw("error in saving module status ", "moduleName", moduleName, "moduleStatus", moduleStatus, "err", err)
 		return ModuleStatusNotInstalled, err
 	}
-	return ModuleStatusInstalled, nil
+	return moduleStatus, nil
 }


### PR DESCRIPTION
# Description
If devtron is installed with cicd then cicd module status should go in installing. 

Fixes #2571

## How Has This Been Tested?
1) cicd module should be installable from UI if devtron is installed without cicd. and its status should be updated to installed if installed successfully.
2) cicd module should be shown as installing if devtron is installed with cicd and user logged in dashboard before installation completes. and after sometime the status should change to installed when installation finishes.
3)  cicd module should be shown as installed if user logged into dashboard after installation completes.

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [x] I have added all the required unit/api test cases.

