### PR TITLE
fix: cluster not reachable handling

### DIFF
--- a/pkg/cluster/ClusterService.go
+++ b/pkg/cluster/ClusterService.go
@@ -56,7 +56,7 @@ type ClusterBean struct {
 	AgentInstallationStage  int                        `json:"agentInstallationStage,notnull"` // -1=external, 0=not triggered, 1=progressing, 2=success, 3=fails
 	K8sVersion              string                     `json:"k8sVersion"`
 	HasConfigOrUrlChanged   bool                       `json:"-"`
-	ErrorInConnecting       string                     `json:"-"`
+	ErrorInConnecting       string                     `json:"errorInNodeListing,omitempty"`
 }
 
 type PrometheusAuth struct {
@@ -462,8 +462,9 @@ func (impl *ClusterServiceImpl) FindAllForAutoComplete() ([]ClusterBean, error) 
 	var beans []ClusterBean
 	for _, m := range model {
 		beans = append(beans, ClusterBean{
-			Id:          m.Id,
-			ClusterName: m.ClusterName,
+			Id:                m.Id,
+			ClusterName:       m.ClusterName,
+			ErrorInConnecting: m.ErrorInConnecting,
 		})
 	}
 	return beans, nil

--- a/pkg/cluster/ClusterService.go
+++ b/pkg/cluster/ClusterService.go
@@ -56,7 +56,7 @@ type ClusterBean struct {
 	AgentInstallationStage  int                        `json:"agentInstallationStage,notnull"` // -1=external, 0=not triggered, 1=progressing, 2=success, 3=fails
 	K8sVersion              string                     `json:"k8sVersion"`
 	HasConfigOrUrlChanged   bool                       `json:"-"`
-	ErrorInConnecting       string                     `json:"errorInNodeListing,omitempty"`
+	ErrorInConnecting       string                     `json:"errorInConnecting,omitempty"`
 }
 
 type PrometheusAuth struct {
@@ -641,8 +641,9 @@ func (impl *ClusterServiceImpl) FindAllForClusterByUserId(userId int32, isAction
 	for _, model := range models {
 		if _, ok := allowedClustersMap[model.ClusterName]; ok {
 			beans = append(beans, ClusterBean{
-				Id:          model.Id,
-				ClusterName: model.ClusterName,
+				Id:                model.Id,
+				ClusterName:       model.ClusterName,
+				ErrorInConnecting: model.ErrorInConnecting,
 			})
 		}
 	}

--- a/specs/cluster_api_spec.yaml
+++ b/specs/cluster_api_spec.yaml
@@ -46,6 +46,9 @@ components:
         clusterName:
           type: string
           description: cluster name
+        errorInConnecting:
+          type: string
+          description: error message if cluster failed to connect
 
     ErrorResponse:
       required:


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description 

When we click on the Resource Browser tab, there is no information about the cluster i.e if the cluster is active or has died on the upfront so that user can see it on the home page. So the error in connecting with the cluster is not being sent int hte api response for the frontend to handle.

## How Has This Been Tested?

- [x] I tested my code locally, while checking the api response when we click on the Resource Browser tab

<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

