### PR TITLE
fix: health fix for nodes in resource tree for missing state

### DIFF
--- a/api/restHandler/AppListingRestHandler.go
+++ b/api/restHandler/AppListingRestHandler.go
@@ -725,7 +725,6 @@ func (handler AppListingRestHandlerImpl) fetchResourceTree(w http.ResponseWriter
 			}
 		}
 		appDetail.ResourceTree = util2.InterfaceToMapAdapter(resp)
-		handler.logger.Debugw("application environment status", "appId", appId, "envId", envId, "resp", resp)
 		if resp.Status == string(health.HealthStatusHealthy) {
 			err = handler.cdApplicationStatusUpdateHandler.SyncPipelineStatusForResourceTreeCall(acdAppName, appId, envId)
 			if err != nil {

--- a/client/argocdServer/application/Application.go
+++ b/client/argocdServer/application/Application.go
@@ -415,7 +415,7 @@ func (c ServiceClientImpl) ResourceTree(ctxt context.Context, query *application
 
 // fill the health status in node from app resources
 func (c ServiceClientImpl) updateNodeHealthStatus(resp *v1alpha1.ApplicationTree, appResp *v1alpha1.ApplicationWatchEvent) {
-	if resp == nil || len(resp.Nodes) == 0 || len(appResp.Application.Status.Resources) == 0 {
+	if resp == nil || len(resp.Nodes) == 0 || appResp == nil || len(appResp.Application.Status.Resources) == 0 {
 		return
 	}
 

--- a/client/argocdServer/application/Application.go
+++ b/client/argocdServer/application/Application.go
@@ -394,6 +394,9 @@ func (c ServiceClientImpl) ResourceTree(ctxt context.Context, query *application
 	if app != nil {
 		appResp, err := app.Recv()
 		if err == nil {
+			// https://github.com/argoproj/argo-cd/issues/11234 workaround
+			c.updateNodeHealthStatus(resp, appResp)
+
 			status = string(appResp.Application.Status.Health.Status)
 			hash = appResp.Application.Status.Sync.Revision
 			conditions = appResp.Application.Status.Conditions
@@ -408,6 +411,36 @@ func (c ServiceClientImpl) ResourceTree(ctxt context.Context, query *application
 		}
 	}
 	return &ResourceTreeResponse{resp, newReplicaSets, status, hash, podMetadata, conditions}, err
+}
+
+// fill the health status in node from app resources
+func (c ServiceClientImpl) updateNodeHealthStatus(resp *v1alpha1.ApplicationTree, appResp *v1alpha1.ApplicationWatchEvent) {
+	if resp == nil || len(resp.Nodes) == 0 || len(appResp.Application.Status.Resources) == 0 {
+		return
+	}
+
+	for index, node := range resp.Nodes {
+		if node.Health != nil {
+			continue
+		}
+		for _, resource := range appResp.Application.Status.Resources {
+			if node.Group != resource.Group || node.Version != resource.Version || node.Kind != resource.Kind ||
+				node.Name != resource.Name || node.Namespace != resource.Namespace {
+				continue
+			}
+			resourceHealth := resource.Health
+			if resourceHealth != nil {
+				node.Health = &v1alpha1.HealthStatus{
+					Message: resourceHealth.Message,
+					Status:  resourceHealth.Status,
+				}
+				// updating the element in slice
+				// https://medium.com/@xcoulon/3-ways-to-update-elements-in-a-slice-d5df54c9b2f8
+				resp.Nodes[index] = node
+			}
+			break
+		}
+	}
 }
 
 func (c ServiceClientImpl) buildPodMetadata(resp *v1alpha1.ApplicationTree, responses []*Result) (podMetaData []*PodMetadata, newReplicaSets []string) {


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
In acd resource tree response, health is coming as nil for nodes which are in missing state but health is coming as expected in another API of acd. so overriding health in resource tree nodes for which health is nil in resource tree and not nil in the other API. 


Fixes #2593 

## How Has This Been Tested?
resource tree response for Apps for which some of the nodes are in missing state
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

