### PR TITLE
fix: 404 not found in devtron without cicd app list page

### DIFF
--- a/charts/devtron/Chart.yaml
+++ b/charts/devtron/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - argocd
   - Hyperion
 engine: gotpl
-version: 0.22.54
+version: 0.22.55
 sources:
   - https://github.com/devtron-labs/charts
 dependencies:

--- a/charts/devtron/devtron-bom.yaml
+++ b/charts/devtron/devtron-bom.yaml
@@ -15,7 +15,7 @@ installer:
   
 components:
   dashboard:
-    image: "quay.io/devtron/dashboard:a6483cb3-325-13800"
+    image: "quay.io/devtron/dashboard:91c24b99-325-13846"
     config:
       extraConfigs:
         USE_V2: "true"

--- a/charts/devtron/values.yaml
+++ b/charts/devtron/values.yaml
@@ -55,7 +55,7 @@ components:
       extraConfigs:
         USE_V2: "true"
         ENABLE_BUILD_CONTEXT: "false"
-    image: "quay.io/devtron/dashboard:a6483cb3-325-13800"
+    image: "quay.io/devtron/dashboard:91c24b99-325-13846"
     imagePullPolicy: IfNotPresent
 
   devtron:


### PR DESCRIPTION
# Description

With the API optimization some APIs weren't replaced in devtron without cicd mode which caused the issue

Fixes #3434 

## How Has This Been Tested?

- [x] Tested by 2 users on separate microk8s clusters

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

