### PR TITLE
chore: update maven dependency tracker plugin

### DIFF
--- a/scripts/sql/189_update_mvn_dependency_tracker_plugin.down.sql
+++ b/scripts/sql/189_update_mvn_dependency_tracker_plugin.down.sql
@@ -1,0 +1,32 @@
+DELETE from plugin_step_variable where name='SkipBuildTest';
+update plugin_pipeline_script SET script=E'mkdir $HOME/outDTrack                                                   
+OutDirDTrack=$HOME/outDTrack                                            
+cd /devtroncd/$CheckoutPath                                             
+ToUploadBom=YES                                                         
+if [ $BuildToolType == "GRADLE" ]                                       
+then                                                                    
+        apk add gradle                                                  
+        gradle cyclonedxBom                                             
+        cp build/reports/bom.json $OutDirDTrack/bom.json                
+elif [ $BuildToolType == "MAVEN" ]                                      
+then                                                                    
+        apk add maven                                                   
+        mvn install                    
+        cp target/bom.json $OutDirDTrack/bom.json                       
+else                                                                    
+    echo "BUILD_TYPE: $BuildToolType not supported"                     
+    ToUploadBom=NO                                                      
+fi                                                                      
+                                                                        
+if [ $ToUploadBom == "YES" ]                                            
+then                                                                    
+        apk add curl                                                    
+    cd $OutDirDTrack                                                    
+        curl -v --location --request POST "$DTrackEndpoint/api/v1/bom" \
+                --header "accept: application/json" \                   
+        --header "X-Api-Key: $DTrackApiKey" \                           
+        --form "projectName=$DTrackProjectName" \                       
+        --form \"autoCreate=true\" \                                   
+        --form "projectVersion=$DTrackProjectVersion" \                 
+        --form "bom=@\"bom.json\""                                       
+fi'  WHERE id=5;

--- a/scripts/sql/189_update_mvn_dependency_tracker_plugin.down.sql
+++ b/scripts/sql/189_update_mvn_dependency_tracker_plugin.down.sql
@@ -22,11 +22,11 @@ if [ $ToUploadBom == "YES" ]
 then                                                                    
         apk add curl                                                    
     cd $OutDirDTrack                                                    
-        curl -v --location --request POST "$DTrackEndpoint/api/v1/bom" \
-                --header "accept: application/json" \                   
-                --header "X-Api-Key: $DTrackApiKey" \                           
-                --form "projectName=$DTrackProjectName" \                       
-                --form \"autoCreate=true\" \                                   
-                --form "projectVersion=$DTrackProjectVersion" \                 
-                --form "bom=@\"bom.json\""                                       
+        curl -v --location --request POST "$DTrackEndpoint/api/v1/bom" \\
+                --header "accept: application/json" \\                   
+                --header "X-Api-Key: $DTrackApiKey" \\                          
+                --form "projectName=$DTrackProjectName" \\                       
+                --form \"autoCreate=true\" \\                                   
+                --form "projectVersion=$DTrackProjectVersion" \\                 
+                --form "bom=@\"bom.json\""                 
 fi'  WHERE id=(SELECT ps.id FROM plugin_metadata p inner JOIN plugin_step ps on ps.plugin_id=p.id WHERE p.name='Dependency track for Maven & Gradle' and ps."index"=1 and ps.deleted=false);

--- a/scripts/sql/189_update_mvn_dependency_tracker_plugin.down.sql
+++ b/scripts/sql/189_update_mvn_dependency_tracker_plugin.down.sql
@@ -29,4 +29,4 @@ then
         --form \"autoCreate=true\" \                                   
         --form "projectVersion=$DTrackProjectVersion" \                 
         --form "bom=@\"bom.json\""                                       
-fi'  WHERE id=5;
+fi'  WHERE id=(SELECT ps.id FROM plugin_metadata p inner JOIN plugin_step ps on ps.plugin_id=p.id WHERE p.name='Dependency track for Maven & Gradle' and ps."index"=1 and ps.deleted=false);

--- a/scripts/sql/189_update_mvn_dependency_tracker_plugin.down.sql
+++ b/scripts/sql/189_update_mvn_dependency_tracker_plugin.down.sql
@@ -1,4 +1,4 @@
-DELETE FROM plugin_step_variable WHERE NAME='SkipBuildTest';
+DELETE FROM plugin_step_variable WHERE NAME='ExcludeBuildTest';
 UPDATE plugin_pipeline_script SET script=E'mkdir $HOME/outDTrack                                                   
 OutDirDTrack=$HOME/outDTrack                                            
 cd /devtroncd/$CheckoutPath                                             

