### PR TITLE
Fix: Skip external ci webhook clone while app clone

### DIFF
--- a/pkg/appClone/AppCloneService.go
+++ b/pkg/appClone/AppCloneService.go
@@ -20,7 +20,6 @@ package appClone
 import (
 	"context"
 	bean2 "github.com/devtron-labs/devtron/api/bean"
-	"github.com/devtron-labs/devtron/internal/util"
 	"github.com/devtron-labs/devtron/pkg/chart"
 	"strings"
 
@@ -597,8 +596,8 @@ func (impl *AppCloneServiceImpl) createWfMappings(refWfMappings []appWorkflow.Ap
 		}
 	}
 	if len(webhookMappings) > 0 {
-		err := &util.ApiError{Code: "501", HttpStatusCode: 501, UserMessage: "ref app has external ci configured, app clone does not supported this"}
-		return err
+		impl.logger.Warn("external ci webhook found in workflow, not supported for clone")
+		return nil
 	}
 	if len(ciMapping) == 0 {
 		impl.logger.Warn("no ci pipeline found")


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description

Skip external ci webhook clone while app clone


Fixes #https://github.com/devtron-labs/devtron/issues/2665

## How Has This Been Tested?

- [x] App Clone with external ci webhook


## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

