### PR TITLE
feat: added env variable to skip gitops validation on create/update

### DIFF
--- a/pkg/app/AppService.go
+++ b/pkg/app/AppService.go
@@ -1698,7 +1698,7 @@ func (impl *AppServiceImpl) CreateGitopsRepo(app *app.App, userId int32) (gitops
 	gitOpsRepoName := impl.chartTemplateService.GetGitOpsRepoName(app.AppName)
 	chartGitAttr, err = impl.chartTemplateService.CreateGitRepositoryForApp(gitOpsRepoName, chart.ReferenceTemplate, chart.ChartVersion, userId)
 	if err != nil {
-		impl.logger.Errorw("error in pushing chart to git ", "path", chartGitAttr.ChartLocation, "err", err)
+		impl.logger.Errorw("error in pushing chart to git ", "gitOpsRepoName", gitOpsRepoName, "err", err)
 		return "", nil, err
 	}
 	return gitOpsRepoName, chartGitAttr, nil

--- a/pkg/gitops/GitOpsConfigService.go
+++ b/pkg/gitops/GitOpsConfigService.go
@@ -81,10 +81,11 @@ const (
 )
 
 type DetailedErrorGitOpsConfigResponse struct {
-	SuccessfulStages []string          `json:"successfulStages"`
-	StageErrorMap    map[string]string `json:"stageErrorMap"`
-	ValidatedOn      time.Time         `json:"validatedOn"`
-	DeleteRepoFailed bool              `json:"deleteRepoFailed"`
+	SuccessfulStages    []string          `json:"successfulStages"`
+	StageErrorMap       map[string]string `json:"stageErrorMap"`
+	ValidatedOn         time.Time         `json:"validatedOn"`
+	DeleteRepoFailed    bool              `json:"deleteRepoFailed"`
+	IsValidationSkipped bool              `json:"isValidationSkipped"`
 }
 
 type GitOpsConfigServiceImpl struct {
@@ -688,7 +689,9 @@ func (impl *GitOpsConfigServiceImpl) GetGitOpsConfigActive() (*bean2.GitOpsConfi
 
 func (impl *GitOpsConfigServiceImpl) GitOpsValidateDryRun(config *bean2.GitOpsConfigDto) DetailedErrorGitOpsConfigResponse {
 	if impl.globalEnvVariables.SkipGitOpsValidation {
-		return DetailedErrorGitOpsConfigResponse{}
+		return DetailedErrorGitOpsConfigResponse{
+			IsValidationSkipped: true,
+		}
 	}
 	if config.Token == "" {
 		model, err := impl.gitOpsRepository.GetGitOpsConfigById(config.Id)

--- a/pkg/gitops/GitOpsConfigService.go
+++ b/pkg/gitops/GitOpsConfigService.go
@@ -81,11 +81,10 @@ const (
 )
 
 type DetailedErrorGitOpsConfigResponse struct {
-	SuccessfulStages    []string          `json:"successfulStages"`
-	StageErrorMap       map[string]string `json:"stageErrorMap"`
-	ValidatedOn         time.Time         `json:"validatedOn"`
-	DeleteRepoFailed    bool              `json:"deleteRepoFailed"`
-	IsValidationSkipped bool              `json:"isValidationSkipped"`
+	SuccessfulStages []string          `json:"successfulStages"`
+	StageErrorMap    map[string]string `json:"stageErrorMap"`
+	ValidatedOn      time.Time         `json:"validatedOn"`
+	DeleteRepoFailed bool              `json:"deleteRepoFailed"`
 }
 
 type GitOpsConfigServiceImpl struct {
@@ -689,9 +688,7 @@ func (impl *GitOpsConfigServiceImpl) GetGitOpsConfigActive() (*bean2.GitOpsConfi
 
 func (impl *GitOpsConfigServiceImpl) GitOpsValidateDryRun(config *bean2.GitOpsConfigDto) DetailedErrorGitOpsConfigResponse {
 	if impl.globalEnvVariables.SkipGitOpsValidation {
-		return DetailedErrorGitOpsConfigResponse{
-			IsValidationSkipped: true,
-		}
+		return DetailedErrorGitOpsConfigResponse{}
 	}
 	if config.Token == "" {
 		model, err := impl.gitOpsRepository.GetGitOpsConfigById(config.Id)

--- a/util/GlobalConfig.go
+++ b/util/GlobalConfig.go
@@ -7,7 +7,8 @@ import (
 )
 
 type GlobalEnvVariables struct {
-	GitOpsRepoPrefix string `env:"GITOPS_REPO_PREFIX" envDefault:""`
+	GitOpsRepoPrefix     string `env:"GITOPS_REPO_PREFIX" envDefault:""`
+	SkipGitOpsValidation bool   `env:"SKIP_GITOPS_VALIDATION" envDefault:"false"`
 }
 
 func GetGlobalEnvVariables() (*GlobalEnvVariables, error) {

--- a/wire_gen.go
+++ b/wire_gen.go
@@ -651,7 +651,7 @@ func InitializeApp() (*App, error) {
 	imageScanRouterImpl := router.NewImageScanRouterImpl(imageScanRestHandlerImpl)
 	policyRestHandlerImpl := restHandler.NewPolicyRestHandlerImpl(sugaredLogger, policyServiceImpl, userServiceImpl, userAuthServiceImpl, enforcerImpl, enforcerUtilImpl, environmentServiceImpl)
 	policyRouterImpl := router.NewPolicyRouterImpl(policyRestHandlerImpl)
-	gitOpsConfigServiceImpl := gitops.NewGitOpsConfigServiceImpl(sugaredLogger, gitOpsConfigRepositoryImpl, k8sUtil, acdAuthConfig, clusterServiceImplExtended, environmentServiceImpl, versionServiceImpl, gitFactory, chartTemplateServiceImpl, argoUserServiceImpl, serviceClientImpl)
+	gitOpsConfigServiceImpl := gitops.NewGitOpsConfigServiceImpl(sugaredLogger, globalEnvVariables, gitOpsConfigRepositoryImpl, k8sUtil, acdAuthConfig, clusterServiceImplExtended, environmentServiceImpl, versionServiceImpl, gitFactory, chartTemplateServiceImpl, argoUserServiceImpl, serviceClientImpl)
 	gitOpsConfigRestHandlerImpl := restHandler.NewGitOpsConfigRestHandlerImpl(sugaredLogger, gitOpsConfigServiceImpl, userServiceImpl, validate, enforcerImpl, teamServiceImpl, gitOpsConfigRepositoryImpl)
 	gitOpsConfigRouterImpl := router.NewGitOpsConfigRouterImpl(gitOpsConfigRestHandlerImpl)
 	dashboardConfig, err := dashboard.GetConfig()


### PR DESCRIPTION
# Description
Added an env variable to skip GitOps validation in Global configuration.

Fixes #3961

## How Has This Been Tested?
- [x] GitHub
  - [x] Save
  - [x] Update
  - [x] Validate

- [x] GitLab
  - [x] Save
  - [x] Update
  - [x] Validate

- [x] Azure
  - [x] Save
  - [x] Update
  - [x] Validate
  
- [x] Bitbucket 
  - [x] Save
  - [x] Update
  - [x] Validate

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