--- a/scripts/sql/189_update_mvn_dependency_tracker_plugin.down.sql
+++ b/scripts/sql/189_update_mvn_dependency_tracker_plugin.down.sql
@@ -21,7 +21,7 @@ fi
 if [ $ToUploadBom == "YES" ]                                            
 then                                                                    
         apk add curl                                                    
-    cd $OutDirDTrack                                                    
+        cd $OutDirDTrack                                                    
         curl -v --location --request POST "$DTrackEndpoint/api/v1/bom" \\
                 --header "accept: application/json" \\                   
                 --header "X-Api-Key: $DTrackApiKey" \\                          

--- a/scripts/sql/189_update_mvn_dependency_tracker_plugin.down.sql
+++ b/scripts/sql/189_update_mvn_dependency_tracker_plugin.down.sql
@@ -1,5 +1,5 @@
-DELETE from plugin_step_variable where name='SkipBuildTest';
-update plugin_pipeline_script SET script=E'mkdir $HOME/outDTrack                                                   
+DELETE FROM plugin_step_variable WHERE NAME='SkipBuildTest';
+UPDATE plugin_pipeline_script SET script=E'mkdir $HOME/outDTrack                                                   
 OutDirDTrack=$HOME/outDTrack                                            
 cd /devtroncd/$CheckoutPath                                             
 ToUploadBom=YES                                                         
@@ -24,9 +24,9 @@ then
     cd $OutDirDTrack                                                    
         curl -v --location --request POST "$DTrackEndpoint/api/v1/bom" \
                 --header "accept: application/json" \                   
-        --header "X-Api-Key: $DTrackApiKey" \                           
-        --form "projectName=$DTrackProjectName" \                       
-        --form \"autoCreate=true\" \                                   
-        --form "projectVersion=$DTrackProjectVersion" \                 
-        --form "bom=@\"bom.json\""                                       
+                --header "X-Api-Key: $DTrackApiKey" \                           
+                --form "projectName=$DTrackProjectName" \                       
+                --form \"autoCreate=true\" \                                   
+                --form "projectVersion=$DTrackProjectVersion" \                 
+                --form "bom=@\"bom.json\""                                       
 fi'  WHERE id=(SELECT ps.id FROM plugin_metadata p inner JOIN plugin_step ps on ps.plugin_id=p.id WHERE p.name='Dependency track for Maven & Gradle' and ps."index"=1 and ps.deleted=false);

--- a/scripts/sql/189_update_mvn_dependency_tracker_plugin.up.sql
+++ b/scripts/sql/189_update_mvn_dependency_tracker_plugin.up.sql
@@ -1,5 +1,5 @@
 INSERT INTO plugin_step_variable (id,plugin_step_id,name,format,description,is_exposed,allow_empty_value,default_value,value,variable_type,value_type,previous_step_index,variable_step_index,variable_step_index_in_plugin,reference_variable_name,deleted,created_on,created_by,updated_on,updated_by) 
-VALUES (nextval('id_seq_plugin_step_variable'),(SELECT ps.id FROM plugin_metadata p inner JOIN plugin_step ps on ps.plugin_id=p.id WHERE p.name='Dependency track for Maven & Gradle' and ps."index"=1 and ps.deleted=false),'SkipBuildTest','BOOL','If Enable, this will skips compiling the tests i.e. it skips building the test artifacts','t','t','f',null,'INPUT','NEW',null,1,null,null,'f','now()',1,'now()',1);
+VALUES (nextval('id_seq_plugin_step_variable'),(SELECT ps.id FROM plugin_metadata p inner JOIN plugin_step ps on ps.plugin_id=p.id WHERE p.name='Dependency track for Maven & Gradle' and ps."index"=1 and ps.deleted=false),'ExcludeBuildTest','BOOL','If Enable, this will skips compiling the tests i.e. it skips building the test artifacts','t','t','f',null,'INPUT','NEW',null,1,null,null,'f','now()',1,'now()',1);
 
 UPDATE plugin_pipeline_script SET script=E'mkdir $HOME/outDTrack
 OutDirDTrack=$HOME/outDTrack
@@ -7,7 +7,7 @@ cd /devtroncd/$CheckoutPath
 ToUploadBom=YES
 
 # Convert SkipBuildTest to lowercase for case-insensitive comparison
-SkipBuildTestLower=$(echo "$SkipBuildTest" | tr "[:upper:]" "[:lower:]")
+SkipBuildTestLower=$(echo "$ExcludeBuildTest" | tr "[:upper:]" "[:lower:]")
 
 if [ $BuildToolType == "GRADLE" ]
 then

