### PR TITLE
fix: old pods are listed in new pod section for devtron apps deployed through Helm

### DIFF
--- a/api/restHandler/AppListingRestHandler.go
+++ b/api/restHandler/AppListingRestHandler.go
@@ -41,6 +41,7 @@ import (
 	"github.com/devtron-labs/devtron/pkg/appStatus"
 	"github.com/devtron-labs/devtron/pkg/appStore/deployment/repository"
 	service1 "github.com/devtron-labs/devtron/pkg/appStore/deployment/service"
+	bean3 "github.com/devtron-labs/devtron/pkg/bean"
 	"github.com/devtron-labs/devtron/pkg/cluster"
 	"github.com/devtron-labs/devtron/pkg/deploymentGroup"
 	"github.com/devtron-labs/devtron/pkg/generateManifest"
@@ -1595,11 +1596,14 @@ func (handler AppListingRestHandlerImpl) fetchResourceTree(w http.ResponseWriter
 		if detail != nil && detail.ReleaseExist {
 			resourceTree = util2.InterfaceToMapAdapter(detail.ResourceTreeResponse)
 			// add "isNew = false" flag in podMetaData - isNew flag will be omitted when the value is false
-			podMetadata := resourceTree["podMetadata"]
-			for _, data := range podMetadata.([]interface{}) {
-				dataMap := data.(map[string]interface{})
-				if _, ok := dataMap["isNew"]; !ok {
-					dataMap["isNew"] = false
+			podMetadata := resourceTree[bean3.PodMetaData]
+			if podMetaDataList, ok := podMetadata.([]interface{}); ok {
+				for _, data := range podMetaDataList {
+					if dataMap, ok := data.(map[string]interface{}); ok {
+						if _, ok := dataMap[bean3.IsNew]; !ok {
+							dataMap[bean3.IsNew] = false
+						}
+					}
 				}
 			}
 			releaseStatus := util2.InterfaceToMapAdapter(detail.ReleaseStatus)

--- a/api/restHandler/AppListingRestHandler.go
+++ b/api/restHandler/AppListingRestHandler.go
@@ -1594,6 +1594,14 @@ func (handler AppListingRestHandlerImpl) fetchResourceTree(w http.ResponseWriter
 		}
 		if detail != nil && detail.ReleaseExist {
 			resourceTree = util2.InterfaceToMapAdapter(detail.ResourceTreeResponse)
+			// add isNew flag in podMetaData - isNew flag will be missing only where it is false
+			podMetadata := resourceTree["podMetadata"]
+			for _, data := range podMetadata.([]interface{}) {
+				dataMap := data.(map[string]interface{})
+				if _, ok := dataMap["isNew"]; !ok {
+					dataMap["isNew"] = false
+				}
+			}
 			releaseStatus := util2.InterfaceToMapAdapter(detail.ReleaseStatus)
 			applicationStatus := detail.ApplicationStatus
 			resourceTree["releaseStatus"] = releaseStatus

--- a/api/restHandler/AppListingRestHandler.go
+++ b/api/restHandler/AppListingRestHandler.go
@@ -1594,7 +1594,7 @@ func (handler AppListingRestHandlerImpl) fetchResourceTree(w http.ResponseWriter
 		}
 		if detail != nil && detail.ReleaseExist {
 			resourceTree = util2.InterfaceToMapAdapter(detail.ResourceTreeResponse)
-			// add isNew flag in podMetaData - isNew flag will be missing only where it is false
+			// add "isNew = false" flag in podMetaData - isNew flag will be omitted when the value is false
 			podMetadata := resourceTree["podMetadata"]
 			for _, data := range podMetadata.([]interface{}) {
 				dataMap := data.(map[string]interface{})

--- a/pkg/bean/app.go
+++ b/pkg/bean/app.go
@@ -852,3 +852,8 @@ const CustomAutoScalingEnabledPathKey = "CUSTOM_AUTOSCALING_ENABLED_PATH"
 const CustomAutoscalingReplicaCountPathKey = "CUSTOM_AUTOSCALING_REPLICA_COUNT_PATH"
 const CustomAutoscalingMinPathKey = "CUSTOM_AUTOSCALING_MIN_PATH"
 const CustomAutoscalingMaxPathKey = "CUSTOM_AUTOSCALING_MAX_PATH"
+
+const (
+	PodMetaData = "podMetadata"
+	IsNew       = "isNew"
+)


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
These changes fix the flag condition which decides whether the pods are new or old

Fixes #4024 

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

