### PR TITLE
feat: Add support for particular keys in rollout & deployment template cm/secret [Ref 4 18 0]

### DIFF
--- a/scripts/devtron-reference-helm-charts/deployment-chart_1-2-0/README.md
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_1-2-0/README.md
@@ -35,7 +35,26 @@ ContainerPort:
 EnvVariables: []
 ```
 To set environment variables for the containers that run in the Pod.
+### EnvVariablesFromSecretKeys
+```yaml
+EnvVariablesFromSecretKeys: 
+  - name: ENV_NAME
+    secretName: SECRET_NAME
+    keyName: SECRET_KEY
 
+```
+ It is use to get the name of Environment Variable name, Secret name and the Key name from which we are using the value in that corresponding Environment Variable.
+
+ ### EnvVariablesFromCongigMapKeys
+```yaml
+EnvVariablesFromCongigMapKeys: 
+  - name: ENV_NAME
+    configMapName: CONFIG_MAP_NAME
+    keyName: CONFIG_MAP_KEY
+
+```
+ It is use to get the name of Environment Variable name, Config Map name and the Key name from which we are using the value in that corresponding Environment Variable.
+ 
 ### Liveness Probe
 
 If this check fails, kubernetes restarts the pod. This should return error code in case of non-recoverable error.

--- a/scripts/devtron-reference-helm-charts/deployment-chart_1-2-0/schema.json
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_1-2-0/schema.json
@@ -86,6 +86,60 @@
           }
         ]
       },
+      "EnvVariablesFromSecretKeys": {
+        "type": "array",
+        "description": "Selects a field of the deployment: It is use to get the name of Environment Variable name, Secret name and the Key name from which we are using the value in that corresponding Environment Variable.",
+        "title": "EnvVariablesFromSecretKeys",
+        "items": [
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "name",
+                "description": "Env variable name to be used."
+              },
+              "secretName": {
+                "type": "string",
+                "title": "secretName",
+                "description": "Name of Secret from which we are taking the value."
+              },
+              "keyName": {
+                "type": "string",
+                "title": "keyName",
+                "description": "Name of The Key Where the value is mapped with."
+              }
+            }
+          }
+        ]
+      },
+      "EnvVariablesFromCongigMapKeys": {
+        "type": "array",
+        "description": "Selects a field of the deployment: It is use to get the name of Environment Variable name, Config Map name and the Key name from which we are using the value in that corresponding Environment Variable.",
+        "title": "EnvVariablesFromCongigMapKeys",
+        "items": [
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "name",
+                "description": "Env variable name to be used."
+              },
+              "configMapName": {
+                "type": "string",
+                "title": "configMapName",
+                "description": "Name of configMap from which we are taking the value."
+              },
+              "keyName": {
+                "type": "string",
+                "title": "keyName",
+                "description": "Name of The Key Where the value is mapped with."
+              }
+            }
+          }
+        ]
+      },
       "GracePeriod": {
         "type": "integer",
         "description": "time for which Kubernetes waits before terminating the pods",

--- a/scripts/devtron-reference-helm-charts/deployment-chart_1-2-0/templates/deployment.yaml
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_1-2-0/templates/deployment.yaml
@@ -288,13 +288,34 @@ spec:
                  fieldPath: {{ .fieldPath }}
           {{- end}}
           {{- range $.Values.EnvVariables }}
-            - name: {{ .name}}
+          {{- if and .name .value }}
+            - name: {{ .name }}
               value: {{ .value | quote }}
-          {{- end}}
+          {{- end }}
+          {{- end }}
+          {{- range $.Values.EnvVariablesFromSecretKeys }}
+          {{- if and .name .secretName .keyName }}
+            - name: {{ .name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .secretName }}
+                  key: {{ .keyName }}
+          {{- end }}
+          {{- end }}
+          {{- range $.Values.EnvVariablesFromCongigMapKeys }}
+          {{- if and .name .configMapName .keyName }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .configMapName }}
+                  key: {{ .keyName }}
+          {{- end }}
+          {{- end }}
           {{- if or (and ($hasCMEnvExists) (.Values.ConfigMaps.enabled)) (and ($hasSecretEnvExists) (.Values.ConfigSecrets.enabled)) }}
           envFrom:
           {{- if .Values.ConfigMaps.enabled }}
           {{- range .Values.ConfigMaps.maps }}
+          {{- if and .name .type .external }}
           {{- if eq .type "environment" }}
           - configMapRef:
               {{- if eq .external true }}
@@ -305,8 +326,10 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
+          {{- end }}
           {{- if .Values.ConfigSecrets.enabled }}
           {{- range .Values.ConfigSecrets.secrets }}
+          {{- if and .name .type .external }}
           {{- if eq .type "environment" }}
           - secretRef:
               {{if eq .external true}}
@@ -314,6 +337,7 @@ spec:
               {{else if eq .external false}}
               name: {{ .name}}-{{ $.Values.app }}
               {{- end }}
+          {{- end }}
           {{- end }}
           {{- end }}
           {{- end }}

--- a/scripts/devtron-reference-helm-charts/deployment-chart_1-2-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_1-2-0/values.yaml
@@ -309,6 +309,16 @@ EnvVariables:
   - name: FLASK_ENV
     value: qa
 
+EnvVariablesFromSecretKeys: []
+  # - name: ENV_NAME
+  #   secretName: SECRET_NAME
+  #   keyName: SECRET_KEY
+
+EnvVariablesFromCongigMapKeys: []
+  # - name: ENV_NAME
+  #   configMapName: CONFIG_MAP_NAME
+  #   keyName: CONFIG_MAP_KEY
+
 LivenessProbe:
   Path: /
   port: 8080

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/README.md
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/README.md
@@ -36,6 +36,26 @@ EnvVariables: []
 ```
 To set environment variables for the containers that run in the Pod.
 