--- a/scripts/sql/189_update_mvn_dependency_tracker_plugin.up.sql
+++ b/scripts/sql/189_update_mvn_dependency_tracker_plugin.up.sql
@@ -1,5 +1,5 @@
 INSERT INTO plugin_step_variable (id,plugin_step_id,name,format,description,is_exposed,allow_empty_value,default_value,value,variable_type,value_type,previous_step_index,variable_step_index,variable_step_index_in_plugin,reference_variable_name,deleted,created_on,created_by,updated_on,updated_by) 
-VALUES (nextval('id_seq_plugin_step_variable'),5,'SkipBuildTest','BOOL','If Enable, this will skips compiling the tests i.e. it skips building the test artifacts','t','t',null,null,'INPUT','NEW',null,1,null,null,'f','now()',1,'now()',1);
+VALUES (nextval('id_seq_plugin_step_variable'),(SELECT ps.id FROM plugin_metadata p inner JOIN plugin_step ps on ps.plugin_id=p.id WHERE p.name='Dependency track for Maven & Gradle' and ps."index"=1 and ps.deleted=false),'SkipBuildTest','BOOL','If Enable, this will skips compiling the tests i.e. it skips building the test artifacts','t','t',null,null,'INPUT','NEW',null,1,null,null,'f','now()',1,'now()',1);
 
 UPDATE plugin_pipeline_script SET script=E'mkdir $HOME/outDTrack
 OutDirDTrack=$HOME/outDTrack
@@ -49,4 +49,4 @@ then
         --form \"autoCreate=true\" \
         --form "projectVersion=$DTrackProjectVersion" \
         --form "bom=@\"bom.json\""
-fi' WHERE id=5;
+fi' WHERE id=(SELECT ps.id FROM plugin_metadata p inner JOIN plugin_step ps on ps.plugin_id=p.id WHERE p.name='Dependency track for Maven & Gradle' and ps."index"=1 and ps.deleted=false);

--- a/scripts/sql/189_update_mvn_dependency_tracker_plugin.up.sql
+++ b/scripts/sql/189_update_mvn_dependency_tracker_plugin.up.sql
@@ -1,0 +1,52 @@
+INSERT INTO plugin_step_variable (id,plugin_step_id,name,format,description,is_exposed,allow_empty_value,default_value,value,variable_type,value_type,previous_step_index,variable_step_index,variable_step_index_in_plugin,reference_variable_name,deleted,created_on,created_by,updated_on,updated_by) 
+VALUES (nextval('id_seq_plugin_step_variable'),5,'SkipBuildTest','BOOL','If Enable, this will skips compiling the tests i.e. it skips building the test artifacts','t','t',null,null,'INPUT','NEW',null,1,null,null,'f','now()',1,'now()',1);
+
+UPDATE plugin_pipeline_script SET script=E'mkdir $HOME/outDTrack
+OutDirDTrack=$HOME/outDTrack
+cd /devtroncd/$CheckoutPath
+ToUploadBom=YES
+
+# Convert SkipBuildTest to lowercase for case-insensitive comparison
+SkipBuildTestLower=$(echo "$SkipBuildTest" | tr "[:upper:]" "[:lower:]")
+
+if [ $BuildToolType == "GRADLE" ]
+then
+    if [ "$SkipBuildTestLower" == "true" ]
+    then
+        apk add gradle
+        gradle cyclonedxBom --exclude-task test
+        cp build/reports/bom.json $OutDirDTrack/bom.json
+    else
+        apk add gradle
+        gradle cyclonedxBom
+        cp build/reports/bom.json $OutDirDTrack/bom.json
+    fi
+elif [ $BuildToolType == "MAVEN" ]
+then
+    if [ "$SkipBuildTestLower" == "true" ]
+    then
+        apk add maven
+        mvn install -Dmaven.test.skip=true
+        cp target/bom.json $OutDirDTrack/bom.json
+    else
+        apk add maven
+        mvn install
+        cp target/bom.json $OutDirDTrack/bom.json
+    fi
+else
+    echo "BUILD_TYPE: $BuildToolType not supported"
+    ToUploadBom=NO
+fi
+
+if [ $ToUploadBom == "YES" ]
+then
+    apk add curl
+    cd $OutDirDTrack
+    curl -v --location --request POST "$DTrackEndpoint/api/v1/bom" \
+        --header "accept: application/json" \
+        --header "X-Api-Key: $DTrackApiKey" \
+        --form "projectName=$DTrackProjectName" \
+        --form \"autoCreate=true\" \
+        --form "projectVersion=$DTrackProjectVersion" \
+        --form "bom=@\"bom.json\""
+fi' WHERE id=5;

