### PR TITLE
fix: not able to delete no-gitops cd pipeline fix

### DIFF
--- a/api/helm-app/models/customErrors.go
+++ b/api/helm-app/models/customErrors.go
@@ -1,0 +1,13 @@
+package models
+
+type NamespaceNotExistError struct {
+	Err error
+}
+
+func (err NamespaceNotExistError) Error() string {
+	return err.Err.Error()
+}
+
+func (err *NamespaceNotExistError) Unwrap() error {
+	return err.Err
+}

--- a/pkg/pipeline/PipelineBuilder.go
+++ b/pkg/pipeline/PipelineBuilder.go
@@ -20,7 +20,9 @@ package pipeline
 import (
 	"context"
 	"encoding/json"
+	errors2 "errors"
 	"fmt"
+	models2 "github.com/devtron-labs/devtron/api/helm-app/models"
 	"github.com/devtron-labs/devtron/pkg/variables"
 	"github.com/devtron-labs/devtron/pkg/variables/parsers"
 	repository6 "github.com/devtron-labs/devtron/pkg/variables/repository"
@@ -2291,7 +2293,7 @@ func (impl *PipelineBuilderImpl) DeleteCdPipeline(pipeline *pipelineConfig.Pipel
 				Namespace:   pipeline.Environment.Namespace,
 			}
 			deleteResourceResponse, err := impl.helmAppService.DeleteApplication(ctx, appIdentifier)
-			if forceDelete {
+			if forceDelete || errors2.As(err, &models2.NamespaceNotExistError{}) {
 				impl.logger.Warnw("error while deletion of helm application, ignore error and delete from db since force delete req", "error", err, "pipelineId", pipeline.Id)
 			} else {
 				if err != nil {

--- a/util/k8s/K8sUtil.go
+++ b/util/k8s/K8sUtil.go
@@ -197,7 +197,7 @@ func (impl K8sUtil) CreateNsIfNotExists(namespace string, clusterConfig *Cluster
 		impl.logger.Errorw("error", "error", err, "clusterConfig", clusterConfig)
 		return err
 	}
-	exists, err := impl.checkIfNsExists(namespace, v12Client)
+	exists, err := impl.CheckIfNsExists(namespace, v12Client)
 	if err != nil {
 		impl.logger.Errorw("error", "error", err, "clusterConfig", clusterConfig)
 		return err
@@ -211,7 +211,7 @@ func (impl K8sUtil) CreateNsIfNotExists(namespace string, clusterConfig *Cluster
 	return err
 }
 
-func (impl K8sUtil) checkIfNsExists(namespace string, client *v12.CoreV1Client) (exists bool, err error) {
+func (impl K8sUtil) CheckIfNsExists(namespace string, client *v12.CoreV1Client) (exists bool, err error) {
 	ns, err := client.Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
 	//ns, err := impl.k8sClient.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
 	impl.logger.Debugw("ns fetch", "name", namespace, "res", ns)

--- a/util/k8s/K8sUtil_test.go
+++ b/util/k8s/K8sUtil_test.go
@@ -60,7 +60,7 @@ func TestK8sUtil_checkIfNsExists(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			impl := k8sUtilClient
 			k8s, _ := impl.GetCoreV1Client(clusterConfig)
-			gotExists, err := impl.checkIfNsExists(tt.namespace, k8s)
+			gotExists, err := impl.CheckIfNsExists(tt.namespace, k8s)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("K8sUtil.checkIfNsExists() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
This pr aims at fixing the below issue:-
Create an env for namespace on devtron, and delete the namespace manually using kubectl.
Create a new cd-pipeline for the same environment and try to deploy it will fail as the namespace doesn't exist.
Now try to delete the cd-pipeline.
Fixes #3885 

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
 tested the fix with multiple pipeline deploying the deleted namespace and then deleting the namespace with kubectl
 - tested the fix with multiple pipeline deploying the deleted namespace and then deleting the namespace with kubectl

<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

