### PR TITLE
fix: updated_by and created_by fields not getting updated in database for sso login services

### DIFF
--- a/api/sso/SsoLoginHandler.go
+++ b/api/sso/SsoLoginHandler.go
@@ -78,6 +78,7 @@ func (handler SsoLoginRestHandlerImpl) CreateSSOLoginConfig(w http.ResponseWrite
 	}
 
 	handler.logger.Infow("request payload, CreateSSOLoginConfig", "payload", dto)
+	dto.UserId = userId
 	resp, err := handler.ssoLoginService.CreateSSOLogin(&dto)
 	if err != nil {
 		handler.logger.Errorw("service err, CreateSSOLoginConfig", "err", err, "payload", dto)
@@ -110,6 +111,7 @@ func (handler SsoLoginRestHandlerImpl) UpdateSSOLoginConfig(w http.ResponseWrite
 	}
 
 	handler.logger.Infow("request payload, UpdateSSOLoginConfig", "payload", dto)
+	dto.UserId = userId
 	resp, err := handler.ssoLoginService.UpdateSSOLogin(&dto)
 	if err != nil {
 		handler.logger.Errorw("service err, UpdateSSOLoginConfig", "err", err, "payload", dto)


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
whenever we create or update an sso login service the created by and updated by fields are not getting updated and are stored as null.

Fixes #[#AB2736](https://dev.azure.com/DevtronLabs/Devtron/_boards/board/t/OSS%20adoption/Stories/?workitem=2736)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

