### PR TITLE
fix: Security scan list fix

### DIFF
--- a/internal/sql/repository/security/ImageScanDeployInfoRepository.go
+++ b/internal/sql/repository/security/ImageScanDeployInfoRepository.go
@@ -186,7 +186,7 @@ func (impl ImageScanDeployInfoRepositoryImpl) scanListQueryWithoutObject(request
 	}
 	query = query + " INNER JOIN environment env on env.id=info.env_id"
 	query = query + " INNER JOIN cluster clus on clus.id=env.cluster_id"
-	query = query + " WHERE info.scan_object_meta_id > 0 and env.active=true"
+	query = query + " WHERE info.scan_object_meta_id > 0 and env.active=true and info.is_latest_image_scanned=true"
 	if len(deployInfoIds) > 0 {
 		ids := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(deployInfoIds)), ","), "[]")
 		query = query + " AND info.id IN (" + ids + ")"

--- a/internal/sql/repository/security/ImageScanDeployInfoRepository.go
+++ b/internal/sql/repository/security/ImageScanDeployInfoRepository.go
@@ -41,6 +41,7 @@ type ImageScanDeployInfo struct {
 	ObjectType                  string   `sql:"object_type,notnull"`
 	EnvId                       int      `sql:"env_id,notnull"`
 	ClusterId                   int      `sql:"cluster_id,notnull"`
+	IsLastImageScanned          bool     `sql:"is_last_image_scanned"`
 	sql.AuditLog
 }
 

--- a/internal/sql/repository/security/ImageScanDeployInfoRepository.go
+++ b/internal/sql/repository/security/ImageScanDeployInfoRepository.go
@@ -41,7 +41,7 @@ type ImageScanDeployInfo struct {
 	ObjectType                  string   `sql:"object_type,notnull"`
 	EnvId                       int      `sql:"env_id,notnull"`
 	ClusterId                   int      `sql:"cluster_id,notnull"`
-	IsLastImageScanned          bool     `sql:"is_last_image_scanned"`
+	IsLatestImageScanned        bool     `sql:"is_latest_image_scanned"`
 	sql.AuditLog
 }
 

