### PR TITLE
feat - Use cluster-name instead of server url in Argo cd application objects 

### DIFF
--- a/client/argocdServer/k8sClient.go
+++ b/client/argocdServer/k8sClient.go
@@ -26,6 +26,7 @@ type AppTemplate struct {
 	ValuesFile      string
 	RepoPath        string
 	RepoUrl         string
+	TargetName      string
 }
 
 const TimeoutSlow = 30 * time.Second

--- a/pkg/app/AppService.go
+++ b/pkg/app/AppService.go
@@ -293,11 +293,12 @@ func (impl *AppServiceImpl) createArgoApplicationIfRequired(appId int, appName s
 			ApplicationName: argoAppName,
 			Namespace:       namespace,
 			TargetNamespace: appNamespace,
+			TargetServer:    envModel.Cluster.ServerUrl,
 			Project:         "default",
 			ValuesFile:      impl.getValuesFileForEnv(envModel.Id),
 			RepoPath:        chart.ChartLocation,
 			RepoUrl:         chart.GitRepoUrl,
-			TargetName:      envModel.Name,
+			TargetName:      envModel.Cluster.ClusterName,
 		}
 
 		argoAppName, err := impl.ArgoK8sClient.CreateAcdApp(appRequest, envModel.Cluster)

--- a/pkg/app/AppService.go
+++ b/pkg/app/AppService.go
@@ -293,11 +293,11 @@ func (impl *AppServiceImpl) createArgoApplicationIfRequired(appId int, appName s
 			ApplicationName: argoAppName,
 			Namespace:       namespace,
 			TargetNamespace: appNamespace,
-			TargetServer:    envModel.Cluster.ServerUrl,
 			Project:         "default",
 			ValuesFile:      impl.getValuesFileForEnv(envModel.Id),
 			RepoPath:        chart.ChartLocation,
 			RepoUrl:         chart.GitRepoUrl,
+			TargetName:      envModel.Name,
 		}
 
 		argoAppName, err := impl.ArgoK8sClient.CreateAcdApp(appRequest, envModel.Cluster)

--- a/pkg/appStore/deployment/fullMode/AppStoreDeploymentFullModeService.go
+++ b/pkg/appStore/deployment/fullMode/AppStoreDeploymentFullModeService.go
@@ -303,11 +303,11 @@ func (impl AppStoreDeploymentFullModeServiceImpl) createInArgo(chartGitAttribute
 		ApplicationName: argocdAppName,
 		Namespace:       impl.aCDAuthConfig.ACDConfigMapNamespace,
 		TargetNamespace: appNamespace,
-		TargetServer:    envModel.Cluster.ServerUrl,
 		Project:         "default",
 		ValuesFile:      fmt.Sprintf("values.yaml"),
 		RepoPath:        chartGitAttribute.ChartLocation,
 		RepoUrl:         chartGitAttribute.RepoUrl,
+		TargetName:      envModel.Name,
 	}
 	_, err := impl.ArgoK8sClient.CreateAcdApp(appreq, envModel.Cluster)
 	//create

--- a/pkg/appStore/deployment/fullMode/AppStoreDeploymentFullModeService.go
+++ b/pkg/appStore/deployment/fullMode/AppStoreDeploymentFullModeService.go
@@ -303,11 +303,12 @@ func (impl AppStoreDeploymentFullModeServiceImpl) createInArgo(chartGitAttribute
 		ApplicationName: argocdAppName,
 		Namespace:       impl.aCDAuthConfig.ACDConfigMapNamespace,
 		TargetNamespace: appNamespace,
+		TargetServer:    envModel.Cluster.ServerUrl,
 		Project:         "default",
 		ValuesFile:      fmt.Sprintf("values.yaml"),
 		RepoPath:        chartGitAttribute.ChartLocation,
 		RepoUrl:         chartGitAttribute.RepoUrl,
-		TargetName:      envModel.Name,
+		TargetName:      envModel.Cluster.ClusterName,
 	}
 	_, err := impl.ArgoK8sClient.CreateAcdApp(appreq, envModel.Cluster)
 	//create

--- a/scripts/argo-assets/APPLICATION_TEMPLATE.JSON
+++ b/scripts/argo-assets/APPLICATION_TEMPLATE.JSON
@@ -9,7 +9,7 @@
   "spec": {
     "destination": {
       "namespace": "{{.TargetNamespace}}",
-      "server": "{{.TargetServer}}"
+      "name": "{{.TargetName}}"
     },
     "project": "{{.Project}}",
     "source": {


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Use cluster `destination.name` instead of `destination.server` in Argocd application object to extend cluster portability.
Fixes #2378 

## How Has This Been Tested?
For testing merged this branch to demo_latest branch and checked the changes on demo
Present
```
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: guestbook
  namespace: argocd
spec:
  project: default
  source:
    repoURL: https://github.com/argoproj/argocd-example-apps.git
    targetRevision: HEAD
    path: guestbook
  destination:
    server: https://kubernetes.default.svc
    namespace: guestbook
```

Proposed
```
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: guestbook
  namespace: argocd
spec:
  project: default
  source:
    repoURL: https://github.com/argoproj/argocd-example-apps.git
    targetRevision: HEAD
    path: guestbook
  destination:
    name: demo-cluster
    namespace: guestbook
```
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

