### PR TITLE
feat: added new minified API for listing chart-app repositories without is editable field

### DIFF
--- a/api/chartRepo/ChartRepositoryRestHandler.go
+++ b/api/chartRepo/ChartRepositoryRestHandler.go
@@ -48,6 +48,7 @@ type ChartBinary struct {
 type ChartRepositoryRestHandler interface {
 	GetChartRepoById(w http.ResponseWriter, r *http.Request)
 	GetChartRepoList(w http.ResponseWriter, r *http.Request)
+	GetChartRepoListMin(w http.ResponseWriter, r *http.Request)
 	CreateChartRepo(w http.ResponseWriter, r *http.Request)
 	UpdateChartRepo(w http.ResponseWriter, r *http.Request)
 	ValidateChartRepo(w http.ResponseWriter, r *http.Request)
@@ -115,13 +116,35 @@ func (handler *ChartRepositoryRestHandlerImpl) GetChartRepoList(w http.ResponseW
 	handler.Logger.Infow("request payload, GetChartRepoList, app store")
 	res, err := handler.chartRepositoryService.GetChartRepoList()
 
-	err = handler.attributesService.UpdateKeyValueByOne(CHART_STORE_VISITED_COUNTER)
-
 	if err != nil {
 		handler.Logger.Errorw("service err, GetChartRepoList, app store", "err", err, "userId", userId)
+		handler.Logger.Debug(res)
 		common.WriteJsonResp(w, err, nil, http.StatusInternalServerError)
 		return
 	}
+
+	err = handler.attributesService.UpdateKeyValueByOne(CHART_STORE_VISITED_COUNTER)
+	// ignoring error here since it shouldn't break the main call. logging it instead
+	handler.Logger.Errorw("service err, GetChartRepoList, app store, updating visited counter", "err", err, "userId", userId)
+
+	common.WriteJsonResp(w, err, res, http.StatusOK)
+}
+
+func (handler *ChartRepositoryRestHandlerImpl) GetChartRepoListMin(w http.ResponseWriter, r *http.Request) {
+	userId, err := handler.userAuthService.GetLoggedInUser(r)
+	if userId == 0 || err != nil {
+		common.WriteJsonResp(w, err, nil, http.StatusUnauthorized)
+		return
+	}
+	handler.Logger.Infow("request payload, GetChartRepoList, app store")
+	res, err := handler.chartRepositoryService.GetChartRepoListMin()
+
+	if err != nil {
+		handler.Logger.Errorw("service err, GetChartRepoListMin, app store", "err", err, "userId", userId)
+		common.WriteJsonResp(w, err, nil, http.StatusInternalServerError)
+		return
+	}
+
 	common.WriteJsonResp(w, err, res, http.StatusOK)
 }
 

--- a/api/chartRepo/ChartRepositoryRestHandler.go
+++ b/api/chartRepo/ChartRepositoryRestHandler.go
@@ -125,7 +125,7 @@ func (handler *ChartRepositoryRestHandlerImpl) GetChartRepoList(w http.ResponseW
 
 	err = handler.attributesService.UpdateKeyValueByOne(CHART_STORE_VISITED_COUNTER)
 	// ignoring error here since it shouldn't break the main call. logging it instead
-	handler.Logger.Errorw("service err, GetChartRepoList, app store, updating visited counter", "err", err, "userId", userId)
+	handler.Logger.Errorw("service err, GetChartRepoList, app store, update visited counter", "err", err, "userId", userId)
 
 	common.WriteJsonResp(w, err, res, http.StatusOK)
 }
@@ -136,7 +136,7 @@ func (handler *ChartRepositoryRestHandlerImpl) GetChartRepoListMin(w http.Respon
 		common.WriteJsonResp(w, err, nil, http.StatusUnauthorized)
 		return
 	}
-	handler.Logger.Infow("request payload, GetChartRepoList, app store")
+	handler.Logger.Infow("request payload, GetChartRepoListMin, app store")
 	res, err := handler.chartRepositoryService.GetChartRepoListMin()
 
 	if err != nil {

--- a/api/chartRepo/ChartRepositoryRouter.go
+++ b/api/chartRepo/ChartRepositoryRouter.go
@@ -38,7 +38,7 @@ func (router ChartRepositoryRouterImpl) Init(configRouter *mux.Router) {
 		HandlerFunc(router.chartRepositoryRestHandler.TriggerChartSyncManual).Methods("POST")
 	configRouter.Path("/list").
 		HandlerFunc(router.chartRepositoryRestHandler.GetChartRepoList).Methods("GET")
-	configRouter.Path("/list-min").
+	configRouter.Path("/list/min").
 		HandlerFunc(router.chartRepositoryRestHandler.GetChartRepoListMin).Methods("GET")
 	configRouter.Path("/{id}").
 		HandlerFunc(router.chartRepositoryRestHandler.GetChartRepoById).Methods("GET")

--- a/api/chartRepo/ChartRepositoryRouter.go
+++ b/api/chartRepo/ChartRepositoryRouter.go
@@ -38,6 +38,8 @@ func (router ChartRepositoryRouterImpl) Init(configRouter *mux.Router) {
 		HandlerFunc(router.chartRepositoryRestHandler.TriggerChartSyncManual).Methods("POST")
 	configRouter.Path("/list").
 		HandlerFunc(router.chartRepositoryRestHandler.GetChartRepoList).Methods("GET")
+	configRouter.Path("/list-min").
+		HandlerFunc(router.chartRepositoryRestHandler.GetChartRepoListMin).Methods("GET")
 	configRouter.Path("/{id}").
 		HandlerFunc(router.chartRepositoryRestHandler.GetChartRepoById).Methods("GET")
 	configRouter.Path("/create").

--- a/pkg/chartRepo/ChartRepositoryService.go
+++ b/pkg/chartRepo/ChartRepositoryService.go
@@ -47,7 +47,7 @@ type ChartRepositoryService interface {
 	UpdateDataInArgocdCm(request *ChartRepoDto) (*chartRepoRepository.ChartRepo, error)
 	GetChartRepoById(id int) (*ChartRepoDto, error)
 	GetChartRepoByName(name string) (*ChartRepoDto, error)
-	GetChartRepoList() ([]*ChartRepoDtoWithIsEditable, error)
+	GetChartRepoList() ([]*ChartRepoWithIsEditableDto, error)
 	GetChartRepoListMin() ([]*ChartRepoDto, error)
 	ValidateChartRepo(request *ChartRepoDto) *DetailedErrorHelmRepoValidation
 	ValidateAndCreateChartRepo(request *ChartRepoDto) (*chartRepoRepository.ChartRepo, error, *DetailedErrorHelmRepoValidation)
@@ -355,14 +355,14 @@ func (impl *ChartRepositoryServiceImpl) convertFromDbResponse(model *chartRepoRe
 	return chartRepo
 }
 
-func (impl *ChartRepositoryServiceImpl) GetChartRepoList() ([]*ChartRepoDtoWithIsEditable, error) {
-	var chartRepos []*ChartRepoDtoWithIsEditable
+func (impl *ChartRepositoryServiceImpl) GetChartRepoList() ([]*ChartRepoWithIsEditableDto, error) {
+	var chartRepos []*ChartRepoWithIsEditableDto
 	models, err := impl.repoRepository.FindAllWithDeploymentCount()
 	if err != nil && !util.IsErrNoRows(err) {
 		return nil, err
 	}
 	for _, model := range models {
-		chartRepo := &ChartRepoDtoWithIsEditable{}
+		chartRepo := &ChartRepoWithIsEditableDto{}
 		chartRepo.Id = model.Id
 		chartRepo.Name = model.Name
 		chartRepo.Url = model.Url

--- a/pkg/chartRepo/ChartRepositoryService.go
+++ b/pkg/chartRepo/ChartRepositoryService.go
@@ -47,7 +47,8 @@ type ChartRepositoryService interface {
 	UpdateDataInArgocdCm(request *ChartRepoDto) (*chartRepoRepository.ChartRepo, error)
 	GetChartRepoById(id int) (*ChartRepoDto, error)
 	GetChartRepoByName(name string) (*ChartRepoDto, error)
-	GetChartRepoList() ([]*ChartRepoDto, error)
+	GetChartRepoList() ([]*ChartRepoDtoWithIsEditable, error)
+	GetChartRepoListMin() ([]*ChartRepoDto, error)
 	ValidateChartRepo(request *ChartRepoDto) *DetailedErrorHelmRepoValidation
 	ValidateAndCreateChartRepo(request *ChartRepoDto) (*chartRepoRepository.ChartRepo, error, *DetailedErrorHelmRepoValidation)
 	ValidateAndUpdateChartRepo(request *ChartRepoDto) (*chartRepoRepository.ChartRepo, error, *DetailedErrorHelmRepoValidation)
@@ -354,14 +355,14 @@ func (impl *ChartRepositoryServiceImpl) convertFromDbResponse(model *chartRepoRe
 	return chartRepo
 }
 
-func (impl *ChartRepositoryServiceImpl) GetChartRepoList() ([]*ChartRepoDto, error) {
-	var chartRepos []*ChartRepoDto
+func (impl *ChartRepositoryServiceImpl) GetChartRepoList() ([]*ChartRepoDtoWithIsEditable, error) {
+	var chartRepos []*ChartRepoDtoWithIsEditable
 	models, err := impl.repoRepository.FindAllWithDeploymentCount()
 	if err != nil && !util.IsErrNoRows(err) {
 		return nil, err
 	}
 	for _, model := range models {
-		chartRepo := &ChartRepoDto{}
+		chartRepo := &ChartRepoDtoWithIsEditable{}
 		chartRepo.Id = model.Id
 		chartRepo.Name = model.Name
 		chartRepo.Url = model.Url
@@ -375,6 +376,30 @@ func (impl *ChartRepositoryServiceImpl) GetChartRepoList() ([]*ChartRepoDto, err
 		chartRepo.IsEditable = true
 		if model.ActiveDeploymentCount > 0 {
 			chartRepo.IsEditable = false
+		}
+		chartRepos = append(chartRepos, chartRepo)
+	}
+	return chartRepos, nil
+}
+
+func (impl *ChartRepositoryServiceImpl) GetChartRepoListMin() ([]*ChartRepoDto, error) {
+	var chartRepos []*ChartRepoDto
+	models, err := impl.repoRepository.FindAll()
+	if err != nil && !util.IsErrNoRows(err) {
+		return nil, err
+	}
+	for _, model := range models {
+		chartRepo := &ChartRepoDto{
+			Id:          model.Id,
+			Name:        model.Name,
+			Url:         model.Url,
+			AuthMode:    model.AuthMode,
+			Password:    model.Password,
+			UserName:    model.UserName,
+			SshKey:      model.SshKey,
+			AccessToken: model.AccessToken,
+			Default:     model.Default,
+			Active:      model.Active,
 		}
 		chartRepos = append(chartRepos, chartRepo)
 	}

--- a/pkg/chartRepo/bean.go
+++ b/pkg/chartRepo/bean.go
@@ -16,10 +16,9 @@ type ChartRepoDto struct {
 	Active      bool                `json:"active"`
 	Default     bool                `json:"default"`
 	UserId      int32               `json:"-"`
-	//IsEditable  bool                `json:"isEditable"`
 }
 
-type ChartRepoDtoWithIsEditable struct {
+type ChartRepoWithIsEditableDto struct {
 	ChartRepoDto
 	IsEditable bool `json:"isEditable"`
 }

--- a/pkg/chartRepo/bean.go
+++ b/pkg/chartRepo/bean.go
@@ -16,7 +16,12 @@ type ChartRepoDto struct {
 	Active      bool                `json:"active"`
 	Default     bool                `json:"default"`
 	UserId      int32               `json:"-"`
-	IsEditable  bool                `json:"isEditable"`
+	//IsEditable  bool                `json:"isEditable"`
+}
+
+type ChartRepoDtoWithIsEditable struct {
+	ChartRepoDto
+	IsEditable bool `json:"isEditable"`
 }
 
 type DetailedErrorHelmRepoValidation struct {


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes #
_Created new minified API to list chart repositories by querying the chart-repo table directly. This was created to fetch repositories to populate filter values on chart store page on the dashboard. Previously, the API being called performed an extensive SQL query to calculate isEditable field which is only required on the configuration page when editing an existing repository_

## How Has This Been Tested?
Manually tested on a local cluster for both APIs 
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

