### PR TITLE
fix: Fixed the image links in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
 <picture>
-  <source media="(prefers-color-scheme: dark)"  srcset="./assets/devtron-darkmode-logo.png">
-  <source media="(prefers-color-scheme: light)"  srcset="./assets/devtron-lightmode-logo.png">
-  <img width="333.333" height="260" src="./assets/devtron-logo-dark-light.png">
+  <source media="(prefers-color-scheme: dark)"  srcset="https://ipfs.io/ipfs/bafybeifjl66ltrs7fqnjvocwemthmrpwo3vcjslynjtpct72ukffgca3c4/devtron-darkmode-logo.png">
+  <source media="(prefers-color-scheme: light)"  srcset="https://ipfs.io/ipfs/bafybeib56fksdl425ia3bztriecija7e2777lanerih7kndggzlexv4qqq/devtron-lightmode-logo.png">
+  <img width="333.333" height="260" src="https://ipfs.io/ipfs/bafybeidmgwngs6h55k7c5ipkyejs7v4uxdifey44x5ykwctnbgzpc25274/devtron-logo-dark-light.png">
 </picture>
 <h1 align= "center">Cloud Native tool integration platform for Kubernetes</h1>
 </p>
@@ -42,33 +42,33 @@
 
 Devtron deeply integrates with products across the lifecycle of microservices,i.e., CI, CD, security, cost, debugging, and observability via an intuitive web interface.
 <br>
