### PR TITLE
fix: SSO Login credentials are sent null to secret if we save after obfuscation

### DIFF
--- a/pkg/sso/SSOLoginService.go
+++ b/pkg/sso/SSOLoginService.go
@@ -199,7 +199,7 @@ func (impl SSOLoginServiceImpl) UpdateSSOLogin(request *bean.SSOLoginDto) (*bean
 		impl.logger.Errorw("error in creating new sso login config", "error", err)
 		return nil, err
 	}
-
+	request.Config = newConfigString
 	_, err = impl.updateDexConfig(request)
 	if err != nil {
 		impl.logger.Errorw("error in creating new sso login config", "error", err)


### PR DESCRIPTION

# Description
SSO Login credentials are sent null to secret if we save after obfuscation

Fixes #3246 

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] Tested the code by deploying on cluster
## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.
