### PR TITLE
fix: Get Artifacts list API is throwing pg no rows error 

### DIFF
--- a/internal/sql/repository/CiArtifactsListingQueryBuilder.go
+++ b/internal/sql/repository/CiArtifactsListingQueryBuilder.go
@@ -17,7 +17,7 @@ func BuildQueryForParentTypeCIOrWebhook(listingFilterOpts bean.ArtifactsListFilt
 		selectQuery := " SELECT cia.* "
 		remainingQuery := " FROM ci_artifact cia" +
 			" INNER JOIN ci_pipeline cp ON (cp.id=cia.pipeline_id or (cp.id=cia.component_id and cia.data_source='post_ci' ) )" +
-			" INNER JOIN pipeline p ON p.ci_pipeline_id = cp.id and p.id=%v" +
+			" INNER JOIN pipeline p ON (p.ci_pipeline_id = cp.id and p.id=%v )" +
 			" WHERE "
 		remainingQuery = fmt.Sprintf(remainingQuery, listingFilterOpts.PipelineId)
 		if len(listingFilterOpts.ExcludeArtifactIds) > 0 {

--- a/pkg/dockerRegistry/DockerRegistryIpsConfigService.go
+++ b/pkg/dockerRegistry/DockerRegistryIpsConfigService.go
@@ -161,7 +161,7 @@ func (impl DockerRegistryIpsConfigServiceImpl) getDockerRegistryIdForCiPipeline(
 		if artifact.CredentialsSourceType == repository3.GLOBAL_CONTAINER_REGISTRY {
 			dockerRegistryId = artifact.CredentialSourceValue
 		}
-	} else {
+	} else if artifact.DataSource == repository3.CI_RUNNER {
 		// if image is created by ci build
 		dockerRegistryId = *ciPipeline.CiTemplate.DockerRegistryId
 		if len(dockerRegistryId) == 0 {

--- a/pkg/pipeline/AppArtifactManager.go
+++ b/pkg/pipeline/AppArtifactManager.go
@@ -623,12 +623,12 @@ func (impl *AppArtifactManagerImpl) RetrieveArtifactsByCDPipelineV2(pipeline *pi
 		sort.SliceStable(ciArtifacts, func(i, j int) bool {
 			return ciArtifacts[i].Id > ciArtifacts[j].Id
 		})
-	}
 
-	ciArtifacts, err = impl.setAdditionalDataInArtifacts(ciArtifacts, pipeline)
-	if err != nil {
-		impl.logger.Errorw("error in setting additional data in fetched artifacts", "pipelineId", pipeline.Id, "err", err)
-		return ciArtifactsResponse, err
+		ciArtifacts, err = impl.setAdditionalDataInArtifacts(ciArtifacts, pipeline)
+		if err != nil {
+			impl.logger.Errorw("error in setting additional data in fetched artifacts", "pipelineId", pipeline.Id, "err", err)
+			return ciArtifactsResponse, err
+		}
 	}
 
 	ciArtifactsResponse.CdPipelineId = pipeline.Id
@@ -673,7 +673,7 @@ func (impl *AppArtifactManagerImpl) setAdditionalDataInArtifacts(ciArtifacts []b
 			if ciArtifacts[i].CredentialsSourceType == repository.GLOBAL_CONTAINER_REGISTRY {
 				dockerRegistryId = ciArtifacts[i].CredentialsSourceValue
 			}
-		} else {
+		} else if ciArtifacts[i].DataSource == repository.CI_RUNNER {
 			ciPipeline, err := impl.CiPipelineRepository.FindById(ciArtifacts[i].CiPipelineId)
 			if err != nil {
 				impl.logger.Errorw("error in fetching ciPipeline", "ciPipelineId", ciPipeline.Id, "error", err)

--- a/pkg/pipeline/CiService.go
+++ b/pkg/pipeline/CiService.go
@@ -481,7 +481,10 @@ func (impl *CiServiceImpl) buildWfRequestForCiPipeline(pipeline *pipelineConfig.
 		}
 		savedWf.ImagePathReservationIds = []int{imagePathReservation.Id}
 		//imagePath = docker.io/avd0/dashboard:fd23414b
-		dockerImageTag = strings.Split(imagePathReservation.ImagePath, ":")[1]
+		imagePathSplit := strings.Split(imagePathReservation.ImagePath, ":")
+		if len(imagePathSplit) >= 1 {
+			dockerImageTag = imagePathSplit[len(imagePathSplit)-1]
+		}
 	} else {
 		dockerImageTag = impl.buildImageTag(commitHashes, pipeline.Id, savedWf.Id)
 	}

--- a/pkg/pipeline/WebhookService.go
+++ b/pkg/pipeline/WebhookService.go
@@ -213,7 +213,10 @@ func (impl WebhookServiceImpl) HandleCiSuccessEvent(ciPipelineId int, request *C
 	if !imagePushedAt.IsZero() {
 		createdOn = *imagePushedAt
 	}
-
+	if pipeline.PipelineType == bean.CI_JOB && request.Image == "" {
+		impl.logger.Errorw("empty image artifact found!", "request", request)
+		return 0, fmt.Errorf("empty image artifact found")
+	}
 	buildArtifact := &repository.CiArtifact{
 		Image:              request.Image,
 		ImageDigest:        request.ImageDigest,
@@ -248,6 +251,9 @@ func (impl WebhookServiceImpl) HandleCiSuccessEvent(ciPipelineId int, request *C
 	var pluginArtifacts []*repository.CiArtifact
 	for registry, artifacts := range request.PluginRegistryArtifactDetails {
 		for _, image := range artifacts {
+			if pipeline.PipelineType == bean.CI_JOB && image == "" {
+				continue
+			}
 			pluginArtifact := &repository.CiArtifact{
 				Image:                 image,
 				ImageDigest:           request.ImageDigest,


### PR DESCRIPTION
# Description
After enabling artifacts V2 flag, get material list API is breaking for external CI and job CI (Throwing error: `pg: no rows in result set`)

Fixes https://github.com/devtron-labs/devtron/issues/4290

## How Has This Been Tested?
- [x] Job CI 
  - [x] Approval list
  - [x] Pre CD list
  - [x] CD list
  - [x] Post CD list
- [x] External CI
  - [x] Approval list
  - [x] Pre CD list
  - [x] CD list
  - [x] Post CD list
- [x] Build CI
  - [x] Approval list
  - [x] Pre CD list
  - [x] CD list
  - [x] Post CD list
- [x] Link CI
  - [x] Approval list
  - [x] Pre CD list
  - [x] CD list
  - [x] Post CD list

Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

