### PR TITLE
fix: Deployment enforcement config save err

### DIFF
--- a/pkg/attributes/AttributesService.go
+++ b/pkg/attributes/AttributesService.go
@@ -257,11 +257,6 @@ func (impl AttributesServiceImpl) AddDeploymentEnforcementConfig(request *Attrib
 				"at least one deployment app type should be allowed", environmentId))
 		}
 	}
-	model, err := impl.attributesRepository.FindByKey(ENFORCE_DEPLOYMENT_TYPE_CONFIG)
-	if err != nil && err != pg.ErrNoRows {
-		impl.logger.Errorw("error in fetching deploymentEnforcementConfig from db", "error", err, "key", request.Key)
-		return request, err
-	}
 	dbConnection := impl.attributesRepository.GetConnection()
 	tx, terr := dbConnection.Begin()
 	if terr != nil {
@@ -269,6 +264,12 @@ func (impl AttributesServiceImpl) AddDeploymentEnforcementConfig(request *Attrib
 	}
 	// Rollback tx on error.
 	defer tx.Rollback()
+
+	model, err := impl.attributesRepository.FindByKey(ENFORCE_DEPLOYMENT_TYPE_CONFIG)
+	if err != nil && err != pg.ErrNoRows {
+		impl.logger.Errorw("error in fetching deploymentEnforcementConfig from db", "error", err, "key", request.Key)
+		return request, err
+	}
 	if err == pg.ErrNoRows {
 		model := &repository.Attributes{
 			Key:   ENFORCE_DEPLOYMENT_TYPE_CONFIG,


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Deployment enforcement config not getting saved for first time in database.
Fixes #Deployment type enforcement config not getting saved for first time

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

