### PR TITLE
fix: app create api bug fix if chart ref is different

### DIFF
--- a/api/restHandler/CoreAppRestHandler.go
+++ b/api/restHandler/CoreAppRestHandler.go
@@ -1759,15 +1759,17 @@ func (handler CoreAppRestHandlerImpl) createEnvDeploymentTemplate(appId int, use
 				handler.logger.Errorw("service err, CreateChartFromEnvOverride", "err", err, "appId", appId, "envId", envId, "chartRefId", chartRefId)
 				return err
 			}
-			_, err = handler.propertiesConfigService.CreateEnvironmentProperties(appId, envConfigProperties)
-			if err != nil {
-				handler.logger.Errorw("service err, CreateEnvironmentProperties", "err", err, "appId", appId, "envId", envId, "chartRefId", chartRefId)
-				return err
-			}
 		} else {
 			handler.logger.Errorw("service err, FindChartByAppIdAndRefId", "err", err, "appId", appId, "envId", envId, "chartRefId", chartRefId)
 			return err
 		}
+	}
+
+	// create if required
+	_, err = handler.propertiesConfigService.CreateEnvironmentProperties(appId, envConfigProperties)
+	if err != nil {
+		handler.logger.Errorw("service err, CreateEnvironmentProperties", "err", err, "appId", appId, "envId", envId, "chartRefId", chartRefId)
+		return err
 	}
 
 	//getting environment properties for db table id(this properties get created when cd pipeline is created)

--- a/api/restHandler/CoreAppRestHandler.go
+++ b/api/restHandler/CoreAppRestHandler.go
@@ -1723,9 +1723,28 @@ func (handler CoreAppRestHandlerImpl) createEnvOverrides(ctx context.Context, ap
 func (handler CoreAppRestHandlerImpl) createEnvDeploymentTemplate(appId int, userId int32, envId int, deploymentTemplateOverride *appBean.DeploymentTemplate) error {
 	handler.logger.Infow("Create App - creating template override", "appId", appId)
 
-	// if chart not found for chart_ref then create
+	// build object
+	template, err := json.Marshal(deploymentTemplateOverride.Template)
+	if err != nil {
+		handler.logger.Errorw("json marshaling error env override template in createEnvDeploymentTemplate", "appId", appId, "envId", envId)
+		return err
+	}
 	chartRefId := deploymentTemplateOverride.ChartRefId
-	_, err := handler.chartRepo.FindChartByAppIdAndRefId(appId, chartRefId)
+	envConfigProperties := &pipeline.EnvironmentProperties{
+		IsOverride:        true,
+		Active:            true,
+		ManualReviewed:    true,
+		Status:            models.CHARTSTATUS_NEW,
+		EnvOverrideValues: template,
+		IsBasicViewLocked: deploymentTemplateOverride.IsBasicViewLocked,
+		CurrentViewEditor: deploymentTemplateOverride.CurrentViewEditor,
+		ChartRefId:        chartRefId,
+		EnvironmentId:     envId,
+		UserId:            userId,
+	}
+
+	// if chart not found for chart_ref then create
+	_, err = handler.chartRepo.FindChartByAppIdAndRefId(appId, chartRefId)
 	if err != nil {
 		if pg.ErrNoRows == err {
 			templateRequest := chart.TemplateRequest{
@@ -1738,6 +1757,11 @@ func (handler CoreAppRestHandlerImpl) createEnvDeploymentTemplate(appId int, use
 			_, err = handler.chartService.CreateChartFromEnvOverride(templateRequest, context.Background())
 			if err != nil {
 				handler.logger.Errorw("service err, CreateChartFromEnvOverride", "err", err, "appId", appId, "envId", envId, "chartRefId", chartRefId)
+				return err
+			}
+			_, err = handler.propertiesConfigService.CreateEnvironmentProperties(appId, envConfigProperties)
+			if err != nil {
+				handler.logger.Errorw("service err, CreateEnvironmentProperties", "err", err, "appId", appId, "envId", envId, "chartRefId", chartRefId)
 				return err
 			}
 		} else {
@@ -1754,23 +1778,8 @@ func (handler CoreAppRestHandlerImpl) createEnvDeploymentTemplate(appId int, use
 	}
 
 	//updating env template override
-	template, err := json.Marshal(deploymentTemplateOverride.Template)
-	if err != nil {
-		handler.logger.Errorw("json marshaling error env override template in createEnvDeploymentTemplate", "appId", appId, "envId", envId)
-		return err
-	}
-
-	envConfigProperties := &pipeline.EnvironmentProperties{
-		Id:                env.EnvironmentConfig.Id,
-		IsOverride:        true,
-		Active:            true,
-		ManualReviewed:    true,
-		Namespace:         env.Namespace,
-		Status:            models.CHARTSTATUS_NEW,
-		EnvOverrideValues: template,
-		IsBasicViewLocked: deploymentTemplateOverride.IsBasicViewLocked,
-		CurrentViewEditor: deploymentTemplateOverride.CurrentViewEditor,
-	}
+	envConfigProperties.Id = env.EnvironmentConfig.Id
+	envConfigProperties.Namespace = env.Namespace
 	_, err = handler.propertiesConfigService.UpdateEnvironmentProperties(appId, envConfigProperties, userId)
 	if err != nil {
 		handler.logger.Errorw("service err, EnvConfigOverrideUpdate", "err", err, "appId", appId, "envId", envId)


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
app create api gives error if chart version is different for any of the environment override from global deployment template

Fixes #2850  

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] Same/different chart ref for override/un-override environment deployment template


## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [x] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```