### PR TITLE
doc: Update devtron-reference charts with pdb

### DIFF
--- a/docs/user-guide/creating-application/deployment-template/deployment.md
+++ b/docs/user-guide/creating-application/deployment-template/deployment.md
@@ -145,6 +145,29 @@ ReadinessProbe:
 | `scheme` | Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.
 | `tcp` | The kubelet will attempt to open a socket to your container on the specified port. If it can establish a connection, the container is considered healthy. |
 
+### Pod Disruption Budget
+
+You can create `PodDisruptionBudget` for each application. A PDB limits the number of pods of a replicated application that are down simultaneously from voluntary disruptions. For example, an application would like to ensure the number of replicas running is never brought below the certain number.
+
+```yaml
+podDisruptionBudget: 
+     minAvailable: 1
+```
+
+or
+
+```yaml
+podDisruptionBudget: 
+     maxUnavailable: 50%
+```
+
+You can specify either `maxUnavailable` or `minAvailable` in a PodDisruptionBudget and it can be expressed as integers or as a percentage.
+
+| Key | Description |
+| :--- | :--- |
+| `minAvailable` | Evictions are allowed as long as they leave behind 1 or more healthy pods of the total number of desired replicas. |
+| `maxUnavailable` | Evictions are allowed as long as at most 1 unhealthy replica among the total number of desired replicas. |
+
 ### Ambassador Mappings
 
 You can create ambassador mappings to access your applications from outside the cluster. At its core a Mapping resource maps a resource to a service.

--- a/docs/user-guide/creating-application/deployment-template/rollout-deployment.md
+++ b/docs/user-guide/creating-application/deployment-template/rollout-deployment.md
@@ -653,19 +653,26 @@ When you create a pod, if you do not create a service account, it is automatical
 
 ### Pod Disruption Budget
 
-```yaml
-podDisruptionBudget: {}
-     minAvailable: 1
-     maxUnavailable: 1
-```
-
 You can create `PodDisruptionBudget` for each application. A PDB limits the number of pods of a replicated application that are down simultaneously from voluntary disruptions. For example, an application would like to ensure the number of replicas running is never brought below the certain number.
 
-You can specify `maxUnavailable` and `minAvailable` in a `PodDisruptionBudget`.
+```yaml
+podDisruptionBudget: 
+     minAvailable: 1
+```
 
-With `minAvailable` of 1, evictions are allowed as long as they leave behind 1 or more healthy pods of the total number of desired replicas.
+or
 
-With `maxAvailable` of 1, evictions are allowed as long as at most 1 unhealthy replica among the total number of desired replicas.
+```yaml
+podDisruptionBudget: 
+     maxUnavailable: 50%
+```
+
+You can specify either `maxUnavailable` or `minAvailable` in a PodDisruptionBudget and it can be expressed as integers or as a percentage.
+
+| Key | Description |
+| :--- | :--- |
+| `minAvailable` | Evictions are allowed as long as they leave behind 1 or more healthy pods of the total number of desired replicas. |
+| `maxUnavailable` | Evictions are allowed as long as at most 1 unhealthy replica among the total number of desired replicas. |
 
 ### Application metrics Envoy Configurations
 

--- a/scripts/devtron-reference-helm-charts/deployment-chart_1-0-0/README.md
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_1-0-0/README.md
@@ -121,6 +121,29 @@ ReadinessProbe:
 | `scheme` | Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.
 | `tcp` | The kubelet will attempt to open a socket to your container on the specified port. If it can establish a connection, the container is considered healthy. |
 
+### Pod Disruption Budget
+
+You can create `PodDisruptionBudget` for each application. A PDB limits the number of pods of a replicated application that are down simultaneously from voluntary disruptions. For example, an application would like to ensure the number of replicas running is never brought below the certain number.
+
+```yaml
+podDisruptionBudget: 
+     minAvailable: 1
+```
+
+or
+
+```yaml
+podDisruptionBudget: 
+     maxUnavailable: 50%
+```
+
+You can specify either `maxUnavailable` or `minAvailable` in a PodDisruptionBudget and it can be expressed as integers or as a percentage.
+
+| Key | Description |
+| :--- | :--- |
+| `minAvailable` | Evictions are allowed as long as they leave behind 1 or more healthy pods of the total number of desired replicas. |
+| `maxUnavailable` | Evictions are allowed as long as at most 1 unhealthy replica among the total number of desired replicas. |
+
 ### Autoscaling
 
 This is connected to HPA and controls scaling up and down in response to request load.

