### PR TITLE
fix:Workflow GET API doesn't fetches the CI pipelines overrides and also remove sample from API

### DIFF
--- a/api/appbean/AppDetail.go
+++ b/api/appbean/AppDetail.go
@@ -3,6 +3,7 @@ package appbean
 import (
 	"github.com/devtron-labs/devtron/internal/sql/models"
 	"github.com/devtron-labs/devtron/internal/sql/repository/pipelineConfig"
+	bean2 "github.com/devtron-labs/devtron/pkg/bean"
 	"github.com/devtron-labs/devtron/pkg/chartRepo/repository"
 	"github.com/devtron-labs/devtron/pkg/pipeline/bean"
 )
@@ -90,6 +91,7 @@ type CiPipelineDetails struct {
 	ParentCiPipeline          int                         `json:"parentCiPipeline,omitempty"`
 	ParentAppId               int                         `json:"parentAppId,omitempty"`
 	LinkedCount               int                         `json:"linkedCount,omitempty"`
+	DockerConfigOverride      bean2.DockerConfigOverride  `json:"dockerConfigOverride"`
 }
 
 type CiPipelineMaterialConfig struct {

--- a/api/restHandler/CoreAppRestHandler.go
+++ b/api/restHandler/CoreAppRestHandler.go
@@ -722,6 +722,7 @@ func (handler CoreAppRestHandlerImpl) buildCiPipelineResp(appId int, ciPipeline 
 		ParentCiPipeline:         ciPipeline.ParentCiPipeline,
 		ParentAppId:              ciPipeline.ParentAppId,
 		LinkedCount:              ciPipeline.LinkedCount,
+		DockerConfigOverride:     ciPipeline.DockerConfigOverride,
 	}
 
 	//build ciPipelineMaterial resp


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
It bugs out when you hit workflow get API. Workflow GET api fetches the ci pipeline details and cd-pipeline details along with env overrides. But It doesn't fetches the CI pipeline override details. For example if container registry is overridden at ci-pipeline level then that would not be fetched.
Fixes #3671

## How Has This Been Tested?
All test are performed locally 

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [x] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

