### PR TITLE
fix: data not flowing into table ImageScanDeployInfo for triggers

### DIFF
--- a/internal/sql/repository/security/ImageScanDeployInfoRepository.go
+++ b/internal/sql/repository/security/ImageScanDeployInfoRepository.go
@@ -145,13 +145,13 @@ func (impl ImageScanDeployInfoRepositoryImpl) FetchListingGroupByObject(size int
 }
 
 func (impl ImageScanDeployInfoRepositoryImpl) FetchByAppIdAndEnvId(appId int, envId int, objectType []string) (*ImageScanDeployInfo, error) {
-	var model ImageScanDeployInfo
-	err := impl.dbConnection.Model(&model).
+	var model *ImageScanDeployInfo
+	err := impl.dbConnection.Model(model).
 		Where("scan_object_meta_id = ?", appId).
 		Where("env_id = ?", envId).Where("object_type in (?)", pg.In(objectType)).
 		Order("created_on desc").Limit(1).
 		Select()
-	return &model, err
+	return model, err
 }
 
 func (impl ImageScanDeployInfoRepositoryImpl) FindByTypeMetaAndTypeId(scanObjectMetaId int, objectType string) (*ImageScanDeployInfo, error) {

--- a/pkg/app/AppService.go
+++ b/pkg/app/AppService.go
@@ -2005,7 +2005,7 @@ func (impl *AppServiceImpl) MarkImageScanDeployed(appId int, envId int, imageDig
 	ot, err := impl.imageScanDeployInfoRepository.FetchByAppIdAndEnvId(appId, envId, []string{security.ScanObjectType_APP})
 	if err != nil && err != pg.ErrNoRows {
 		return err
-	} else if err == pg.ErrNoRows {
+	} else if err == pg.ErrNoRows || ot == nil {
 		imageScanDeployInfo := &security.ImageScanDeployInfo{
 			ImageScanExecutionHistoryId: ids,
 			ScanObjectMetaId:            appId,

--- a/pkg/app/AppService.go
+++ b/pkg/app/AppService.go
@@ -2001,7 +2001,8 @@ func (impl *AppServiceImpl) MarkImageScanDeployed(appId int, envId int, imageDig
 	var ids []int
 	ids = append(ids, executionHistory.Id)
 
-	ot, err := impl.imageScanDeployInfoRepository.FindByTypeMetaAndTypeId(appId, security.ScanObjectType_APP) //todo insure this touple unique in db
+	//ot, err := impl.imageScanDeployInfoRepository.FindByTypeMetaAndTypeId(appId, security.ScanObjectType_APP) //todo insure this touple unique in db
+	ot, err := impl.imageScanDeployInfoRepository.FetchByAppIdAndEnvId(appId, envId, []string{security.ScanObjectType_APP})
 	if err != nil && err != pg.ErrNoRows {
 		return err
 	} else if err == pg.ErrNoRows {

--- a/pkg/app/AppService.go
+++ b/pkg/app/AppService.go
@@ -2001,7 +2001,6 @@ func (impl *AppServiceImpl) MarkImageScanDeployed(appId int, envId int, imageDig
 	var ids []int
 	ids = append(ids, executionHistory.Id)
 
-	//ot, err := impl.imageScanDeployInfoRepository.FindByTypeMetaAndTypeId(appId, security.ScanObjectType_APP) //todo insure this touple unique in db
 	ot, err := impl.imageScanDeployInfoRepository.FetchByAppIdAndEnvId(appId, envId, []string{security.ScanObjectType_APP})
 	if err != nil && err != pg.ErrNoRows {
 		return err

--- a/scripts/sql/171_remove_index_image_scan_deploy_info_down.sql
+++ b/scripts/sql/171_remove_index_image_scan_deploy_info_down.sql
@@ -1,1 +1,2 @@
+DROP index image_scan_deploy_info;
 CREATE UNIQUE INDEX image_scan_deploy_info_unique ON public.image_scan_deploy_info USING btree (scan_object_meta_id, object_type);

--- a/scripts/sql/171_remove_index_image_scan_deploy_info_down.sql
+++ b/scripts/sql/171_remove_index_image_scan_deploy_info_down.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX image_scan_deploy_info_unique ON public.image_scan_deploy_info USING btree (scan_object_meta_id, object_type);

--- a/scripts/sql/171_remove_index_image_scan_deploy_info_up.sql
+++ b/scripts/sql/171_remove_index_image_scan_deploy_info_up.sql
@@ -1,1 +1,2 @@
 DROP index image_scan_deploy_info_unique;
+CREATE INDEX image_scan_deploy_info ON public.image_scan_deploy_info USING btree (scan_object_meta_id, object_type);

--- a/scripts/sql/171_remove_index_image_scan_deploy_info_up.sql
+++ b/scripts/sql/171_remove_index_image_scan_deploy_info_up.sql
@@ -1,0 +1,1 @@
+DROP index image_scan_deploy_info_unique;


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes #3538 

For CD triggers in an app with multiple CD pipelines, data was being persisted for only app and first environment. The fix replaces the get call to fetch data on both app and env instead of just app and data flows separately for each environment

## How Has This Been Tested?
Tested manually for app with multiple CD with a repo containing vulnerabilities.
Banner was visible after a fresh trigger for all environments
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

