### PR TITLE
fix:notes.txt throws error when charts require special KubeVersion

### DIFF
--- a/api/helm-app/HelmAppService.go
+++ b/api/helm-app/HelmAppService.go
@@ -693,12 +693,7 @@ func (impl *HelmAppServiceImpl) TemplateChart(ctx context.Context, templateChart
 		}
 		return nil, clusterNotFoundErr
 	}
-	discoveryClient, err := impl.K8sUtil.GetK8sDiscoveryClientInCluster()
-	if err != nil {
-		impl.logger.Errorw("eexception caught in getting discoveryClient", "err", err)
-		return nil, err
-	}
-	k8sServerVersion, err := discoveryClient.ServerVersion()
+	k8sServerVersion, err := impl.K8sUtil.GetKubeVersion()
 	if err != nil {
 		impl.logger.Errorw("exception caught in getting k8sServerVersion", "err", err)
 		return nil, err

--- a/internal/util/K8sUtil.go
+++ b/internal/util/K8sUtil.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
 	"net/http"
 	"os/user"
 	"path/filepath"
@@ -747,4 +748,17 @@ func OverrideK8sHttpClientWithTracer(restConfig *rest.Config) (*http.Client, err
 	}
 	httpClientFor.Transport = otelhttp.NewTransport(httpClientFor.Transport)
 	return httpClientFor, nil
+}
+func (impl K8sUtil) GetKubeVersion() (*version.Info, error) {
+	discoveryClient, err := impl.GetK8sDiscoveryClientInCluster()
+	if err != nil {
+		impl.logger.Errorw("eexception caught in getting discoveryClient", "err", err)
+		return nil, err
+	}
+	k8sServerVersion, err := discoveryClient.ServerVersion()
+	if err != nil {
+		impl.logger.Errorw("exception caught in getting k8sServerVersion", "err", err)
+		return nil, err
+	}
+	return k8sServerVersion, err
 }

--- a/pkg/appStore/deployment/service/InstalledAppService.go
+++ b/pkg/appStore/deployment/service/InstalledAppService.go
@@ -798,12 +798,7 @@ func (impl *InstalledAppServiceImpl) FindNotesForArgoApplication(installedAppId,
 			impl.logger.Errorw("error fetching app store app version in installed app service", "err", err)
 			return notes, appName, err
 		}
-		discoveryClient, err := impl.K8sUtil.GetK8sDiscoveryClientInCluster()
-		if err != nil {
-			impl.logger.Errorw("eexception caught in getting discoveryClient", "err", err)
-			return notes, appName, err
-		}
-		k8sServerVersion, err := discoveryClient.ServerVersion()
+		k8sServerVersion, err := impl.K8sUtil.GetKubeVersion()
 		if err != nil {
 			impl.logger.Errorw("exception caught in getting k8sServerVersion", "err", err)
 			return notes, appName, err


### PR DESCRIPTION
# Description
This  PR aims to fix the notes.txt generation error (as shown below) when charts require special KubeVersion.

<img width="1437" alt="Screenshot 2023-03-22 at 1 53 08 PM" src="https://user-images.githubusercontent.com/91401966/226842819-633592f0-b381-461f-8516-4863d990746f.png">

Fixes [AB2520](https://dev.azure.com/DevtronLabs/Devtron/_boards/board/t/OSS%20adoption/Stories/?workitem=2520)
## How Has This Been Tested?
1. I have done testing this via image deployment on vm.
2. I have checked for all possible test cases.
Test cases are:-
a.deployed  helm chart when no apps is present.
b. deployed  same helm chart again when above app  is present.
c.deployed helm chart via gitOps.
4. I have also done testing by applying multiple breakpoint for checking data is coming or not.

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.