--- a/scripts/devtron-reference-helm-charts/deployment-chart_1-0-0/app-values.yaml
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_1-0-0/app-values.yaml
@@ -1,5 +1,7 @@
 # Mandatory configs
 
+podDisruptionBudget: {}
+
 rolloutLabels: {}
 rolloutAnnotations: {}
 

--- a/scripts/devtron-reference-helm-charts/deployment-chart_1-1-0/README.md
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_1-1-0/README.md
@@ -123,6 +123,29 @@ ReadinessProbe:
 | `scheme` | Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.
 | `tcp` | The kubelet will attempt to open a socket to your container on the specified port. If it can establish a connection, the container is considered healthy. |
 
+### Pod Disruption Budget
+
+You can create `PodDisruptionBudget` for each application. A PDB limits the number of pods of a replicated application that are down simultaneously from voluntary disruptions. For example, an application would like to ensure the number of replicas running is never brought below the certain number.
+
+```yaml
+podDisruptionBudget: 
+     minAvailable: 1
+```
+
+or
+
+```yaml
+podDisruptionBudget: 
+     maxUnavailable: 50%
+```
+
+You can specify either `maxUnavailable` or `minAvailable` in a PodDisruptionBudget and it can be expressed as integers or as a percentage.
+
+| Key | Description |
+| :--- | :--- |
+| `minAvailable` | Evictions are allowed as long as they leave behind 1 or more healthy pods of the total number of desired replicas. |
+| `maxUnavailable` | Evictions are allowed as long as at most 1 unhealthy replica among the total number of desired replicas. |
+
 ### Ambassador Mappings
 
 You can create ambassador mappings to access your applications from outside the cluster. At its core a Mapping resource maps a resource to a service.

--- a/scripts/devtron-reference-helm-charts/deployment-chart_1-1-0/app-values.yaml
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_1-1-0/app-values.yaml
@@ -1,4 +1,5 @@
 # Mandatory configs
+podDisruptionBudget: {}
 
 rolloutLabels: {}
 rolloutAnnotations: {}

--- a/scripts/devtron-reference-helm-charts/deployment-chart_4-18-0/README.md
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_4-18-0/README.md
@@ -142,6 +142,29 @@ ReadinessProbe:
 | `scheme` | Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.
 | `tcp` | The kubelet will attempt to open a socket to your container on the specified port. If it can establish a connection, the container is considered healthy. |
 
+### Pod Disruption Budget
+
+You can create `PodDisruptionBudget` for each application. A PDB limits the number of pods of a replicated application that are down simultaneously from voluntary disruptions. For example, an application would like to ensure the number of replicas running is never brought below the certain number.
+
+```yaml
+podDisruptionBudget: 
+     minAvailable: 1
+```
+
+or
+
+```yaml
+podDisruptionBudget: 
+     maxUnavailable: 50%
+```
+
+You can specify either `maxUnavailable` or `minAvailable` in a PodDisruptionBudget and it can be expressed as integers or as a percentage
+
+| Key | Description |
+| :--- | :--- |
+| `minAvailable` | Evictions are allowed as long as they leave behind 1 or more healthy pods of the total number of desired replicas. |
+| `maxUnavailable` | Evictions are allowed as long as at most 1 unhealthy replica among the total number of desired replicas. |
+
 ### Ambassador Mappings
 
 You can create ambassador mappings to access your applications from outside the cluster. At its core a Mapping resource maps a resource to a service.

--- a/scripts/devtron-reference-helm-charts/deployment-chart_4-18-0/app-values.yaml
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_4-18-0/app-values.yaml
@@ -1,5 +1,6 @@
 # Mandatory configs
 
+podDisruptionBudget: {}
 rolloutLabels: {}
 rolloutAnnotations: {}
 

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-16-0/README.md
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-16-0/README.md
@@ -121,6 +121,23 @@ ReadinessProbe:
 | `scheme` | Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.
 | `tcp` | The kubelet will attempt to open a socket to your container on the specified port. If it can establish a connection, the container is considered healthy. |
 
+### Pod Disruption Budget
+
+```yaml
+podDisruptionBudget: 
+     minAvailable: 1
+     maxUnavailable: 1
+```
+
+You can create `PodDisruptionBudget` for each application. A PDB limits the number of pods of a replicated application that are down simultaneously from voluntary disruptions. For example, an application would like to ensure the number of replicas running is never brought below the certain number.
+
+You can specify maxUnavailable and minAvailable in a PodDisruptionBudget.
+
+| Key | Description |
+| :--- | :--- |
+| `minAvailable` | Evictions are allowed as long as they leave behind 1 or more healthy pods of the total number of desired replicas. |
+| `maxUnavailable` | Evictions are allowed as long as at most 1 unhealthy replica among the total number of desired replicas. |
+
 ### Autoscaling
 
 This is connected to HPA and controls scaling up and down in response to request load.

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-16-0/README.md
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-16-0/README.md
@@ -123,15 +123,21 @@ ReadinessProbe:
 
 ### Pod Disruption Budget
 