--- a/pkg/app/AppService.go
+++ b/pkg/app/AppService.go
@@ -181,7 +181,7 @@ type AppService interface {
 	GetConfigMapAndSecretJson(appId int, envId int, pipelineId int) ([]byte, error)
 	UpdateCdWorkflowRunnerByACDObject(app *v1alpha1.Application, cdWfrId int, updateTimedOutStatus bool) error
 	GetCmSecretNew(appId int, envId int, isJob bool) (*bean.ConfigMapJson, *bean.ConfigSecretJson, error)
-	MarkImageScanDeployed(appId int, envId int, imageDigest string, clusterId int) error
+	MarkImageScanDeployed(appId int, envId int, imageDigest string, clusterId int, isScanEnabled bool) error
 	UpdateDeploymentStatusForGitOpsPipelines(app *v1alpha1.Application, statusTime time.Time, isAppStore bool) (bool, bool, error)
 	WriteCDSuccessEvent(appId int, envId int, override *chartConfig.PipelineOverride)
 	GetGitOpsRepoPrefix() string
@@ -1709,11 +1709,9 @@ func (impl *AppServiceImpl) TriggerPipeline(overrideRequest *bean.ValuesOverride
 
 	go impl.WriteCDTriggerEvent(overrideRequest, valuesOverrideResponse.Artifact, valuesOverrideResponse.PipelineOverride.PipelineReleaseCounter, valuesOverrideResponse.PipelineOverride.Id)
 
-	if valuesOverrideResponse.Artifact.ScanEnabled {
-		_, span := otel.Tracer("orchestrator").Start(ctx, "MarkImageScanDeployed")
-		_ = impl.MarkImageScanDeployed(overrideRequest.AppId, valuesOverrideResponse.EnvOverride.TargetEnvironment, valuesOverrideResponse.Artifact.ImageDigest, overrideRequest.ClusterId)
-		span.End()
-	}
+	_, spann := otel.Tracer("orchestrator").Start(ctx, "MarkImageScanDeployed")
+	_ = impl.MarkImageScanDeployed(overrideRequest.AppId, valuesOverrideResponse.EnvOverride.TargetEnvironment, valuesOverrideResponse.Artifact.ImageDigest, overrideRequest.ClusterId, valuesOverrideResponse.Artifact.ScanEnabled)
+	spann.End()
 
 	middleware.CdTriggerCounter.WithLabelValues(overrideRequest.AppName, overrideRequest.EnvName).Inc()
 
@@ -1862,7 +1860,7 @@ func (impl *AppServiceImpl) autoHealChartLocationInChart(ctx context.Context, en
 	return nil
 }
 
-func (impl *AppServiceImpl) MarkImageScanDeployed(appId int, envId int, imageDigest string, clusterId int) error {
+func (impl *AppServiceImpl) MarkImageScanDeployed(appId int, envId int, imageDigest string, clusterId int, isScanEnabled bool) error {
 	impl.logger.Debugw("mark image scan deployed for normal app, from cd auto or manual trigger", "imageDigest", imageDigest)
 	executionHistory, err := impl.imageScanHistoryRepository.FindByImageDigest(imageDigest)
 	if err != nil && err != pg.ErrNoRows {
@@ -1880,13 +1878,14 @@ func (impl *AppServiceImpl) MarkImageScanDeployed(appId int, envId int, imageDig
 	ot, err := impl.imageScanDeployInfoRepository.FindByTypeMetaAndTypeId(appId, security.ScanObjectType_APP) //todo insure this touple unique in db
 	if err != nil && err != pg.ErrNoRows {
 		return err
-	} else if err == pg.ErrNoRows {
+	} else if err == pg.ErrNoRows && isScanEnabled {
 		imageScanDeployInfo := &security.ImageScanDeployInfo{
 			ImageScanExecutionHistoryId: ids,
 			ScanObjectMetaId:            appId,
 			ObjectType:                  security.ScanObjectType_APP,
 			EnvId:                       envId,
 			ClusterId:                   clusterId,
+			IsLastImageScanned:          true,
 			AuditLog: sql.AuditLog{
 				CreatedOn: time.Now(),
 				CreatedBy: 1,
@@ -1902,6 +1901,7 @@ func (impl *AppServiceImpl) MarkImageScanDeployed(appId int, envId int, imageDig
 	} else {
 		// Updating Execution history for Latest Deployment to fetch out security Vulnerabilities for latest deployed info
 		ot.ImageScanExecutionHistoryId = ids
+		ot.IsLastImageScanned = isScanEnabled
 		err = impl.imageScanDeployInfoRepository.Update(ot)
 		if err != nil {
 			impl.logger.Errorw("error in updating deploy info for latest deployed image", "err", err)

--- a/pkg/app/AppService.go
+++ b/pkg/app/AppService.go
@@ -1885,7 +1885,7 @@ func (impl *AppServiceImpl) MarkImageScanDeployed(appId int, envId int, imageDig
 			ObjectType:                  security.ScanObjectType_APP,
 			EnvId:                       envId,
 			ClusterId:                   clusterId,
-			IsLastImageScanned:          true,
+			IsLatestImageScanned:        true,
 			AuditLog: sql.AuditLog{
 				CreatedOn: time.Now(),
 				CreatedBy: 1,
@@ -1901,7 +1901,7 @@ func (impl *AppServiceImpl) MarkImageScanDeployed(appId int, envId int, imageDig
 	} else {
 		// Updating Execution history for Latest Deployment to fetch out security Vulnerabilities for latest deployed info
 		ot.ImageScanExecutionHistoryId = ids
-		ot.IsLastImageScanned = isScanEnabled
+		ot.IsLatestImageScanned = isScanEnabled
 		err = impl.imageScanDeployInfoRepository.Update(ot)
 		if err != nil {
 			impl.logger.Errorw("error in updating deploy info for latest deployed image", "err", err)

--- a/scripts/sql/169_security_scan_list_fix.down.sql
+++ b/scripts/sql/169_security_scan_list_fix.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE image_scan_deploy_info DROP COLUMN is_latest_image_scanned;

--- a/scripts/sql/169_security_scan_list_fix.up.sql
+++ b/scripts/sql/169_security_scan_list_fix.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE image_scan_deploy_info ADD COLUMN is_latest_image_scanned BOOLEAN DEFAULT TRUE;

--- a/scripts/sql/169_security_scan_list_fix.up.sql
+++ b/scripts/sql/169_security_scan_list_fix.up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE image_scan_deploy_info ADD COLUMN is_latest_image_scanned BOOLEAN DEFAULT TRUE;
+ALTER TABLE image_scan_deploy_info ADD COLUMN IF NOT EXISTS is_latest_image_scanned BOOLEAN DEFAULT TRUE;


### PR DESCRIPTION
# Description

Fix For 

1: user created a new app with security scan on but all kind of vulnerabilities is allowed .
2: app get deployed , now go to the security section , go to security scan tab , app will be visible there .
3:now i turned off the security scan  and again create new image of app and deploy that image with no vulnerability scanning . as scanning was off so in new build no vulnerabilities  would be listed .
4: But the security scan tab still the app in the list with timestamp of when it was earlier published with security scan .

Fixes #

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [x] Test locally
- [x] Test  by deploying it in VM
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [x] I have added all the required unit/api test cases.
