### PR TITLE
fix: duplicate name in charts and chart Group

### DIFF
--- a/api/appStore/InstalledAppRestHandler.go
+++ b/api/appStore/InstalledAppRestHandler.go
@@ -295,7 +295,16 @@ func (handler *InstalledAppRestHandlerImpl) DeployBulk(w http.ResponseWriter, r 
 	}
 	//RBAC block ends here
 
+	visited := make(map[string]bool)
+
 	for _, item := range request.ChartGroupInstallChartRequest {
+		if visited[item.AppName] {
+			handler.Logger.Errorw("service err, CreateInstalledApp", "err", err, "payload", request)
+			common.WriteJsonResp(w, errors.New("Duplicate appName found"), nil, http.StatusInternalServerError)
+			return
+		} else {
+			visited[item.AppName] = true
+		}
 		isChartRepoActive, err := handler.appStoreDeploymentService.IsChartRepoActive(item.AppStoreVersion)
 		if err != nil {
 			handler.Logger.Errorw("service err, CreateInstalledApp", "err", err, "payload", request)

--- a/api/appStore/InstalledAppRestHandler.go
+++ b/api/appStore/InstalledAppRestHandler.go
@@ -300,7 +300,7 @@ func (handler *InstalledAppRestHandlerImpl) DeployBulk(w http.ResponseWriter, r 
 	for _, item := range request.ChartGroupInstallChartRequest {
 		if visited[item.AppName] {
 			handler.Logger.Errorw("service err, CreateInstalledApp", "err", err, "payload", request)
-			common.WriteJsonResp(w, errors.New("Duplicate appName found"), nil, http.StatusBadRequest)
+			common.WriteJsonResp(w, errors.New("duplicate appName found"), nil, http.StatusBadRequest)
 			return
 		} else {
 			visited[item.AppName] = true

--- a/api/appStore/InstalledAppRestHandler.go
+++ b/api/appStore/InstalledAppRestHandler.go
@@ -300,7 +300,7 @@ func (handler *InstalledAppRestHandlerImpl) DeployBulk(w http.ResponseWriter, r 
 	for _, item := range request.ChartGroupInstallChartRequest {
 		if visited[item.AppName] {
 			handler.Logger.Errorw("service err, CreateInstalledApp", "err", err, "payload", request)
-			common.WriteJsonResp(w, errors.New("Duplicate appName found"), nil, http.StatusInternalServerError)
+			common.WriteJsonResp(w, errors.New("Duplicate appName found"), nil, http.StatusBadRequest)
 			return
 		} else {
 			visited[item.AppName] = true

--- a/api/restHandler/ChartGroupRestHandler.go
+++ b/api/restHandler/ChartGroupRestHandler.go
@@ -99,7 +99,11 @@ func (impl *ChartGroupRestHandlerImpl) CreateChartGroup(w http.ResponseWriter, r
 	res, err := impl.ChartGroupService.CreateChartGroup(&request)
 	if err != nil {
 		impl.Logger.Errorw("service err, CreateChartGroup", "err", err, "payload", request)
-		common.WriteJsonResp(w, err, nil, http.StatusInternalServerError)
+		statusCode := http.StatusInternalServerError
+		if service.AppNameAlreadyExistsError == err.Error() {
+			statusCode = http.StatusBadRequest
+		}
+		common.WriteJsonResp(w, err, nil, statusCode)
 		return
 	}
 	common.WriteJsonResp(w, err, res, http.StatusOK)
@@ -312,7 +316,7 @@ func (impl *ChartGroupRestHandlerImpl) GetChartGroupListMin(w http.ResponseWrite
 	common.WriteJsonResp(w, err, res, http.StatusOK)
 }
 
-func(impl *ChartGroupRestHandlerImpl) DeleteChartGroup(w http.ResponseWriter, r *http.Request){
+func (impl *ChartGroupRestHandlerImpl) DeleteChartGroup(w http.ResponseWriter, r *http.Request) {
 	userId, err := impl.userAuthService.GetLoggedInUser(r)
 	if userId == 0 || err != nil {
 		common.WriteJsonResp(w, err, "Unauthorized User", http.StatusUnauthorized)

--- a/internal/sql/repository/app/AppRepository.go
+++ b/internal/sql/repository/app/AppRepository.go
@@ -135,6 +135,7 @@ func (repo AppRepositoryImpl) CheckAppExists(appNames []string) ([]*App, error) 
 	err := repo.dbConnection.
 		Model(&apps).
 		Where("app_name in (?)", pg.In(appNames)).
+		Where("active = ?", true).
 		Select()
 	return apps, err
 }

--- a/pkg/appStore/deployment/repository/ChartGroup.go
+++ b/pkg/appStore/deployment/repository/ChartGroup.go
@@ -53,6 +53,7 @@ type ChartGroupReposotory interface {
 	FindById(chartGroupId int) (*ChartGroup, error)
 	GetAll(max int) ([]*ChartGroup, error)
 	MarkChartGroupDeleted(chartGroupId int, tx *pg.Tx) error
+	FindByName(chartGroupName string) (bool, error)
 }
 
 func (impl *ChartGroupReposotoryImpl) Save(model *ChartGroup) (*ChartGroup, error) {
@@ -104,4 +105,13 @@ func (impl *ChartGroupReposotoryImpl) MarkChartGroupDeleted(chartGroupId int, tx
 		Set("deleted = ?", true).
 		Update()
 	return err
+}
+
+func (impl *ChartGroupReposotoryImpl) FindByName(chartGroupName string) (bool, error) {
+	var ChartGroup ChartGroup
+	exists, err := impl.dbConnection.Model(&ChartGroup).Where("name = ?", chartGroupName).
+		Where("deleted = ?", false).
+		Exists()
+
+	return exists, err
 }

--- a/pkg/appStore/deployment/service/ChartGroupService.go
+++ b/pkg/appStore/deployment/service/ChartGroupService.go
@@ -18,6 +18,7 @@
 package service
 
 import (
+	"errors"
 	appStoreBean "github.com/devtron-labs/devtron/pkg/appStore/bean"
 	"github.com/devtron-labs/devtron/pkg/appStore/deployment/repository"
 	appStoreValuesRepository "github.com/devtron-labs/devtron/pkg/appStore/values/repository"
@@ -69,7 +70,7 @@ type ChartGroupList struct {
 	Groups []*ChartGroupBean `json:"groups,omitempty"`
 }
 type ChartGroupBean struct {
-	Name               string                 `json:"name,omitempty" validate:"name-component,max=200"`
+	Name               string                 `json:"name,omitempty" validate:"name-component,max=200,min=5"`
 	Description        string                 `json:"description,omitempty"`
 	Id                 int                    `json:"id,omitempty"`
 	ChartGroupEntries  []*ChartGroupEntryBean `json:"chartGroupEntries,omitempty"`
@@ -110,6 +111,17 @@ type InstalledChart struct {
 
 func (impl *ChartGroupServiceImpl) CreateChartGroup(req *ChartGroupBean) (*ChartGroupBean, error) {
 	impl.Logger.Debugw("chart group create request", "req", req)
+
+	exist, err := impl.chartGroupRepository.FindByName(req.Name)
+	if err != nil {
+		impl.Logger.Errorw("error in creating chart group", "req", req, "err", err)
+		return nil, err
+	}
+	if exist {
+		impl.Logger.Errorw("Chart with this name already exist", "req", req, "err", err)
+		return nil, errors.New("A chart with this name already exist")
+	}
+
 	chartGrouModel := &repository.ChartGroup{
 		Name:        req.Name,
 		Description: req.Description,

--- a/pkg/appStore/deployment/service/ChartGroupService.go
+++ b/pkg/appStore/deployment/service/ChartGroupService.go
@@ -109,6 +109,8 @@ type InstalledChart struct {
 	InstalledAppId int `json:"installedAppId,omitempty"`
 }
 
+const AppNameAlreadyExistsError = "A chart with this name already exist"
+
 func (impl *ChartGroupServiceImpl) CreateChartGroup(req *ChartGroupBean) (*ChartGroupBean, error) {
 	impl.Logger.Debugw("chart group create request", "req", req)
 
@@ -119,7 +121,7 @@ func (impl *ChartGroupServiceImpl) CreateChartGroup(req *ChartGroupBean) (*Chart
 	}
 	if exist {
 		impl.Logger.Errorw("Chart with this name already exist", "req", req, "err", err)
-		return nil, errors.New("A chart with this name already exist")
+		return nil, errors.New(AppNameAlreadyExistsError)
 	}
 
 	chartGrouModel := &repository.ChartGroup{


### PR DESCRIPTION

# Description
Added check so that user cannot create chart group with mentioned condition.

Create chart group with name 'ch' or 'cha' or 'char', i.e. less than 5 characters.
Try to create one more chart group with same name that you used earlier.
User can't deploy multiple instances of charts with duplicate name.

Fixes https://github.com/devtron-labs/devtron/issues/1290
Fixes https://github.com/devtron-labs/devtron/issues/1289

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [x] Tested locally with invalid constraints. Able to get the expected behaviour.
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

