### PR TITLE
fix: k8s log stream cpu issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18  AS build-env
+FROM golang:1.20  AS build-env
 
 RUN echo $GOPATH
 RUN apt update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19  AS build-env
+FROM golang:1.18  AS build-env
 
 RUN echo $GOPATH
 RUN apt update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20  AS build-env
+FROM golang:1.18  AS build-env
 
 RUN echo $GOPATH
 RUN apt update

--- a/DockerfileEA
+++ b/DockerfileEA
@@ -1,4 +1,4 @@
-FROM golang:1.19  AS build-env
+FROM golang:1.18  AS build-env
 
 RUN echo $GOPATH
 RUN apt update

--- a/api/connector/Connector.go
+++ b/api/connector/Connector.go
@@ -235,11 +235,9 @@ func (impl *PumpImpl) sendEvent(eventId []byte, eventName []byte, payload []byte
 		res = append(res, payload...)
 	}
 	res = append(res, '\n', '\n')
-	if i, err := w.Write(res); err != nil {
+	if _, err := w.Write(res); err != nil {
 		impl.logger.Errorf("Failed to send response chunk: %v", err)
 		return err
-	} else {
-		impl.logger.Debugw("msg written", "count", i)
 	}
 
 	return nil

--- a/api/connector/Connector.go
+++ b/api/connector/Connector.go
@@ -107,6 +107,10 @@ func (impl PumpImpl) StartK8sStreamWithHeartBeat(w http.ResponseWriter, isReconn
 	// heartbeat end
 	for {
 		sc := bufio.NewScanner(stream)
+		//adjust the capacity to your need (max characters in line)
+		const defaultBufSize = 4096
+		buf := make([]byte, defaultBufSize)
+		sc.Buffer(buf, defaultBufSize)
 		for sc.Scan() {
 			log := sc.Text()
 			a := regexp.MustCompile(" ")

--- a/util/k8s/k8sApplicationRestHandler.go
+++ b/util/k8s/k8sApplicationRestHandler.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -548,6 +549,17 @@ func (handler *K8sApplicationRestHandlerImpl) GetPodLogs(w http.ResponseWriter, 
 		isReconnect = true
 	}
 	stream, err := handler.k8sApplicationService.GetPodLogs(r.Context(), request)
+	ctx, cancel := context.WithCancel(r.Context())
+	if cn, ok := w.(http.CloseNotifier); ok {
+		go func(done <-chan struct{}, closed <-chan bool) {
+			select {
+			case <-done:
+			case <-closed:
+				cancel()
+			}
+		}(ctx.Done(), cn.CloseNotify())
+	}
+	defer cancel()
 	defer util.Close(stream, handler.logger)
 	handler.pump.StartK8sStreamWithHeartBeat(w, isReconnect, stream, err)
 }


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
Added close to stream and moved from scanner to reader for log stream fetch. Also, downgraded go version to 1.18.

Fixes #2947 

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] Tested with multiple log stream requests at once


## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

