### PR TITLE
docs: deprecated devtron installation for s3 authentication

### DIFF
--- a/docs/setup/install/install-devtron-with-cicd-with-gitops.md
+++ b/docs/setup/install/install-devtron-with-cicd-with-gitops.md
@@ -87,24 +87,6 @@ helm install devtron devtron/devtron-operator \
 --set argo-cd.enabled=true
 ```
 
-*  Install using access-key and secret-key for AWS S3 authentication:
-
-```bash
-helm repo add devtron https://helm.devtron.ai
-
-helm install devtron devtron/devtron-operator \
---create-namespace --namespace devtroncd \
---set installer.modules={cicd} \
---set configs.BLOB_STORAGE_PROVIDER=S3 \
---set configs.DEFAULT_CACHE_BUCKET=demo-s3-bucket \
---set configs.DEFAULT_CACHE_BUCKET_REGION=us-east-1 \
---set configs.DEFAULT_BUILD_LOGS_BUCKET=demo-s3-bucket \
---set configs.DEFAULT_CD_LOGS_BUCKET_REGION=us-east-1 \
---set secrets.BLOB_STORAGE_S3_ACCESS_KEY=<access-key> \
---set secrets.BLOB_STORAGE_S3_SECRET_KEY=<secret-key> \
---set argo-cd.enabled=true
-```
-
 *  Install using S3 compatible storages: 
 
 ```bash
@@ -121,6 +103,24 @@ helm install devtron devtron/devtron-operator \
 --set secrets.BLOB_STORAGE_S3_ACCESS_KEY=<access-key> \
 --set secrets.BLOB_STORAGE_S3_SECRET_KEY=<secret-key> \
 --set configs.BLOB_STORAGE_S3_ENDPOINT=<endpoint> \
+--set argo-cd.enabled=true
+```
+
+*  Install using access-key and secret-key for AWS S3 authentication (Deprecated):
+
+```bash
+helm repo add devtron https://helm.devtron.ai
+
+helm install devtron devtron/devtron-operator \
+--create-namespace --namespace devtroncd \
+--set installer.modules={cicd} \
+--set configs.BLOB_STORAGE_PROVIDER=S3 \
+--set configs.DEFAULT_CACHE_BUCKET=demo-s3-bucket \
+--set configs.DEFAULT_CACHE_BUCKET_REGION=us-east-1 \
+--set configs.DEFAULT_BUILD_LOGS_BUCKET=demo-s3-bucket \
+--set configs.DEFAULT_CD_LOGS_BUCKET_REGION=us-east-1 \
+--set secrets.BLOB_STORAGE_S3_ACCESS_KEY=<access-key> \
+--set secrets.BLOB_STORAGE_S3_SECRET_KEY=<secret-key> \
 --set argo-cd.enabled=true
 ```
 

--- a/docs/setup/install/install-devtron-with-cicd.md
+++ b/docs/setup/install/install-devtron-with-cicd.md
@@ -99,23 +99,6 @@ helm install devtron devtron/devtron-operator \
 --set configs.DEFAULT_CD_LOGS_BUCKET_REGION=us-east-1
 ```
 
