### PR TITLE
chore: Update pr-issue-validator.yaml

### DIFF
--- a/.github/workflows/pr-issue-validator.yaml
+++ b/.github/workflows/pr-issue-validator.yaml
@@ -39,8 +39,20 @@ jobs:
         TITLE: ${{ github.event.pull_request.title }}
       run: |
         set -x
+        echo "base or target repo : ${{ github.event.pull_request.base.repo.full_name }}"
+        echo "head or source repo : ${{ github.event.pull_request.head.repo.full_name }}"
+        if [[ ${{ github.event.pull_request.head.repo.full_name }} == ${{ github.event.pull_request.base.repo.full_name }} ]]; then
+          export forked=false
+        else
+          export forked=true
+        fi
+        echo "forked: $forked"
         if [[ "$TITLE" == *"doc:"* || "$TITLE" == *"docs:"* || "$TITLE" == *"chore:"* || "$TITLE" == *"release:"* || "$TITLE" == *"Release:"*  ]]; then
           echo "Skipping validation as this is a PR for documentation or chore."
+          if [[ $forked == true ]]; then
+            echo "PR:Ready-to-Review, exiting gracefully"
+            exit 0
+          fi
           gh pr edit $PRNUM --remove-label "PR:Issue-verification-failed"
           gh pr edit $PRNUM --add-label "PR:Ready-to-Review"
           exit 0
@@ -78,6 +90,10 @@ jobs:
             echo "issue_num is : $issue_num"
         else
             echo "No Issue number detected hence failing the PR Validation check."
+            if [[ $forked == true ]]; then
+              echo "PR:Issue-verification-failed, exiting forcefully!"
+              exit 1
+            fi
             gh pr edit $PRNUM --add-label "PR:Issue-verification-failed"
             gh pr edit $PRNUM --remove-label "PR:Ready-to-Review"
             exit 1
@@ -105,17 +121,31 @@ jobs:
           if [[ $(echo "$text" | jq -r '.state') == "open" ]]; then
             echo "Issue #$issue_num is open"
             echo "Issue reference found in the pull request body."
+            if [[ $forked == true ]]; then
+              echo "PR:Ready-to-Review, exiting gracefully"
+              exit 0
+            fi
             gh pr edit $PRNUM --remove-label "PR:Issue-verification-failed"
             gh pr edit $PRNUM --add-label "PR:Ready-to-Review"
             exit 0
           else
             echo "Issue #$issue_num is not open"
+            if [[ $forked == true ]]; then
+              echo "PR:Issue-verification-failed, exiting forcefully!"
+              exit 1
+            fi
+            gh pr edit $PRNUM --add-label "PR:Issue-verification-failed"
+            gh pr edit $PRNUM --remove-label "PR:Ready-to-Review"
             exit 1
           fi
         else
             echo "Invalid Response Code obtained - error code: $response_code"
             echo "No valid issue reference found in the pull request body."
             gh pr comment $PRNUM --body "PR is not linked to any issue, please make the corresponding changes in the body."
+            if [[ $forked == true ]]; then
+              echo "PR:Issue-verification-failed, exiting forcefully!"
+              exit 1
+            fi
             gh pr edit $PRNUM --add-label "PR:Issue-verification-failed"
             gh pr edit $PRNUM --remove-label "PR:Ready-to-Review"
             exit 1


### PR DESCRIPTION
Updates pr-issue-validator.yaml github workflow for scenarios where PR was raised from a forked repo. 
Due to security reasons github doesn't allow adding label to PR if Pull Request's source repo doesn't belong to `devtron-labs/devtron`. 
The change is : we'll verify the github issue as we were doing previously but we will not be adding the corresponding label.   