### PR TITLE
feat: add configuration for only logging pg queries exceeding a threshold duration

### DIFF
--- a/pkg/sql/connection.go
+++ b/pkg/sql/connection.go
@@ -70,7 +70,8 @@ func NewDbConnection(cfg *Config, logger *zap.SugaredLogger) (*pg.DB, error) {
 		dbConnection.OnQueryProcessed(func(event *pg.QueryProcessedEvent) {
 			query, err := event.FormattedQuery()
 			if err != nil {
-				logger.Errorw("Error formatting query")
+				logger.Errorw("Error formatting query",
+					"err", err)
 				return
 			}
 

--- a/pkg/sql/connection.go
+++ b/pkg/sql/connection.go
@@ -76,12 +76,7 @@ func NewDbConnection(cfg *Config, logger *zap.SugaredLogger) (*pg.DB, error) {
 
 			queryDuration := time.Since(event.StartTime)
 
-			if cfg.LogAllQuery {
-				logger.Debugw("query time",
-					"duration", queryDuration.Seconds(),
-					"query", query)
-
-			} else if queryDuration.Milliseconds() > cfg.QueryDurationThreshold {
+			if cfg.LogAllQuery || queryDuration.Milliseconds() > cfg.QueryDurationThreshold {
 				logger.Debugw("query time",
 					"duration", queryDuration.Seconds(),
 					"query", query)


### PR DESCRIPTION
# Description
Currently all queries are logged, with this PR we are introducing a feature to add a separate configuration for only logging queries which exceeds a threshold duration 

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR requires documentation updates?
* [x] I have performed a self-review of my own code.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