-*  Install using access-key and secret-key for AWS S3 authentication:
-
-```bash
-helm repo add devtron https://helm.devtron.ai
-
-helm install devtron devtron/devtron-operator \
---create-namespace --namespace devtroncd \
---set installer.modules={cicd} \
---set configs.BLOB_STORAGE_PROVIDER=S3 \
---set configs.DEFAULT_CACHE_BUCKET=demo-s3-bucket \
---set configs.DEFAULT_CACHE_BUCKET_REGION=us-east-1 \
---set configs.DEFAULT_BUILD_LOGS_BUCKET=demo-s3-bucket \
---set configs.DEFAULT_CD_LOGS_BUCKET_REGION=us-east-1 \
---set secrets.BLOB_STORAGE_S3_ACCESS_KEY=<access-key> \
---set secrets.BLOB_STORAGE_S3_SECRET_KEY=<secret-key>
-```
-
 *  Install using S3 compatible storages: 
 
 ```bash
@@ -132,6 +115,23 @@ helm install devtron devtron/devtron-operator \
 --set secrets.BLOB_STORAGE_S3_ACCESS_KEY=<access-key> \
 --set secrets.BLOB_STORAGE_S3_SECRET_KEY=<secret-key> \
 --set configs.BLOB_STORAGE_S3_ENDPOINT=<endpoint>
+```
+
+*  Install using access-key and secret-key for AWS S3 authentication (Deprecated):
+
+```bash
+helm repo add devtron https://helm.devtron.ai
+
+helm install devtron devtron/devtron-operator \
+--create-namespace --namespace devtroncd \
+--set installer.modules={cicd} \
+--set configs.BLOB_STORAGE_PROVIDER=S3 \
+--set configs.DEFAULT_CACHE_BUCKET=demo-s3-bucket \
+--set configs.DEFAULT_CACHE_BUCKET_REGION=us-east-1 \
+--set configs.DEFAULT_BUILD_LOGS_BUCKET=demo-s3-bucket \
+--set configs.DEFAULT_CD_LOGS_BUCKET_REGION=us-east-1 \
+--set secrets.BLOB_STORAGE_S3_ACCESS_KEY=<access-key> \
+--set secrets.BLOB_STORAGE_S3_SECRET_KEY=<secret-key>
 ```
 
 {% endtab %}

--- a/docs/setup/install/installation-configuration.md
+++ b/docs/setup/install/installation-configuration.md
@@ -161,22 +161,6 @@ helm upgrade devtron devtron/devtron-operator --namespace devtroncd \
 --set configs.DEFAULT_CD_LOGS_BUCKET_REGION=us-east-1
 ```
 
-*  **Configure using access-key and secret-key for aws S3 authentication:**
-
-```bash
-helm repo update
-
-helm upgrade devtron devtron/devtron-operator --namespace devtroncd \
---set installer.modules={cicd} \
---set configs.BLOB_STORAGE_PROVIDER=S3 \
---set configs.DEFAULT_CACHE_BUCKET=demo-s3-bucket \
---set configs.DEFAULT_CACHE_BUCKET_REGION=us-east-1 \
---set configs.DEFAULT_BUILD_LOGS_BUCKET=demo-s3-bucket \
---set configs.DEFAULT_CD_LOGS_BUCKET_REGION=us-east-1 \
---set secrets.BLOB_STORAGE_S3_ACCESS_KEY=<access-key> \
---set secrets.BLOB_STORAGE_S3_SECRET_KEY=<secret-key>
-```
-
 *  **Configure using S3 compatible storages:**
 
 ```bash
@@ -192,6 +176,22 @@ helm upgrade devtron devtron/devtron-operator --namespace devtroncd \
 --set secrets.BLOB_STORAGE_S3_ACCESS_KEY=<access-key> \
 --set secrets.BLOB_STORAGE_S3_SECRET_KEY=<secret-key> \
 --set configs.BLOB_STORAGE_S3_ENDPOINT=<endpoint>
+```
+
+*  **Configure using access-key and secret-key for aws S3 authentication (Deprecated):**
+
+```bash
+helm repo update
+
+helm upgrade devtron devtron/devtron-operator --namespace devtroncd \
+--set installer.modules={cicd} \
+--set configs.BLOB_STORAGE_PROVIDER=S3 \
+--set configs.DEFAULT_CACHE_BUCKET=demo-s3-bucket \
+--set configs.DEFAULT_CACHE_BUCKET_REGION=us-east-1 \
+--set configs.DEFAULT_BUILD_LOGS_BUCKET=demo-s3-bucket \
+--set configs.DEFAULT_CD_LOGS_BUCKET_REGION=us-east-1 \
+--set secrets.BLOB_STORAGE_S3_ACCESS_KEY=<access-key> \
+--set secrets.BLOB_STORAGE_S3_SECRET_KEY=<secret-key>
 ```
 
 {% endtab %}


### PR DESCRIPTION
Marked devtron installation using access-key and secret-key for aws S3 authentication as deprecated.

<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - Marked devtron installation using access-key and secret-key for aws S3 authentication as deprecated

-->

# Description
<!--
Marked devtron installation using access-key and secret-key for aws S3 authentication as deprecated
-->
