### PR TITLE
fix: updated copy container image plugin for multi arc build support

### DIFF
--- a/scripts/sql/193_copy_container_images_updated.down.sql
+++ b/scripts/sql/193_copy_container_images_updated.down.sql
@@ -1,0 +1,3 @@
+UPDATE plugin_pipeline_script
+    SET container_image_path ='quay.io/devtron/copy-container-images:48bdcbb4-567-19597'
+    WHERE container_image_path ='quay.io/devtron/copy-container-images:7c76e5f0-567-19627';

--- a/scripts/sql/193_copy_container_images_updated.up.sql
+++ b/scripts/sql/193_copy_container_images_updated.up.sql
@@ -1,0 +1,3 @@
+UPDATE plugin_pipeline_script
+    SET container_image_path ='quay.io/devtron/copy-container-images:7c76e5f0-567-19627'
+    WHERE container_image_path ='quay.io/devtron/copy-container-images:48bdcbb4-567-19597';


### PR DESCRIPTION
# Description

fix: Added multi arc build support to copy container image plugin

Fixes https://github.com/devtron-labs/devtron/issues/4283

## How Has This Been Tested?

- [x] Build and Trigger CI with Multi Arc build
- [x] Copy the Image form Private to Public repo a multi arc image
- [x] Copy the Image form Private to Private repo a multi arc image
- [x] Trigger copy image for same artifact in parallel

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