+### EnvVariablesFromSecretKeys
+```yaml
+EnvVariablesFromSecretKeys: 
+  - name: ENV_NAME
+    secretName: SECRET_NAME
+    keyName: SECRET_KEY
+
+```
+ It is use to get the name of Environment Variable name, Secret name and the Key name from which we are using the value in that corresponding Environment Variable.
+
+ ### EnvVariablesFromCongigMapKeys
+```yaml
+EnvVariablesFromCongigMapKeys: 
+  - name: ENV_NAME
+    configMapName: CONFIG_MAP_NAME
+    keyName: CONFIG_MAP_KEY
+
+```
+ It is use to get the name of Environment Variable name, Config Map name and the Key name from which we are using the value in that corresponding Environment Variable.
+
 ### Liveness Probe
 
 If this check fails, kubernetes restarts the pod. This should return error code in case of non-recoverable error.

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/schema.json
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/schema.json
@@ -85,6 +85,60 @@
         }
       ]
     },
+    "EnvVariablesFromSecretKeys": {
+      "type": "array",
+      "description": "Selects a field of the deplyment: It is use to get the name of Environment Variable name, Secret name and the Key name from which we are using the value in that corresponding Environment Variable.",
+      "title": "EnvVariablesFromSecretKeys",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "name",
+              "description": "Env variable name to be used."
+            },
+            "secretName": {
+              "type": "string",
+              "title": "secretName",
+              "description": "Name of Secret from which we are taking the value."
+            },
+            "keyName": {
+              "type": "string",
+              "title": "keyName",
+              "description": "Name of The Key Where the value is mapped with."
+            }
+          }
+        }
+      ]
+    },
+    "EnvVariablesFromCongigMapKeys": {
+      "type": "array",
+      "description": "Selects a field of the deplyment: It is use to get the name of Environment Variable name, Config Map name and the Key name from which we are using the value in that corresponding Environment Variable.",
+      "title": "EnvVariablesFromCongigMapKeys",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "name",
+              "description": "Env variable name to be used."
+            },
+            "configMapName": {
+              "type": "string",
+              "title": "configMapName",
+              "description": "Name of configMap from which we are taking the value."
+            },
+            "keyName": {
+              "type": "string",
+              "title": "keyName",
+              "description": "Name of The Key Where the value is mapped with."
+            }
+          }
+        }
+      ]
+    },
     "GracePeriod": {
       "type": "integer",
       "description": "time for which Kubernetes waits before terminating the pods",

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/schema.json
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/schema.json
@@ -87,7 +87,7 @@
     },
     "EnvVariablesFromSecretKeys": {
       "type": "array",
-      "description": "Selects a field of the deplyment: It is use to get the name of Environment Variable name, Secret name and the Key name from which we are using the value in that corresponding Environment Variable.",
+      "description": "Selects a field of the deployment: It is use to get the name of Environment Variable name, Secret name and the Key name from which we are using the value in that corresponding Environment Variable.",
       "title": "EnvVariablesFromSecretKeys",
       "items": [
         {
@@ -114,7 +114,7 @@
     },
     "EnvVariablesFromCongigMapKeys": {
       "type": "array",
-      "description": "Selects a field of the deplyment: It is use to get the name of Environment Variable name, Config Map name and the Key name from which we are using the value in that corresponding Environment Variable.",
+      "description": "Selects a field of the deployment: It is use to get the name of Environment Variable name, Config Map name and the Key name from which we are using the value in that corresponding Environment Variable.",
       "title": "EnvVariablesFromCongigMapKeys",
       "items": [
         {

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/templates/deployment.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/templates/deployment.yaml
@@ -282,15 +282,19 @@ spec:
             - name: DEVTRON_CONTAINER_TAG
               value: "{{ .Values.server.deployment.image_tag }}"
           {{- range $.Values.EnvVariablesFromFieldPath }}
+          {{- if and .name .fieldPath }}
             - name: {{ .name }}
               valueFrom:
                 fieldRef:
                  fieldPath: {{ .fieldPath }}
-          {{- end}}
+          {{- end }}
+          {{- end }}
           {{- range $.Values.EnvVariables }}
+          {{- if and .name .value }}
             - name: {{ .name }}
               value: {{ .value | quote }}
-          {{- end}}
+          {{- end }}
+          {{- end }}
           {{- range $.Values.EnvVariablesFromSecretKeys }}
           {{- if and .name .secretName .keyName }}
             - name: {{ .name }}
@@ -313,6 +317,7 @@ spec:
           envFrom:
           {{- if .Values.ConfigMaps.enabled }}
           {{- range .Values.ConfigMaps.maps }}
+          {{- if and .name .type .external }}
           {{- if eq .type "environment" }}
           - configMapRef:
               {{- if eq .external true }}
@@ -323,8 +328,10 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
+          {{- end }}
           {{- if .Values.ConfigSecrets.enabled }}
           {{- range .Values.ConfigSecrets.secrets }}
+          {{- if and .name .type .external }}
           {{- if eq .type "environment" }}
           - secretRef:
               {{if eq .external true}}
@@ -332,6 +339,7 @@ spec:
               {{else if eq .external false}}
               name: {{ .name}}-{{ $.Values.app }}
               {{- end }}
+          {{- end }}
           {{- end }}
           {{- end }}
           {{- end }}

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/templates/deployment.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/templates/deployment.yaml
@@ -303,7 +303,7 @@ spec:
                   name: {{ .secretName }}
                   key: {{ .keyName }}
           {{- end }}
-          {{- end}}
+          {{- end }}
           {{- range $.Values.EnvVariablesFromCongigMapKeys }}
           {{- if and .name .configMapName .keyName }}
             - name: {{ .name }}
@@ -312,7 +312,7 @@ spec:
                   name: {{ .configMapName }}
                   key: {{ .keyName }}
           {{- end }}
-          {{- end}}
+          {{- end }}
           {{- if or (and ($hasCMEnvExists) (.Values.ConfigMaps.enabled)) (and ($hasSecretEnvExists) (.Values.ConfigSecrets.enabled)) }}
           envFrom:
           {{- if .Values.ConfigMaps.enabled }}

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/templates/deployment.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/templates/deployment.yaml
@@ -292,18 +292,22 @@ spec:
               value: {{ .value | quote }}
           {{- end}}
           {{- range $.Values.EnvVariablesFromSecretKeys }}
+          {{- if and .name .secretName .keyName }}
             - name: {{ .name }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .secretName }}
                   key: {{ .keyName }}
+          {{- end }}
           {{- end}}
           {{- range $.Values.EnvVariablesFromCongigMapKeys }}
+          {{- if and .name .configMapName .keyName }}
             - name: {{ .name }}
               valueFrom:
                 configMapKeyRef:
                   name: {{ .configMapName }}
                   key: {{ .keyName }}
+          {{- end }}
           {{- end}}
           {{- if or (and ($hasCMEnvExists) (.Values.ConfigMaps.enabled)) (and ($hasSecretEnvExists) (.Values.ConfigSecrets.enabled)) }}
           envFrom:

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/templates/deployment.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/templates/deployment.yaml
@@ -288,8 +288,22 @@ spec:
                  fieldPath: {{ .fieldPath }}
           {{- end}}
           {{- range $.Values.EnvVariables }}
-            - name: {{ .name}}
+            - name: {{ .name }}
               value: {{ .value | quote }}
+          {{- end}}
+          {{- range $.Values.EnvVariablesFromSecretKeys }}
+            - name: {{ .name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .secretName }}
+                  key: {{ .keyName }}
+          {{- end}}
+          {{- range $.Values.EnvVariablesFromCongigMapKeys }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .configMapName }}
+                  key: {{ .keyName }}
           {{- end}}
           {{- if or (and ($hasCMEnvExists) (.Values.ConfigMaps.enabled)) (and ($hasSecretEnvExists) (.Values.ConfigSecrets.enabled)) }}
           envFrom:

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/test_values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/test_values.yaml
@@ -143,6 +143,16 @@ EnvVariables:
   - name: FLASK_ENV
     value: qa
 
+EnvVariablesFromSecretKeys: []
+  # - name: ENV_NAME
+  #   secretName: SECRET_NAME
+  #   keyName: SECRET_KEY
+
+EnvVariablesFromCongigMapKeys: []
+  # - name: ENV_NAME
+  #   configMapName: CONFIG_MAP_NAME
+  #   keyName: CONFIG_MAP_KEY
+
 LivenessProbe:
   Path: /
   port: 8080

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/values.yaml
@@ -134,14 +134,14 @@ EnvVariables:
   - name: FLASK_ENV
     value: qa
 
-EnvVariablesFromSecretKeys: 
-  - name: ENV_NAME1
-    keyName: SECRET_KEY1
-  - name: ENV_NAME2
-    secretName: SECRET_NAME2
-    keyName: SECRET_KEY2
-  - name: ENV_NAME3
-    secretName: SECRET_NAME3
+EnvVariablesFromSecretKeys: []
+  # - name: ENV_NAME1
+  #   keyName: SECRET_KEY1
+  # - name: ENV_NAME2
+  #   secretName: SECRET_NAME2
+  #   keyName: SECRET_KEY2
+  # - name: ENV_NAME3
+  #   secretName: SECRET_NAME3
 
 EnvVariablesFromCongigMapKeys: []
   # - name: ENV_NAME

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/values.yaml
@@ -134,10 +134,14 @@ EnvVariables:
   - name: FLASK_ENV
     value: qa
 
-EnvVariablesFromSecretKeys: []
-  # - name: ENV_NAME
-  #   secretName: SECRET_NAME
-  #   keyName: SECRET_KEY
+EnvVariablesFromSecretKeys: 
+  - name: ENV_NAME1
+    keyName: SECRET_KEY1
+  - name: ENV_NAME2
+    secretName: SECRET_NAME2
+    keyName: SECRET_KEY2
+  - name: ENV_NAME3
+    secretName: SECRET_NAME3
 
 EnvVariablesFromCongigMapKeys: []
   # - name: ENV_NAME

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/values.yaml
@@ -134,6 +134,16 @@ EnvVariables:
   - name: FLASK_ENV
     value: qa
 
+EnvVariablesFromSecretKeys: []
+  # - name: ENV_NAME
+  #   secretName: SECRET_NAME
+  #   keyName: SECRET_KEY
+
+EnvVariablesFromCongigMapKeys: []
+  # - name: ENV_NAME
+  #   configMapName: CONFIG_MAP_NAME
+  #   keyName: CONFIG_MAP_KEY
+
 LivenessProbe:
   Path: /
   port: 8080

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/values.yaml
@@ -135,13 +135,9 @@ EnvVariables:
     value: qa
 
 EnvVariablesFromSecretKeys: []
-  # - name: ENV_NAME1
-  #   keyName: SECRET_KEY1
-  # - name: ENV_NAME2
-  #   secretName: SECRET_NAME2
-  #   keyName: SECRET_KEY2
-  # - name: ENV_NAME3
-  #   secretName: SECRET_NAME3
+  # - name: ENV_NAME
+  #   secretName: SECRET_NAME
+  #   keyName: SECRET_KEY
 
 EnvVariablesFromCongigMapKeys: []
   # - name: ENV_NAME


### PR DESCRIPTION
Title: Add support for particular keys in rollout & deployment template cm/secret [Ref 4 18 0]
types: feat


feat: Add support for particular keys in rollout & deployment template cm/secret [Ref 4 18 0]

Added 2 fields that use to add EnvVariablesFrom SecretKeys and ConfigMapKey.
```
EnvVariablesFromSecretKeys: []
  # - name: ENV_NAME
  #   secretName: SECRET_NAME
  #   keyName: SECRET_KEY

EnvVariablesFromCongigMapKeys: []
  # - name: ENV_NAME
  #   configMapName: CONFIG_MAP_NAME
  #   keyName: CONFIG_MAP_KEY

```
