### PR TITLE
fix: getting force_security_scan value from devtron-cm

### DIFF
--- a/pkg/pipeline/PipelineBuilder.go
+++ b/pkg/pipeline/PipelineBuilder.go
@@ -87,6 +87,12 @@ type DeploymentServiceTypeConfig struct {
 	IsInternalUse bool `env:"IS_INTERNAL_USE" envDefault:"false"`
 }
 
+type SecurityConfig struct {
+	//FORCE_SECURITY_SCANNING flag is being maintained in both dashboard and orchestrator CM's
+	//TODO: rishabh will remove FORCE_SECURITY_SCANNING from dashboard's CM.
+	ForceSecurityScanning bool `env:"FORCE_SECURITY_SCANNING" envDefault:"false"`
+}
+
 func GetDeploymentServiceTypeConfig() (*DeploymentServiceTypeConfig, error) {
 	cfg := &DeploymentServiceTypeConfig{}
 	err := env.Parse(cfg)
@@ -217,6 +223,7 @@ type PipelineBuilderImpl struct {
 	appGroupService                                 appGroup2.AppGroupService
 	chartDeploymentService                          util.ChartDeploymentService
 	K8sUtil                                         *util.K8sUtil
+	securityConfig                                  *SecurityConfig
 }
 
 func NewPipelineBuilderImpl(logger *zap.SugaredLogger,
@@ -270,6 +277,12 @@ func NewPipelineBuilderImpl(logger *zap.SugaredLogger,
 	appGroupService appGroup2.AppGroupService,
 	chartDeploymentService util.ChartDeploymentService,
 	K8sUtil *util.K8sUtil) *PipelineBuilderImpl {
+
+	securityConfig := &SecurityConfig{}
+	err := env.Parse(securityConfig)
+	if err != nil {
+		logger.Errorw("error in parsing securityConfig,setting  ForceSecurityScanning to default value", "defaultValue", securityConfig.ForceSecurityScanning, "err", err)
+	}
 	return &PipelineBuilderImpl{
 		logger:                        logger,
 		ciCdPipelineOrchestrator:      ciCdPipelineOrchestrator,
@@ -330,6 +343,7 @@ func NewPipelineBuilderImpl(logger *zap.SugaredLogger,
 		appGroupService:                                 appGroupService,
 		chartDeploymentService:                          chartDeploymentService,
 		K8sUtil:                                         K8sUtil,
+		securityConfig:                                  securityConfig,
 	}
 }
 
@@ -1423,28 +1437,8 @@ func (impl PipelineBuilderImpl) PatchCiPipeline(request *bean.CiPatchRequest) (c
 	ciConfig.AppWorkflowId = request.AppWorkflowId
 	ciConfig.UserId = request.UserId
 	if request.CiPipeline != nil {
-		client, err := impl.K8sUtil.GetClientForInCluster()
-		if err != nil {
-			impl.logger.Errorw("exception while getting unique client id", "error", err)
-			return nil, err
-		}
-		cm, err := impl.K8sUtil.GetConfigMap(argo.DEVTRONCD_NAMESPACE, DashboardConfigMap, client)
-		if err != nil {
-			impl.logger.Errorw("error while getting dashboard-cm", "error", err)
-			return nil, err
-		}
-		if cm == nil {
-			impl.logger.Errorw("error while getting dashboard-cm", "error", err)
-			return nil, err
-		}
-		datamap := cm.Data
-		forceScanConfig, err := strconv.ParseBool(datamap[SECURITY_SCANNING])
-		if err != nil {
-			forceScanConfig = false
-		}
-		if forceScanConfig {
-			request.CiPipeline.ScanEnabled = true
-		}
+		//setting ScanEnabled value from env variable,
+		request.CiPipeline.ScanEnabled = impl.securityConfig.ForceSecurityScanning
 		ciConfig.ScanEnabled = request.CiPipeline.ScanEnabled
 	}
 	switch request.Action {

--- a/pkg/pipeline/PipelineBuilder.go
+++ b/pkg/pipeline/PipelineBuilder.go
@@ -1438,7 +1438,7 @@ func (impl PipelineBuilderImpl) PatchCiPipeline(request *bean.CiPatchRequest) (c
 	ciConfig.UserId = request.UserId
 	if request.CiPipeline != nil {
 		//setting ScanEnabled value from env variable,
-		request.CiPipeline.ScanEnabled = impl.securityConfig.ForceSecurityScanning
+		request.CiPipeline.ScanEnabled = request.CiPipeline.ScanEnabled || impl.securityConfig.ForceSecurityScanning
 		ciConfig.ScanEnabled = request.CiPipeline.ScanEnabled
 	}
 	switch request.Action {


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Issue:  we are fetching dashboard-cm to read a variable,but the name of the variable is not always same.this will cause error if the CM of dashboard is different(not devtron-cm).

Fix: now maintaining the variable in devtron-cm that is being fetched from dashboard-cm ,which will resolve the issue for now. later this variable will be removed from dashboard-cm and communicated to dashboard from orchestrator.
Fixes #

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

