### PR TITLE
fix: migration down sql for 84

### DIFF
--- a/scripts/sql/84_alter_ci_cd_workflow.down.sql
+++ b/scripts/sql/84_alter_ci_cd_workflow.down.sql
@@ -1,3 +1,3 @@
 ALTER TABLE ci_workflow DROP COLUMN pod_name;
 
-ALTER TABLE cd_workflow_runner DROP COLUMN pod_name text;
+ALTER TABLE cd_workflow_runner DROP COLUMN pod_name;


### PR DESCRIPTION
# Description

fix: migration down sql for 84
it fails if we rollback

## How Has This Been Tested?

- [x] Tested with a rollback

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

