### PR TITLE
FEAT : Adds readiness probe and liveness probe

### DIFF
--- a/charts/devtron/templates/devtron.yaml
+++ b/charts/devtron/templates/devtron.yaml
@@ -121,6 +121,20 @@ spec:
             - name: devtron
               containerPort: 8080
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 3
+            failureThreshold: 2
           env:
             - name: DEVTRON_APP_NAME
               value: devtron


### PR DESCRIPTION
FEAT : Adds readiness probe and liveness probe on orchestrator.

- port : 8080
- path : /health