+You can create `PodDisruptionBudget` for each application. A PDB limits the number of pods of a replicated application that are down simultaneously from voluntary disruptions. For example, an application would like to ensure the number of replicas running is never brought below the certain number.
+
 ```yaml
 podDisruptionBudget: 
      minAvailable: 1
-     maxUnavailable: 1
 ```
 
-You can create `PodDisruptionBudget` for each application. A PDB limits the number of pods of a replicated application that are down simultaneously from voluntary disruptions. For example, an application would like to ensure the number of replicas running is never brought below the certain number.
+or
 
-You can specify maxUnavailable and minAvailable in a PodDisruptionBudget.
+```yaml
+podDisruptionBudget: 
+     maxUnavailable: 50%
+```
+
+You can specify either `maxUnavailable` or `minAvailable` in a PodDisruptionBudget and it can be expressed as integers or as a percentage
 
 | Key | Description |
 | :--- | :--- |

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-16-0/app-values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-16-0/app-values.yaml
@@ -1,5 +1,7 @@
 # Mandatory configs
 
+podDisruptionBudget: {}
+
 rolloutLabels: {}
 rolloutAnnotations: {}
 

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-17-0/README.md
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-17-0/README.md
@@ -125,15 +125,21 @@ ReadinessProbe:
 
 ### Pod Disruption Budget
 
+You can create `PodDisruptionBudget` for each application. A PDB limits the number of pods of a replicated application that are down simultaneously from voluntary disruptions. For example, an application would like to ensure the number of replicas running is never brought below the certain number.
+
 ```yaml
 podDisruptionBudget: 
      minAvailable: 1
-     maxUnavailable: 1
 ```
 
-You can create `PodDisruptionBudget` for each application. A PDB limits the number of pods of a replicated application that are down simultaneously from voluntary disruptions. For example, an application would like to ensure the number of replicas running is never brought below the certain number.
+or
 
-You can specify maxUnavailable and minAvailable in a PodDisruptionBudget.
+```yaml
+podDisruptionBudget: 
+     maxUnavailable: 50%
+```
+
+You can specify either `maxUnavailable` or `minAvailable` in a PodDisruptionBudget and it can be expressed as integers or as a percentage
 
 | Key | Description |
 | :--- | :--- |

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-17-0/README.md
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-17-0/README.md
@@ -123,6 +123,23 @@ ReadinessProbe:
 | `scheme` | Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.
 | `tcp` | The kubelet will attempt to open a socket to your container on the specified port. If it can establish a connection, the container is considered healthy. |
 
+### Pod Disruption Budget
+
+```yaml
+podDisruptionBudget: 
+     minAvailable: 1
+     maxUnavailable: 1
+```
+
+You can create `PodDisruptionBudget` for each application. A PDB limits the number of pods of a replicated application that are down simultaneously from voluntary disruptions. For example, an application would like to ensure the number of replicas running is never brought below the certain number.
+
+You can specify maxUnavailable and minAvailable in a PodDisruptionBudget.
+
+| Key | Description |
+| :--- | :--- |
+| `minAvailable` | Evictions are allowed as long as they leave behind 1 or more healthy pods of the total number of desired replicas. |
+| `maxUnavailable` | Evictions are allowed as long as at most 1 unhealthy replica among the total number of desired replicas. |
+
 ### Ambassador Mappings
 
 You can create ambassador mappings to access your applications from outside the cluster. At its core a Mapping resource maps a resource to a service.

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-17-0/app-values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-17-0/app-values.yaml
@@ -1,5 +1,7 @@
 # Mandatory configs
 
+podDisruptionBudget: {}
+
 rolloutLabels: {}
 rolloutAnnotations: {}
 

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/README.md
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/README.md
@@ -145,15 +145,21 @@ ReadinessProbe:
 
 ### Pod Disruption Budget
 
-```yaml
-podDisruptionBudget: {}
-     minAvailable: 1
-     maxUnavailable: 1
-```
-
 You can create `PodDisruptionBudget` for each application. A PDB limits the number of pods of a replicated application that are down simultaneously from voluntary disruptions. For example, an application would like to ensure the number of replicas running is never brought below the certain number.
 
