### PR TITLE
fix: ci job handling in app create api

### DIFF
--- a/api/appbean/AppDetail.go
+++ b/api/appbean/AppDetail.go
@@ -90,6 +90,7 @@ type CiPipelineDetails struct {
 	ParentCiPipeline          int                         `json:"parentCiPipeline,omitempty"`
 	ParentAppId               int                         `json:"parentAppId,omitempty"`
 	LinkedCount               int                         `json:"linkedCount,omitempty"`
+	PipelineType              string                      `json:"pipelineType,omitempty"`
 }
 
 type CiPipelineMaterialConfig struct {

--- a/api/restHandler/CoreAppRestHandler.go
+++ b/api/restHandler/CoreAppRestHandler.go
@@ -1656,6 +1656,7 @@ func (handler CoreAppRestHandlerImpl) createCiPipeline(appId int, userId int32, 
 			ParentCiPipeline:         ciPipelineData.ParentCiPipeline,
 			ParentAppId:              ciPipelineData.ParentAppId,
 			LinkedCount:              ciPipelineData.LinkedCount,
+			PipelineType:             bean.PipelineType(ciPipelineData.PipelineType),
 		},
 	}
 

--- a/api/restHandler/CoreAppRestHandler.go
+++ b/api/restHandler/CoreAppRestHandler.go
@@ -722,6 +722,7 @@ func (handler CoreAppRestHandlerImpl) buildCiPipelineResp(appId int, ciPipeline 
 		ParentCiPipeline:         ciPipeline.ParentCiPipeline,
 		ParentAppId:              ciPipeline.ParentAppId,
 		LinkedCount:              ciPipeline.LinkedCount,
+		PipelineType:             string(ciPipeline.PipelineType),
 	}
 
 	//build ciPipelineMaterial resp

--- a/api/restHandler/app/BuildPipelineRestHandler.go
+++ b/api/restHandler/app/BuildPipelineRestHandler.go
@@ -420,22 +420,6 @@ func (handler PipelineConfigRestHandlerImpl) PatchCiPipelines(w http.ResponseWri
 	if app.AppType == helper.Job {
 		patchRequest.IsJob = true
 	}
-	if patchRequest.CiPipeline.PipelineType == bean.CI_JOB {
-		patchRequest.CiPipeline.IsDockerConfigOverridden = true
-		patchRequest.CiPipeline.DockerConfigOverride = bean.DockerConfigOverride{
-			DockerRegistry:   ciConf.DockerRegistry,
-			DockerRepository: ciConf.DockerRepository,
-			CiBuildConfig: &bean1.CiBuildConfigBean{
-				Id:                        0,
-				GitMaterialId:             patchRequest.CiPipeline.CiMaterial[0].GitMaterialId,
-				BuildContextGitMaterialId: patchRequest.CiPipeline.CiMaterial[0].GitMaterialId,
-				UseRootBuildContext:       false,
-				CiBuildType:               bean1.SKIP_BUILD_TYPE,
-				DockerBuildConfig:         nil,
-				BuildPackConfig:           nil,
-			},
-		}
-	}
 	createResp, err := handler.pipelineBuilder.PatchCiPipeline(&patchRequest)
 	if err != nil {
 		handler.Logger.Errorw("service err, PatchCiPipelines", "err", err, "PatchCiPipelines", patchRequest)

--- a/pkg/pipeline/BuildPipelineConfigService.go
+++ b/pkg/pipeline/BuildPipelineConfigService.go
@@ -818,6 +818,22 @@ func (impl *PipelineBuilderImpl) PatchCiPipeline(request *bean.CiPatchRequest) (
 		impl.logger.Errorw("err in fetching template for pipeline patch, ", "err", err, "appId", request.AppId)
 		return nil, err
 	}
+	if request.CiPipeline.PipelineType == bean.CI_JOB {
+		request.CiPipeline.IsDockerConfigOverridden = true
+		request.CiPipeline.DockerConfigOverride = bean.DockerConfigOverride{
+			DockerRegistry:   ciConfig.DockerRegistry,
+			DockerRepository: ciConfig.DockerRepository,
+			CiBuildConfig: &bean3.CiBuildConfigBean{
+				Id:                        0,
+				GitMaterialId:             request.CiPipeline.CiMaterial[0].GitMaterialId,
+				BuildContextGitMaterialId: request.CiPipeline.CiMaterial[0].GitMaterialId,
+				UseRootBuildContext:       false,
+				CiBuildType:               bean3.SKIP_BUILD_TYPE,
+				DockerBuildConfig:         nil,
+				BuildPackConfig:           nil,
+			},
+		}
+	}
 	ciConfig.AppWorkflowId = request.AppWorkflowId
 	ciConfig.UserId = request.UserId
 	if request.CiPipeline != nil {


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Adding support for creating Creating job using api "/orchestrator/core/v1beta1/application".

Fixes #4055 

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
test-cases
- [x] creating ci job
- [x] cloning app with ci-job
- [x] creating app with app create api


## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

