### PR TITLE
fix: optimized fetch deployment status timeline api

### DIFF
--- a/api/appStore/AppStoreStatusTimelineRestHandler.go
+++ b/api/appStore/AppStoreStatusTimelineRestHandler.go
@@ -47,6 +47,12 @@ func (handler AppStoreStatusTimelineRestHandlerImpl) FetchTimelinesForAppStore(w
 		return
 	}
 	installedAppVersionHistoryId := 0
+	showTimeline := false
+	showTimeline, err = strconv.ParseBool(r.URL.Query().Get("showTimeline"))
+	if err != nil {
+		common.WriteJsonResp(w, err, nil, http.StatusBadRequest)
+		return
+	}
 	installedAppVersionHistoryIdParam := r.URL.Query().Get("installedAppVersionHistoryId")
 	if len(installedAppVersionHistoryIdParam) != 0 {
 		installedAppVersionHistoryId, err = strconv.Atoi(installedAppVersionHistoryIdParam)
@@ -56,7 +62,7 @@ func (handler AppStoreStatusTimelineRestHandlerImpl) FetchTimelinesForAppStore(w
 		}
 	}
 	//rbac will already be handled at app level
-	timelines, err := handler.pipelineStatusTimelineService.FetchTimelinesForAppStore(installedAppId, envId, installedAppVersionHistoryId)
+	timelines, err := handler.pipelineStatusTimelineService.FetchTimelinesForAppStore(installedAppId, envId, installedAppVersionHistoryId, showTimeline)
 	if err != nil {
 		handler.logger.Errorw("error in getting pipeline status timelines by installedAppVersionHistoryId", "err", err, "installedAppVersionHistoryId", installedAppVersionHistoryId, "installedAppId", installedAppId, "envId", envId)
 		common.WriteJsonResp(w, err, nil, http.StatusInternalServerError)

--- a/api/appStore/AppStoreStatusTimelineRestHandler.go
+++ b/api/appStore/AppStoreStatusTimelineRestHandler.go
@@ -48,10 +48,13 @@ func (handler AppStoreStatusTimelineRestHandlerImpl) FetchTimelinesForAppStore(w
 	}
 	installedAppVersionHistoryId := 0
 	showTimeline := false
-	showTimeline, err = strconv.ParseBool(r.URL.Query().Get("showTimeline"))
-	if err != nil {
-		common.WriteJsonResp(w, err, nil, http.StatusBadRequest)
-		return
+	showTimelineParam := r.URL.Query().Get("showTimeline")
+	if len(showTimelineParam) > 0 {
+		showTimeline, err = strconv.ParseBool(showTimelineParam)
+		if err != nil {
+			common.WriteJsonResp(w, err, nil, http.StatusBadRequest)
+			return
+		}
 	}
 	installedAppVersionHistoryIdParam := r.URL.Query().Get("installedAppVersionHistoryId")
 	if len(installedAppVersionHistoryIdParam) != 0 {

--- a/api/restHandler/PipelineStatusTimelineRestHandler.go
+++ b/api/restHandler/PipelineStatusTimelineRestHandler.go
@@ -55,6 +55,16 @@ func (handler *PipelineStatusTimelineRestHandlerImpl) FetchTimelines(w http.Resp
 			return
 		}
 	}
+	showTimeline := false
+	showTimelineParam := r.URL.Query().Get("showTimeline")
+	if len(showTimelineParam) > 0 {
+		showTimeline, err = strconv.ParseBool(showTimelineParam)
+		if err != nil {
+			common.WriteJsonResp(w, err, nil, http.StatusBadRequest)
+			return
+		}
+	}
+
 	resourceName := handler.enforcerUtil.GetAppRBACNameByAppId(appId)
 	token := r.Header.Get("token")
 	if ok := handler.enforcer.Enforce(token, casbin.ResourceApplications, casbin.ActionGet, resourceName); !ok {
@@ -62,7 +72,7 @@ func (handler *PipelineStatusTimelineRestHandlerImpl) FetchTimelines(w http.Resp
 		return
 	}
 
-	timelines, err := handler.pipelineStatusTimelineService.FetchTimelines(appId, envId, wfrId)
+	timelines, err := handler.pipelineStatusTimelineService.FetchTimelines(appId, envId, wfrId, showTimeline)
 	if err != nil {
 		handler.logger.Errorw("error in getting cd pipeline status timelines by wfrId", "err", err, "wfrId", wfrId)
 		common.WriteJsonResp(w, err, nil, http.StatusInternalServerError)

--- a/pkg/app/status/PipelineStatusTimelineService.go
+++ b/pkg/app/status/PipelineStatusTimelineService.go
@@ -15,7 +15,7 @@ import (
 type PipelineStatusTimelineService interface {
 	SaveTimeline(timeline *pipelineConfig.PipelineStatusTimeline, tx *pg.Tx, isAppStore bool) error
 	FetchTimelines(appId, envId, wfrId int) (*PipelineTimelineDetailDto, error)
-	FetchTimelinesForAppStore(installedAppId, envId, installedAppVersionHistoryId int) (*PipelineTimelineDetailDto, error)
+	FetchTimelinesForAppStore(installedAppId, envId, installedAppVersionHistoryId int, showTimeline bool) (*PipelineTimelineDetailDto, error)
 	GetTimelineDbObjectByTimelineStatusAndTimelineDescription(cdWorkflowRunnerId int, timelineStatus pipelineConfig.TimelineStatus, timelineDescription string, userId int32) *pipelineConfig.PipelineStatusTimeline
 }
 
@@ -242,7 +242,7 @@ func (impl *PipelineStatusTimelineServiceImpl) FetchTimelines(appId, envId, wfrI
 	return timelineDetail, nil
 }
 
-func (impl *PipelineStatusTimelineServiceImpl) FetchTimelinesForAppStore(installedAppId, envId, installedAppVersionHistoryId int) (*PipelineTimelineDetailDto, error) {
+func (impl *PipelineStatusTimelineServiceImpl) FetchTimelinesForAppStore(installedAppId, envId, installedAppVersionHistoryId int, showTimeline bool) (*PipelineTimelineDetailDto, error) {
 	var deploymentStartedOn time.Time
 	var deploymentFinishedOn time.Time
 	var installedAppVersionHistoryStatus string
@@ -287,7 +287,7 @@ func (impl *PipelineStatusTimelineServiceImpl) FetchTimelinesForAppStore(install
 	var timelineDtos []*PipelineStatusTimelineDto
 	var statusLastFetchedAt time.Time
 	var statusFetchCount int
-	if util.IsAcdApp(deploymentAppType) {
+	if util.IsAcdApp(deploymentAppType) && showTimeline {
 		timelines, err := impl.pipelineStatusTimelineRepository.FetchTimelinesByInstalledAppVersionHistoryId(installedAppVersionHistoryId)
 		if err != nil {
 			impl.logger.Errorw("error in getting timelines by installedAppVersionHistoryId", "err", err, "wfrId", installedAppVersionHistoryId)

--- a/pkg/app/status/PipelineStatusTimelineService.go
+++ b/pkg/app/status/PipelineStatusTimelineService.go
@@ -14,7 +14,7 @@ import (
 
 type PipelineStatusTimelineService interface {
 	SaveTimeline(timeline *pipelineConfig.PipelineStatusTimeline, tx *pg.Tx, isAppStore bool) error
-	FetchTimelines(appId, envId, wfrId int) (*PipelineTimelineDetailDto, error)
+	FetchTimelines(appId, envId, wfrId int, showTimeline bool) (*PipelineTimelineDetailDto, error)
 	FetchTimelinesForAppStore(installedAppId, envId, installedAppVersionHistoryId int, showTimeline bool) (*PipelineTimelineDetailDto, error)
 	GetTimelineDbObjectByTimelineStatusAndTimelineDescription(cdWorkflowRunnerId int, timelineStatus pipelineConfig.TimelineStatus, timelineDescription string, userId int32) *pipelineConfig.PipelineStatusTimeline
 }
@@ -154,7 +154,7 @@ func (impl *PipelineStatusTimelineServiceImpl) saveOrUpdateTimeline(timeline *pi
 	return nil
 }
 
-func (impl *PipelineStatusTimelineServiceImpl) FetchTimelines(appId, envId, wfrId int) (*PipelineTimelineDetailDto, error) {
+func (impl *PipelineStatusTimelineServiceImpl) FetchTimelines(appId, envId, wfrId int, showTimeline bool) (*PipelineTimelineDetailDto, error) {
 	var triggeredBy int32
 	var deploymentStartedOn time.Time
 	var deploymentFinishedOn time.Time
@@ -191,7 +191,7 @@ func (impl *PipelineStatusTimelineServiceImpl) FetchTimelines(appId, envId, wfrI
 	var timelineDtos []*PipelineStatusTimelineDto
 	var statusLastFetchedAt time.Time
 	var statusFetchCount int
-	if util.IsAcdApp(deploymentAppType) {
+	if util.IsAcdApp(deploymentAppType) && showTimeline {
 		timelines, err := impl.pipelineStatusTimelineRepository.FetchTimelinesByWfrId(wfrId)
 		if err != nil {
 			impl.logger.Errorw("error in getting timelines by wfrId", "err", err, "wfrId", wfrId)


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Added a query param in fetch deployment status  timeline api, saving multiple db calls where the data is not needed on UI
Fixes #

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