--- a/scripts/sql/189_update_mvn_dependency_tracker_plugin.up.sql
+++ b/scripts/sql/189_update_mvn_dependency_tracker_plugin.up.sql
@@ -42,11 +42,11 @@ if [ $ToUploadBom == "YES" ]
 then
     apk add curl
     cd $OutDirDTrack
-    curl -v --location --request POST "$DTrackEndpoint/api/v1/bom" \
-        --header "accept: application/json" \
-        --header "X-Api-Key: $DTrackApiKey" \
-        --form "projectName=$DTrackProjectName" \
-        --form \"autoCreate=true\" \
-        --form "projectVersion=$DTrackProjectVersion" \
+    curl -v --location --request POST "$DTrackEndpoint/api/v1/bom" \\
+        --header "accept: application/json" \\
+        --header "X-Api-Key: $DTrackApiKey" \\
+        --form "projectName=$DTrackProjectName" \\
+        --form \"autoCreate=true\" \\
+        --form "projectVersion=$DTrackProjectVersion" \\
         --form "bom=@\"bom.json\""
 fi' WHERE id=(SELECT ps.id FROM plugin_metadata p inner JOIN plugin_step ps on ps.plugin_id=p.id WHERE p.name='Dependency track for Maven & Gradle' and ps."index"=1 and ps.deleted=false);

--- a/scripts/sql/189_update_mvn_dependency_tracker_plugin.up.sql
+++ b/scripts/sql/189_update_mvn_dependency_tracker_plugin.up.sql
@@ -1,5 +1,5 @@
 INSERT INTO plugin_step_variable (id,plugin_step_id,name,format,description,is_exposed,allow_empty_value,default_value,value,variable_type,value_type,previous_step_index,variable_step_index,variable_step_index_in_plugin,reference_variable_name,deleted,created_on,created_by,updated_on,updated_by) 
-VALUES (nextval('id_seq_plugin_step_variable'),(SELECT ps.id FROM plugin_metadata p inner JOIN plugin_step ps on ps.plugin_id=p.id WHERE p.name='Dependency track for Maven & Gradle' and ps."index"=1 and ps.deleted=false),'ExcludeBuildTest','BOOL','If Enable, this will skips compiling the tests i.e. it skips building the test artifacts','t','t','f',null,'INPUT','NEW',null,1,null,null,'f','now()',1,'now()',1);
+VALUES (nextval('id_seq_plugin_step_variable'),(SELECT ps.id FROM plugin_metadata p inner JOIN plugin_step ps on ps.plugin_id=p.id WHERE p.name='Dependency track for Maven & Gradle' and ps."index"=1 and ps.deleted=false),'ExcludeBuildTest','BOOL','If Enable, this will skips compiling the tests i.e. it skips building the test artifacts','t','t','false',null,'INPUT','NEW',null,1,null,null,'f','now()',1,'now()',1);
 
 UPDATE plugin_pipeline_script SET script=E'mkdir $HOME/outDTrack
 OutDirDTrack=$HOME/outDTrack

--- a/scripts/sql/189_update_mvn_dependency_tracker_plugin.up.sql
+++ b/scripts/sql/189_update_mvn_dependency_tracker_plugin.up.sql
@@ -1,5 +1,5 @@
 INSERT INTO plugin_step_variable (id,plugin_step_id,name,format,description,is_exposed,allow_empty_value,default_value,value,variable_type,value_type,previous_step_index,variable_step_index,variable_step_index_in_plugin,reference_variable_name,deleted,created_on,created_by,updated_on,updated_by) 
-VALUES (nextval('id_seq_plugin_step_variable'),(SELECT ps.id FROM plugin_metadata p inner JOIN plugin_step ps on ps.plugin_id=p.id WHERE p.name='Dependency track for Maven & Gradle' and ps."index"=1 and ps.deleted=false),'SkipBuildTest','BOOL','If Enable, this will skips compiling the tests i.e. it skips building the test artifacts','t','t',null,null,'INPUT','NEW',null,1,null,null,'f','now()',1,'now()',1);
+VALUES (nextval('id_seq_plugin_step_variable'),(SELECT ps.id FROM plugin_metadata p inner JOIN plugin_step ps on ps.plugin_id=p.id WHERE p.name='Dependency track for Maven & Gradle' and ps."index"=1 and ps.deleted=false),'SkipBuildTest','BOOL','If Enable, this will skips compiling the tests i.e. it skips building the test artifacts','t','t','f',null,'INPUT','NEW',null,1,null,null,'f','now()',1,'now()',1);
 
 UPDATE plugin_pipeline_script SET script=E'mkdir $HOME/outDTrack
 OutDirDTrack=$HOME/outDTrack


### PR DESCRIPTION
We had extented the Maven Dependency Tracker Plugin to skip the BuildTest. 