### PR TITLE
fix: invalid post deployment status in App group

### DIFF
--- a/pkg/pipeline/CdHandler.go
+++ b/pkg/pipeline/CdHandler.go
@@ -1372,7 +1372,7 @@ func (impl *CdHandlerImpl) FetchAppWorkflowStatusForTriggerViewForEnvironment(re
 				cdWorkflowStatus.PreStatus = statusMap[item.WfrId]
 			} else if item.WorkflowType == WorklowTypeDeploy {
 				cdWorkflowStatus.DeployStatus = statusMap[item.WfrId]
-			} else if item.WorkflowType == WorklowTypePre {
+			} else if item.WorkflowType == WorklowTypePost {
 				cdWorkflowStatus.PostStatus = statusMap[item.WfrId]
 			}
 			cdMap[item.PipelineId] = cdWorkflowStatus


### PR DESCRIPTION
# Description

This PR fixed the issue: If any app having pipe line with pre post CD and it is running healthy but if u again deploy the cd pipe line in devtron app then check the post CD status in App group

Fixes #3674 

## How Has This Been Tested?
- [x] Devtron App:
  - [x] With PRE, DEPLOY and POST:
    - [x] App Group Page:
    - [x] Devtron App Page:
  - [x] With PRE and DEPLOY:
    - [x] App Group Page:
    - [x] Devtron App Page:
  - [x] With DEPLOY and POST:
    - [x] App Group Page:
    - [x] Devtron App Page:
  - [x] With only DEPLOY:
    - [x] App Group Page:
    - [x] Devtron App Page:

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

