### PR TITLE
doc: Fixed issuer url in okta docs

### DIFF
--- a/docs/user-guide/global-configurations/okta.md
+++ b/docs/user-guide/global-configurations/okta.md
@@ -50,7 +50,7 @@ OIDC stands for OpenID Connect. [Click here](https://www.okta.com/openid-connect
 2. In the **URL** field, enter the Devtron application URL (a valid https link) where it is hosted.
 3. Under `Configuration` tab, locate the config object, and provide the `clientID` and `clientSecret` of the app integration you created on Okta.
 4. Add a key `insecureSkipEmailVerified: true`. Note that this key is only required for Okta SSO. For other types of OIDC SSO, refer [OIDC supported configurations](https://dexidp.io/docs/connectors/oidc/).
-5. Provide `issuer` value as `https://${yourOktaDomain}/oauth2/default`. Replace `${yourOktaDomain}` with your domain on Okta as shown in the video.
+5. Provide `issuer` value as `https://${yourOktaDomain}`. Replace `${yourOktaDomain}` with your domain on Okta as shown in the video.
 6. For providing `redirectURI` or `callbackURI` registered with the SSO provider, you can either select `Configuration` or `Sample Script`. Note that the redirect URI is already given in the helper text (as seen in the previous section).
 7. Click **Save** to create and activate Okta SSO login.
 


### PR DESCRIPTION
# Description

In Paid License or organization okta accounts /oauth2/default isn't enabled by default and the issuer url without /oauth2/default works for both organization as well as trial accounts as well as the recommended url for issuer

## How Has This Been Tested?

- [x] Tested on Okta trial account
- [x] Tested on Okta organization account

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.
