### PR TITLE
fix: updated query for getting workflow runner by appId and envId for active pipelines only

### DIFF
--- a/api/router/pubsub/CiEventHandler.go
+++ b/api/router/pubsub/CiEventHandler.go
@@ -92,6 +92,7 @@ func (impl *CiEventHandlerImpl) Subscribe() error {
 			impl.logger.Error("error while unmarshalling json data", "error", err)
 			return
 		}
+		util.TriggerCIMetrics(ciCompleteEvent.Metrics, impl.ciEventConfig.ExposeCiMetrics, ciCompleteEvent.PipelineName, ciCompleteEvent.AppName)
 		impl.logger.Debugw("ci complete event for ci", "ciPipelineId", ciCompleteEvent.PipelineId)
 		req, err := impl.BuildCiArtifactRequest(ciCompleteEvent)
 		if err != nil {

--- a/internal/sql/repository/pipelineConfig/CdWorfkflowRepository.go
+++ b/internal/sql/repository/pipelineConfig/CdWorfkflowRepository.go
@@ -292,6 +292,7 @@ func (impl *CdWorkflowRepositoryImpl) FindCdWorkflowMetaByEnvironmentId(appId in
 		Column("cd_workflow_runner.*", "CdWorkflow", "CdWorkflow.Pipeline", "CdWorkflow.CiArtifact").
 		Where("p.environment_id = ?", environmentId).
 		Where("p.app_id = ?", appId).
+		Where("p.deleted = ?", false).
 		Order("cd_workflow_runner.id DESC").
 		Join("inner join cd_workflow wf on wf.id = cd_workflow_runner.cd_workflow_id").
 		Join("inner join ci_artifact cia on cia.id = wf.ci_artifact_id").


### PR DESCRIPTION

<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
We were fetching cd workflow runners by using appId and envId but were not checking pipeline deleted status. Updated query to get runners for active pipeline only.

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] Local environment



## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

