### PR TITLE
chore: adjust duplicate action threshold

### DIFF
--- a/.github/workflows/azure-devops-issue-sync.yml
+++ b/.github/workflows/azure-devops-issue-sync.yml
@@ -60,9 +60,9 @@ jobs:
           # Label to set, when potential duplicates are detected.
           label: potential-duplicate
           # Get issues with state to compare. Supported state: 'all', 'closed', 'open'.
-          state: all
+          state: open
           # If similarity is higher than this threshold([0,1]), issue will be marked as duplicate.
-          threshold: 0.4
+          threshold: 0.6
           # Reactions to be add to comment when potential duplicates are detected.
           # Available reactions: "-1", "+1", "confused", "laugh", "heart", "hooray", "rocket", "eyes"
           reactions: 'eyes, confused'


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
Adjusted github duplicate action threshold to 0.6



## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