-You can specify maxUnavailable and minAvailable in a PodDisruptionBudget.
+```yaml
+podDisruptionBudget: 
+     minAvailable: 1
+```
+
+or
+
+```yaml
+podDisruptionBudget: 
+     maxUnavailable: 50%
+```
+
+You can specify either `maxUnavailable` or `minAvailable` in a PodDisruptionBudget and it can be expressed as integers or as a percentage
 
 | Key | Description |
 | :--- | :--- |

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/README.md
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/README.md
@@ -143,6 +143,23 @@ ReadinessProbe:
 | `scheme` | Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.
 | `tcp` | The kubelet will attempt to open a socket to your container on the specified port. If it can establish a connection, the container is considered healthy. |
 
+### Pod Disruption Budget
+
+```yaml
+podDisruptionBudget: {}
+     minAvailable: 1
+     maxUnavailable: 1
+```
+
+You can create `PodDisruptionBudget` for each application. A PDB limits the number of pods of a replicated application that are down simultaneously from voluntary disruptions. For example, an application would like to ensure the number of replicas running is never brought below the certain number.
+
+You can specify maxUnavailable and minAvailable in a PodDisruptionBudget.
+
+| Key | Description |
+| :--- | :--- |
+| `minAvailable` | Evictions are allowed as long as they leave behind 1 or more healthy pods of the total number of desired replicas. |
+| `maxUnavailable` | Evictions are allowed as long as at most 1 unhealthy replica among the total number of desired replicas. |
+
 ### Ambassador Mappings
 
 You can create ambassador mappings to access your applications from outside the cluster. At its core a Mapping resource maps a resource to a service.

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/app-values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/app-values.yaml
@@ -1,4 +1,5 @@
 # Mandatory configs
+podDisruptionBudget: {}
 
 rolloutLabels: {}
 rolloutAnnotations: {}

--- a/scripts/devtron-reference-helm-charts/reference-chart_5-0-0/README.md
+++ b/scripts/devtron-reference-helm-charts/reference-chart_5-0-0/README.md
@@ -1,5 +1,5 @@
 
-# Rollout Deployment Chart - v4.18
+# Rollout Deployment Chart - v5.0
 
 ## 1. Yaml File -
 
@@ -142,6 +142,29 @@ ReadinessProbe:
 | `httpHeaders` | Custom headers to set in the request. HTTP allows repeated headers,You can override the default headers by defining .httpHeaders for the probe. |
 | `scheme` | Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.
 | `tcp` | The kubelet will attempt to open a socket to your container on the specified port. If it can establish a connection, the container is considered healthy. |
+
+### Pod Disruption Budget
+
+You can create `PodDisruptionBudget` for each application. A PDB limits the number of pods of a replicated application that are down simultaneously from voluntary disruptions. For example, an application would like to ensure the number of replicas running is never brought below the certain number.
+
+```yaml
+podDisruptionBudget: 
+     minAvailable: 1
+```
+
+or
+
+```yaml
+podDisruptionBudget: 
+     maxUnavailable: 50%
+```
+
+You can specify either `maxUnavailable` or `minAvailable` in a PodDisruptionBudget and it can be expressed as integers or as a percentage
+
+| Key | Description |
+| :--- | :--- |
+| `minAvailable` | Evictions are allowed as long as they leave behind 1 or more healthy pods of the total number of desired replicas. |
+| `maxUnavailable` | Evictions are allowed as long as at most 1 unhealthy replica among the total number of desired replicas. |
 
 ### Ambassador Mappings
 

--- a/scripts/devtron-reference-helm-charts/reference-chart_5-0-0/app-values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_5-0-0/app-values.yaml
@@ -1,5 +1,5 @@
 # Mandatory configs
-
+podDisruptionBudget: {}
 rolloutLabels: {}
 rolloutAnnotations: {}
 

--- a/scripts/devtron-reference-helm-charts/reference-chart_5-0-0/env-values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_5-0-0/env-values.yaml
@@ -1,3 +1,4 @@
+podDisruptionBudget: {}
 replicaCount: 1
 MaxSurge: 1
 MaxUnavailable: 0

--- a/scripts/devtron-reference-helm-charts/reference-chart_5-0-0/env-values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_5-0-0/env-values.yaml
@@ -1,4 +1,3 @@
-podDisruptionBudget: {}
 replicaCount: 1
 MaxSurge: 1
 MaxUnavailable: 0


### PR DESCRIPTION
# Description

Updated Devtron reference helm charts with podDisruptionBudget to show in README as well in Devtron UI

## Checklist:

* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note
Users using Rollout chart - 4-16-0, 4-17-0, 4-18-0 will now be able to see the podDisruptionBudget field in the Deployment template.
```

