### PR TITLE
feat:Sorting applist according to deployed time

### DIFF
--- a/internal/sql/repository/helper/AppListingRepositoryQueryBuilder.go
+++ b/internal/sql/repository/helper/AppListingRepositoryQueryBuilder.go
@@ -57,7 +57,8 @@ const (
 )
 
 const (
-	AppNameSortBy SortBy = "appNameSort"
+	AppNameSortBy      SortBy = "appNameSort"
+	LastDeployedSortBy        = "lastDeployedSort"
 )
 
 func (impl AppListingRepositoryQueryBuilder) BuildAppListingQuery(appListingFilter AppListingFilter) string {

--- a/pkg/app/AppListingViewBuilder.go
+++ b/pkg/app/AppListingViewBuilder.go
@@ -103,6 +103,20 @@ func (impl *AppListingViewBuilderImpl) BuildView(fetchAppListingRequest FetchApp
 					return appContainersResponses[i].AppName > appContainersResponses[j].AppName
 				})
 			}
+		} else if helper.LastDeployedSortBy == fetchAppListingRequest.SortBy {
+			if fetchAppListingRequest.SortOrder == helper.Asc {
+				sort.Slice(appContainersResponses, func(i, j int) bool {
+					deployedTime1 := appContainersResponses[i].AppEnvironmentContainer[0].LastDeployedTime
+					deployedTime2 := appContainersResponses[j].AppEnvironmentContainer[0].LastDeployedTime
+					return deployedTime1 > deployedTime2
+				})
+			} else if fetchAppListingRequest.SortOrder == helper.Desc {
+				sort.Slice(appContainersResponses, func(i, j int) bool {
+					deployedTime1 := appContainersResponses[i].AppEnvironmentContainer[0].LastDeployedTime
+					deployedTime2 := appContainersResponses[j].AppEnvironmentContainer[0].LastDeployedTime
+					return deployedTime1 < deployedTime2
+				})
+			}
 		}
 	}
 	return appContainersResponses, nil


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Previously we had an option of only sorting according to the app-name and now we are adding the feature of sorting according to the deployed time.In the case of ascending order we will get the latest deployed apps first and in case of descending order we will get the latest deployed apps at last.And in the applist the ,for a particualr app the latest deployed app shoukd be displayed in the applist.

Fixes [#AB2358](https://dev.azure.com/DevtronLabs/Devtron/_boards/board/t/OSS%20adoption/Stories/?workitem=2358)


## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->
- 1.I have created various apps with various at various instances and sorted them according to deployed time.
- 2.I have tested the changes on local host and it worked fine.

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

