### PR TITLE
fix: Unable to delete chart group with existing helm chart

### DIFF
--- a/pkg/appStore/deployment/repository/ChartGroupEntry.go
+++ b/pkg/appStore/deployment/repository/ChartGroupEntry.go
@@ -110,8 +110,7 @@ func (impl *ChartGroupEntriesRepositoryImpl) MarkChartGroupEntriesDeleted(chartG
 	var chartGroupEntries []*ChartGroupEntry
 	_, err := tx.Model(&chartGroupEntries).
 		Where("id in (?)", pg.In(chartGroupId)).
-		Set("deleted = ", true).
+		Set("deleted = ?", true).
 		Update()
 	return chartGroupEntries, err
 }
-


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
These changes fix the issue where users were unable to delete chart group with existing helm chart and had to delete all existing helm chart one by one in order to delete the chart group.

Fixes #3460

## How Has This Been Tested?
- [x] Tested locally

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