-<p align="center"><img src="./assets/readme-comic.png"></p>
+<p align="center"><img src="https://ipfs.io/ipfs/bafybeih2m3dqbnyue4igpjkmusj7iaz47kaorhq7c3uftp3egs7jnjwrtu/readme-comic.png"></p>
 
 [Devtron](#install-devtron) helps you deploy, observe, manage & debug existing Helm apps in all your clusters.
 
 
 ## Devtron Demo Environment
 
-Please log in the <a href="https://preview.devtron.ai/dashboard/" rel="nofollow">Demo environment</a> using github credentials. Please note the user is granted view access.
+Please log in to the <a href="https://preview.devtron.ai/dashboard/" rel="nofollow">Demo environment</a> using github credentials. Please note the user is granted view access.
 
 ## Devtron Features
 
 <details><summary><b>Application-level Resource grouping for easier Debugging</b></summary>
 <br>
  
-- Devtron groups your Kubernetes objects deployed via Helm charts and display them in a slick UI for easier monitoring or debugging. Access pod logs and resource manifests right from the Devtron UI and even edit them!
+- Devtron groups your Kubernetes objects deployed via Helm charts and displays them in a slick UI for easier monitoring or debugging. Access pod logs and resource manifest right from the Devtron UI and even edit them!
  
 </details>
 <details><summary> <b>Centralized Access Management</b></summary>
 <br>
 
-- Control and give customizable view-only, edit access to users on Project, Environment and Application levels
+- Control and give customizable view-only, edit access to users on Project, Environment, and Application levels
 </details>
 
 <details><summary> <b>Deploy, Manage and Observe on multiple clusters</b></summary>
 <br>
 
-- Deploy and manage Helm charts, applications across multiple Kubernetes clusters (hosted on multiple clouds/on-prem) right from a single Devtron setup
+- Deploy and manage Helm charts, and applications across multiple Kubernetes clusters (hosted on multiple clouds/on-prem) right from a single Devtron setup
 </details>
 
 <br>
@@ -93,7 +93,7 @@ Devtron is designed to be modular, and its functionality can be easily extended 
 
 ## Architecture
 
-<p align="center"><img src="./assets/Architecture.jpg"></p>
+<p align="center"><img src="https://ipfs.io/ipfs/bafybeibeoblxb7c7uklb7tfov35kgoryv2jghjqtr2qzblljt2jotgyh6u/Architecture.jpg"></p>
 
 ## Installation
 
@@ -164,7 +164,7 @@ helm install devtron devtron/devtron-operator --create-namespace --namespace dev
  
 Devtron is built on some of the most trusted and loved technologies:
 <br>
-<p align="center"><img width="70%" height="70%" src="./assets/we-support.jpg"></p>
+<p align="center"><img width="70%" height="70%" src="https://ipfs.io/ipfs/bafybeieq54kesu7hlr3itcwpvjqo27wsr4u3gwppxx2pd3i6lxyg5shvbe/we-support.jpg"></p>
  
 ## :video_camera: Videos
  
@@ -200,7 +200,7 @@ Devtron is trusted by Enterprises and Communities all across the globe:
  
 ### Current build
  
-- Devtron uses modified version of [Argo Rollout](https://argoproj.github.io/argo-rollouts/)
+- Devtron uses a modified version of [Argo Rollout](https://argoproj.github.io/argo-rollouts/)
 - Application metrics only work for K8s version 1.16+
  
 ## Support, Contribution, and Community
@@ -212,12 +212,12 @@ Get updates on Devtron's development and chat with project maintainers, contribu
 - Raise feature requests, suggest enhancements, and report bugs in our [GitHub Issues](https://github.com/devtron-labs/devtron/issues)
 - Articles, Howtos, Tutorials - [Devtron Blogs](https://devtron.ai/blog/)
  
-### Join us at Discord channel
+### Join us on Discord channel
 <p>
 <a href="https://discord.gg/jsRG5qx2gp">
    <img
    src="https://invidget.switchblade.xyz/jsRG5qx2gp"
-   alt="Join Devtron : Heroku for Kubernetes"
+   alt="Join Devtron: Heroku for Kubernetes"
    >
 </a>
 </p>

--- a/docs/user-guide/user-guide.md
+++ b/docs/user-guide/user-guide.md
@@ -1,14 +1,14 @@
 # Introduction
 
-Devtron is an open source software delivery workflow for kubernetes written in go.  
+Devtron is an open-source software delivery workflow for Kubernetes written in go.  
   
  [Website](https://devtron.ai/) · [Blog](https://devtron.ai/blog/) · [Join Discord](https://discord.gg/jsRG5qx2gp) · [Twitter](https://twitter.com/DevtronL)
 
 ## Why Devtron?
 
-It is designed as a self-serve platform for operationalizing and maintaining applications \(AppOps\) on kubernetes in a developer friendly way.   
+It is designed as a self-serve platform for operationalizing and maintaining applications \(AppOps\) on Kubernetes in a developer-friendly way.   
    
- ![](../.gitbook/assets/preview.gif)   
+ ![Trusted By](https://ipfs.io/ipfs/bafybeichsgwthoyjb6ccvdpdghk3b4uzmmclz3q7yfpuemtjiiy7eahily/trusted-by.jpg)   
    
 
 
@@ -16,66 +16,66 @@ It is designed as a self-serve platform for operationalizing and maintaining app
 
 #### Zero code software delivery workflow
 
-* Workflow which understands the domain of **kubernetes, testing, CD, SecOps** so that you don't have to write scripts
+* Workflow which understands the domain of **Kubernetes, testing, CD, SecOps** so that you don't have to write scripts
 * Reusable and composable components so that workflows are easy to construct and reason through
 
-#### Multi cloud deployment
+#### Multi-cloud deployment
 
-* deploy to multiple kubernetes cluster
-* test on aws cloud 
+* deploy to multiple Kubernetes cluster
+* test on AWS cloud 
 
-  > coming soon: support for GCP and microsoft azure
+  > Coming soon: support for GCP and Microsoft azure
 
 #### Easy dev-sec-ops integration
 
-* Multi level security policy at global, cluster, environment and application for efficient hierarchical policy management
-* Behavior driven security policy
-* Define policies and exception for kubernetes resources
+* Multi-level security policy at global, cluster, environment, and application for efficient hierarchical policy management
+* Behavior-driven security policy
+* Define policies and exceptions for Kubernetes resources
 * Define policies for events for faster resolution
 
 #### Application debugging dashboard
 
-* One place for all historical kubernetes events 
+* One place for all historical Kubernetes events 
 * Access all manifests securely for eg secret obfuscation 
-* _**Application metrics**_ for cpu, ram, http status code and latency with comparison between new and old 
+* _**Application metrics**_ for CPU, RAM, HTTP status code, and latency with comparison between new and old 
 * _**Advanced logging**_ with grep and json search 
 * Intelligent _**correlation between events, logs**_ for faster triangulation of issue 
 * Auto issue identification 
 
-#### Enterprise Grade security and compliances
+#### Enterprise Grade security and compliance
 
-* Fine grained access control; control who can edit configuration and who can deploy.
+* Fine-grained access control; control who can edit the configuration and who can deploy.
 * Audit log to know who did what and when
 * History of all CI and CD events
-* Kubernetes events impacting application
+* Kubernetes events impacting the application
 * Relevant cloud events and their impact on applications
-* Advanced workflow policies like blackout window, branch environment relationship to secure build and deployment pipelines
+* Advanced workflow policies like blackout window, and branch environment relationship to secure build and deployment pipelines
 
 #### Gitops aware
 
 * Gitops exposed through API and UI so that you don't have to interact with git cli
-* Gitops backed by postgres for easier analysis
+* Gitops backed by Postgres for easier analysis
 * Enforce finer access control than git
 
 #### Operational insights
 
-* Deployment metrics to measure success of agile process. It captures mttr, change failure rate, deployment frequency, deployment size out of the box.
+* Deployment metrics to measure the success of the agile process. It captures mttr, change failure rate, deployment frequency, and deployment size out of the box.
 * Audit log to understand the failure causes
 * Monitor changes across deployments and revert easily
 
 ## Compatibility notes
 
-* Only AWS kubernetes cluster is supported as of now
-* It uses modified version of [argo rollout](https://argoproj.github.io/argo-rollouts/).
-* application metrics only works for k8s 1.16+
+* Only the AWS Kubernetes cluster is supported as of now
+* It uses a modified version of [argo rollout](https://argoproj.github.io/argo-rollouts/).
+* application metrics only work for k8s 1.16+
 
 ## Community
 
-Get updates on Devtron's development and chat with the project maintainers, contributors and community members.
+Get updates on Devtron's development and chat with the project maintainers, contributors, and community members.
 
 * Join the [Discord Community](https://discord.gg/jsRG5qx2gp) 
 * Follow [@DevtronL on Twitter](https://twitter.com/DevtronL)
-* Raise feature requests, suggest enhancements, report bugs at [GitHub issues](https://github.com/devtron-labs/devtron/issues)
+* Raise feature requests, suggest enhancements, and report bugs at [GitHub issues](https://github.com/devtron-labs/devtron/issues)
 * Read the [Devtron blog](https://devtron.ai/blog/)
 
 ## Contribute


### PR DESCRIPTION
# Description
In the latest PR, I've replaced GitHub relative links with IPFS storage links in the README.md file to enhance image reliability. This change addresses image loading issues on GitHub, as demonstrated by the examples below, and ensures a consistent experience, particularly for contributors and developers with slower internet connections. Your feedback on this update is highly valuable.

### Examples: 
![Screenshot (1086)](https://github.com/devtron-labs/devtron/assets/62978274/c283eba6-5872-4f6f-9e41-cfa5200b0c52)
![Screenshot (1087)](https://github.com/devtron-labs/devtron/assets/62978274/f1e3a748-cfc0-4410-a091-f0dc855db5b6)
![Screenshot (1088)](https://github.com/devtron-labs/devtron/assets/62978274/3eaac230-c9ab-462a-ab1a-fc8ab0dc4cf5)

## How Has This Been Tested?
We can now go to the README.md file and check that the images will be loading in any scenario. 

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
```release-note

```

Could you please check once? Will be happy to learn and grow by correcting my mistakes. 
Also, if possible could you please add the HacktoberFest label if you find it worth it?
Thank you.