### PR TITLE
fix: Helm app deployment history page breaking due to user details not found

### DIFF
--- a/pkg/appStore/deployment/tool/gitops/AppStoreDeploymentArgoCdService.go
+++ b/pkg/appStore/deployment/tool/gitops/AppStoreDeploymentArgoCdService.go
@@ -394,10 +394,14 @@ func (impl AppStoreDeploymentArgoCdServiceImpl) GetDeploymentHistory(ctx context
 			return result, err
 		}
 		for _, updateHistory := range versionHistory {
-			user, err := impl.userService.GetById(updateHistory.CreatedBy)
-			if err != nil {
+			emailId := "anonymous"
+			user, err := impl.userService.GetByIdIncludeDeleted(updateHistory.CreatedBy)
+			if err != nil && !util.IsErrNoRows(err) {
 				impl.Logger.Errorw("error while fetching user Details", "error", err)
 				return result, err
+			}
+			if user != nil {
+				emailId = user.EmailId
 			}
 			history = append(history, &client.HelmAppDeploymentDetail{
 				ChartMetadata: &client.ChartMetadata{
@@ -407,7 +411,7 @@ func (impl AppStoreDeploymentArgoCdServiceImpl) GetDeploymentHistory(ctx context
 					Home:         installedAppVersionModel.AppStoreApplicationVersion.Home,
 					Sources:      sources,
 				},
-				DeployedBy:   user.EmailId,
+				DeployedBy:   emailId,
 				DockerImages: []string{installedAppVersionModel.AppStoreApplicationVersion.AppVersion},
 				DeployedAt: &timestamp.Timestamp{
 					Seconds: updateHistory.CreatedOn.Unix(),


### PR DESCRIPTION
# Description

When a user has previously deployed any helm application and after that the user is deleted. Then post the user deletion  event the deployment history page of helm apps will break . It was Handled for devtron app where the deleted user is marked as anonymous but it is not handled  in helm apps. This PR will fix that issue

Fixes #3415 

## How Has This Been Tested?

- [x] Helm Apps Deployment History 
  - [x] Deployed by Admin
  - [x] Deployed by user
  - [x] Deployed by an deleted user

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

