### PR TITLE
fix: unblocked pre cd auto trigger in case of manual cd 

### DIFF
--- a/pkg/pipeline/WorkflowDagExecutor.go
+++ b/pkg/pipeline/WorkflowDagExecutor.go
@@ -238,10 +238,6 @@ func (impl *WorkflowDagExecutorImpl) HandleCiSuccessEvent(artifact *repository.C
 		return err
 	}
 	for _, pipeline := range pipelines {
-		if pipeline.TriggerType == pipelineConfig.TRIGGER_TYPE_MANUAL {
-			impl.logger.Warnw("skipping deployment for manual trigger for webhook", "pipeline", pipeline)
-			continue
-		}
 		err = impl.triggerStage(nil, pipeline, artifact, applyAuth, async, triggeredBy)
 		if err != nil {
 			impl.logger.Debugw("error on trigger cd pipeline", "err", err)


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
Pre cd auto trigger not working when cd is set as manual trigger type. 
Fixes #2669 

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

