### PR TITLE
fix: getting cluster list min api optimized by enforcing env object in batch

### DIFF
--- a/util/k8s/k8sCapacityRestHandler.go
+++ b/util/k8s/k8sCapacityRestHandler.go
@@ -420,11 +420,11 @@ func (handler *K8sCapacityRestHandlerImpl) CheckRbacForCluster(cluster *cluster.
 	}
 
 	var envIdentifierList []string
-	envIdentifierMap := make(map[string]*int)
+	envIdentifierMap := make(map[string]bool)
 	for _, env := range envs {
 		envIdentifier := strings.ToLower(env.EnvironmentIdentifier)
 		envIdentifierList = append(envIdentifierList, envIdentifier)
-		envIdentifierMap[envIdentifier] = &env.Id
+		envIdentifierMap[envIdentifier] = true
 	}
 	if len(envIdentifierList) == 0 {
 		return false, errors.New("environment identifier list for rbac batch enforcing contains zero environments")


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
This pr optimizes the capacity/cluster/list/raw api. Previously the ebac enforcer was getting applied on env in a loop, this pr enforces rbac by email in batch on the list of envs.
Fixes #

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] tested locally via postman
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

