### PR TITLE
task: updated logic for adding health status timeline

### DIFF
--- a/pkg/app/AppService.go
+++ b/pkg/app/AppService.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/argoproj/gitops-engine/pkg/health"
+	"github.com/argoproj/gitops-engine/pkg/sync/common"
 	"github.com/caarlos0/env"
 	client2 "github.com/devtron-labs/devtron/api/helm-app"
 	"github.com/devtron-labs/devtron/pkg/chart"
@@ -520,39 +521,37 @@ func (impl *AppServiceImpl) UpdatePipelineStatusTimelineForApplicationChanges(ap
 	if err != nil {
 		impl.logger.Errorw("error in saving/updating timeline resources", "err", err, "cdWfrId", cdWfrId)
 	}
-	if app.Status.Sync.Status == v1alpha1.SyncStatusCodeSynced {
+	var kubectlApplySyncedTimeline *pipelineConfig.PipelineStatusTimeline
+	if app != nil && app.Status.OperationState != nil && app.Status.OperationState.Phase == common.OperationSucceeded {
 		timeline.Id = 0
 		timeline.Status = pipelineConfig.TIMELINE_STATUS_KUBECTL_APPLY_SYNCED
-		if app != nil && app.Status.OperationState != nil {
-			timeline.StatusDetail = app.Status.OperationState.Message
-		}
-		var currentTimeline *pipelineConfig.PipelineStatusTimeline
+		timeline.StatusDetail = app.Status.OperationState.Message
 		//checking and saving if this timeline is present or not because kubewatch may stream same objects multiple times
-		currentTimeline, err, isTimelineUpdated = impl.SavePipelineStatusTimelineIfNotAlreadyPresent(cdWfrId, timeline.Status, timeline)
+		kubectlApplySyncedTimeline, err, isTimelineUpdated = impl.SavePipelineStatusTimelineIfNotAlreadyPresent(cdWfrId, timeline.Status, timeline)
 		if err != nil {
 			impl.logger.Errorw("error in saving pipeline status timeline", "err", err)
 			return isTimelineUpdated, isTimelineTimedOut, err
 		}
 		impl.logger.Debugw("APP_STATUS_UPDATE_REQ", "stage", "APPLY_SYNCED", "app", app, "status", timeline.Status)
-		if currentTimeline.StatusTime.Before(app.Status.ReconciledAt.Time) {
-			haveNewTimeline := false
-			timeline.Id = 0
-			if app.Status.Health.Status == health.HealthStatusHealthy {
-				impl.logger.Infow("updating pipeline status timeline for healthy app", "app", app, "APP_TO_UPDATE", app.Name)
-				haveNewTimeline = true
-				timeline.Status = pipelineConfig.TIMELINE_STATUS_APP_HEALTHY
-				timeline.StatusDetail = "App status is Healthy."
+	}
+	if kubectlApplySyncedTimeline != nil && kubectlApplySyncedTimeline.Id > 0 && kubectlApplySyncedTimeline.StatusTime.Before(app.Status.ReconciledAt.Time) {
+		haveNewTimeline := false
+		timeline.Id = 0
+		if app.Status.Health.Status == health.HealthStatusHealthy {
+			impl.logger.Infow("updating pipeline status timeline for healthy app", "app", app, "APP_TO_UPDATE", app.Name)
+			haveNewTimeline = true
+			timeline.Status = pipelineConfig.TIMELINE_STATUS_APP_HEALTHY
+			timeline.StatusDetail = "App status is Healthy."
+		}
+		if haveNewTimeline {
+			//not checking if this status is already present or not because already checked for terminal status existence earlier
+			err = impl.pipelineStatusTimelineService.SaveTimeline(timeline, nil)
+			if err != nil {
+				impl.logger.Errorw("error in creating timeline status", "err", err, "timeline", timeline)
+				return isTimelineUpdated, isTimelineTimedOut, err
 			}
-			if haveNewTimeline {
-				//not checking if this status is already present or not because already checked for terminal status existence earlier
-				err = impl.pipelineStatusTimelineService.SaveTimeline(timeline, nil)
-				if err != nil {
-					impl.logger.Errorw("error in creating timeline status", "err", err, "timeline", timeline)
-					return isTimelineUpdated, isTimelineTimedOut, err
-				}
-				isTimelineUpdated = true
-				impl.logger.Debugw("APP_STATUS_UPDATE_REQ", "stage", "terminal_status", "app", app, "status", timeline.Status)
-			}
+			isTimelineUpdated = true
+			impl.logger.Debugw("APP_STATUS_UPDATE_REQ", "stage", "terminal_status", "app", app, "status", timeline.Status)
 		}
 	}
 

--- a/pkg/pipeline/CdHandler.go
+++ b/pkg/pipeline/CdHandler.go
@@ -249,6 +249,10 @@ func (impl *CdHandlerImpl) UpdatePipelineTimelineAndStatusByLiveApplicationFetch
 			return err, isTimelineUpdated
 		}
 	} else {
+		if app == nil {
+			impl.Logger.Errorw("found empty argo application object", "appName", pipeline.DeploymentAppName)
+			return fmt.Errorf("found empty argo application object"), isTimelineUpdated
+		}
 		isSucceeded, isTimelineUpdated, err = impl.appService.UpdateDeploymentStatusForGitOpsCdPipelines(app, time.Now())
 		if err != nil {
 			impl.Logger.Errorw("error in updating deployment status for gitOps cd pipelines", "app", app)


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
Updated logic for adding health status timeline for gitOps pipelines. Instead of checking sync.status in application object, updated using operationState.Phase for marking kubectl apply synced complete and then health status timeline.

Fixes #2889 

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] Tested with OutOfSync argo app

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

