### PR TITLE
fix: Deployment Template HCL parsing with % keyword

### DIFF
--- a/pkg/variables/parsers/VariableTemplateParser.go
+++ b/pkg/variables/parsers/VariableTemplateParser.go
@@ -213,12 +213,13 @@ func (impl *VariableTemplateParserImpl) convertToHclCompatible(templateType Vari
 		}
 		template = fmt.Sprintf(`{"root":%s}`, template)
 	}
-	template = impl.diluteExistingHclVars(template)
+	template = impl.diluteExistingHclVars(template, "$")
+	template = impl.diluteExistingHclVars(template, "%")
 	return impl.convertToHclExpression(template), nil
 }
 
-func (impl *VariableTemplateParserImpl) diluteExistingHclVars(template string) string {
-	hclVarRegex := regexp.MustCompile(`\$\{`)
+func (impl *VariableTemplateParserImpl) diluteExistingHclVars(template string, templateControlKeyword string) string {
+	hclVarRegex := regexp.MustCompile(templateControlKeyword + `\{`)
 	indexesData := hclVarRegex.FindAllIndex([]byte(template), -1)
 	var strBuilder strings.Builder
 	strBuilder.Grow(len(template))
@@ -226,7 +227,7 @@ func (impl *VariableTemplateParserImpl) diluteExistingHclVars(template string) s
 	for _, datum := range indexesData {
 		startIndex := datum[0]
 		endIndex := datum[1]
-		strBuilder.WriteString(template[currentIndex:startIndex] + "$" + template[startIndex:endIndex])
+		strBuilder.WriteString(template[currentIndex:startIndex] + templateControlKeyword + template[startIndex:endIndex])
 		currentIndex = endIndex
 	}
 	if currentIndex <= len(template) {

--- a/pkg/variables/parsers/VariableTemplateParser_test.go
+++ b/pkg/variables/parsers/VariableTemplateParser_test.go
@@ -35,14 +35,14 @@ func TestVariableTemplateParserImpl_ParseTemplate(t *testing.T) {
 	assert.Nil(t, err)
 	templateParser := NewVariableTemplateParserImpl(logger)
 	t.Run("parse template", func(t *testing.T) {
-		scopedVariables := []*models.ScopedVariableData{{VariableName: "container-port-number-new", VariableValue: models.VariableValue{Value: "1800"}}}
+		scopedVariables := []*models.ScopedVariableData{{VariableName: "container-port-number-new", VariableValue: &models.VariableValue{Value: "1800"}}}
 		parserResponse := templateParser.ParseTemplate(VariableParserRequest{TemplateType: JsonVariableTemplate, Template: JsonWithIntParam, Variables: scopedVariables})
 		parsedTemplate := parserResponse.ResolvedTemplate
 		assert.Equal(t, JsonWithIntParamResolvedTemplate, parsedTemplate)
 	})
 
 	t.Run("parse stringify template", func(t *testing.T) {
-		scopedVariables := []*models.ScopedVariableData{{VariableName: "Variable1", VariableValue: models.VariableValue{Value: "123"}}}
+		scopedVariables := []*models.ScopedVariableData{{VariableName: "Variable1", VariableValue: &models.VariableValue{Value: "123"}}}
 		parserResponse := templateParser.ParseTemplate(VariableParserRequest{TemplateType: StringVariableTemplate, Template: StringTemplate, Variables: scopedVariables})
 		err = parserResponse.Error
 		assert.Nil(t, err)
@@ -50,7 +50,7 @@ func TestVariableTemplateParserImpl_ParseTemplate(t *testing.T) {
 	})
 
 	t.Run("parse stringify template with int value", func(t *testing.T) {
-		scopedVariables := []*models.ScopedVariableData{{VariableName: "container-port-number-new", VariableValue: models.VariableValue{Value: "1800"}}}
+		scopedVariables := []*models.ScopedVariableData{{VariableName: "container-port-number-new", VariableValue: &models.VariableValue{Value: "1800"}}}
 		parserResponse := templateParser.ParseTemplate(VariableParserRequest{TemplateType: StringVariableTemplate, Template: StringTemplateWithIntParam, Variables: scopedVariables})
 		err = parserResponse.Error
 		assert.Nil(t, err)


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->


Fixes #4009 
The issue arose due to syntax conflict with HCL while parsing template for variables, which was in the format of %{some_value}

This syntax needed to be escaped before calling the parser so that HCL ignores this, since it was not intended by the user.
We made the current implementation of hcl parsing to also escape this format along with the already implemented escaping of the format @{some_value}

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

