### PR TITLE
Feat oci support ea

### DIFF
--- a/api/restHandler/DockerRegRestHandler.go
+++ b/api/restHandler/DockerRegRestHandler.go
@@ -120,8 +120,14 @@ func NewDockerRegRestHandlerImpl(
 func ValidateDockerArtifactStoreRequestBean(bean types.DockerArtifactStoreBean) error {
 	// handling for EA mode registry setup
 	if util2.IsBaseStack() {
-		if bean.DockerRegistryIpsConfig != nil {
-			bean.DockerRegistryIpsConfig = nil
+		// For EA MODE, DockerRegistryIpsConfig should be nil
+		bean.DockerRegistryIpsConfig = nil
+		// For EA MODE, IsDefault should be FALSE
+		bean.IsDefault = false
+
+		// For EA MODE, IsOCICompliantRegistry should be TRUE
+		if bean.RegistryType == repository.REGISTRYTYPE_GCR {
+			return fmt.Errorf("Invalid payload! 'GCR' is not supported as an OCI registry.")
 		}
 		// For EA MODE, IsOCICompliantRegistry should be TRUE
 		if !bean.IsOCICompliantRegistry {

--- a/api/restHandler/DockerRegRestHandler.go
+++ b/api/restHandler/DockerRegRestHandler.go
@@ -27,6 +27,7 @@ import (
 	deleteService "github.com/devtron-labs/devtron/pkg/delete"
 	"github.com/devtron-labs/devtron/pkg/pipeline/types"
 	"github.com/devtron-labs/devtron/pkg/user/casbin"
+	util2 "github.com/devtron-labs/devtron/util"
 	"k8s.io/utils/strings/slices"
 	"net/http"
 	"strings"
@@ -116,21 +117,45 @@ func NewDockerRegRestHandlerImpl(
 	}
 }
 
-func ValidateDockerArtifactStoreRequestBean(bean types.DockerArtifactStoreBean) bool {
+func ValidateDockerArtifactStoreRequestBean(bean types.DockerArtifactStoreBean) error {
+	// handling for EA mode registry setup
+	if util2.IsBaseStack() {
+		if bean.DockerRegistryIpsConfig != nil {
+			bean.DockerRegistryIpsConfig = nil
+		}
+		// For EA MODE, IsOCICompliantRegistry should be TRUE
+		if !bean.IsOCICompliantRegistry {
+			return fmt.Errorf("Invalid payload! 'isOCICompliantRegistry' is required.")
+		}
+		// For EA MODE, OCIRegistryConfig is mandatory
+		if bean.OCIRegistryConfig == nil {
+			return fmt.Errorf("Invalid payload! 'ociRegistryConfig' is required.")
+		}
+
+		// For EA MODE there should be no config for Container "PULL/PUSH"
+		if _, containerStorageActionExists := bean.OCIRegistryConfig[repository.OCI_REGISRTY_REPO_TYPE_CONTAINER]; containerStorageActionExists {
+			return fmt.Errorf("Invalid payload! 'ociRegistryConfig' has invalid field 'CONTAINER'.")
+		}
+		// For EA MODE, Charts storage action type should always be "PULL"
+		chartStorageActionType, chartStorageActionExists := bean.OCIRegistryConfig[repository.OCI_REGISRTY_REPO_TYPE_CHART]
+		if chartStorageActionExists && chartStorageActionType != repository.STORAGE_ACTION_TYPE_PULL {
+			return fmt.Errorf("Invalid payload! 'ociRegistryConfig[CHART]' has invalid value '%s'.", chartStorageActionType)
+		}
+	}
 	// validating secure connection configs
 	if (bean.Connection == secureWithCert && bean.Cert == "") ||
 		(bean.Connection != secureWithCert && bean.Cert != "") {
-		return false
+		return fmt.Errorf("Invalid payload! invalid value of 'cert' for the 'connection' type '%s'.", bean.Connection)
 	}
 	// validating OCI Registry configs
 	if bean.IsOCICompliantRegistry {
 		if bean.OCIRegistryConfig == nil {
-			return false
+			return fmt.Errorf("Invalid payload! 'ociRegistryConfig' is required")
 		}
 		// For Containers, storage action should be "PULL/PUSH"
 		containerStorageActionType, containerStorageActionExists := bean.OCIRegistryConfig[repository.OCI_REGISRTY_REPO_TYPE_CONTAINER]
 		if containerStorageActionExists && containerStorageActionType != repository.STORAGE_ACTION_TYPE_PULL_AND_PUSH && bean.DockerRegistryIpsConfig == nil {
-			return false
+			return fmt.Errorf("Invalid payload! 'ociRegistryConfig[CONTAINER]' has invalid value '%s'.", containerStorageActionType)
 		}
 		chartStorageActionType, chartStorageActionExists := bean.OCIRegistryConfig[repository.OCI_REGISRTY_REPO_TYPE_CHART]
 		// For Charts with storage action type "PULL", default will always be false
@@ -141,7 +166,7 @@ func ValidateDockerArtifactStoreRequestBean(bean types.DockerArtifactStoreBean) 
 		// For Charts with storage action type "PULL/PUSH" or "PULL", RepositoryList cannot be nil
 		if chartStorageActionExists && (chartStorageActionType == repository.STORAGE_ACTION_TYPE_PULL_AND_PUSH || chartStorageActionType == repository.STORAGE_ACTION_TYPE_PULL) {
 			if bean.RepositoryList == nil || len(bean.RepositoryList) == 0 || slices.Contains(bean.RepositoryList, "") {
-				return false
+				return fmt.Errorf("Invalid payload! invalid value for the required field 'repositoryList'.")
 			}
 		}
 		// For public registry, URL prefix "oci://" should be trimmed, DockerRegistryIpsConfig should be nil and default should be false
@@ -150,12 +175,16 @@ func ValidateDockerArtifactStoreRequestBean(bean types.DockerArtifactStoreBean) 
 			bean.DockerRegistryIpsConfig = nil
 			bean.RegistryURL = strings.TrimPrefix(bean.RegistryURL, OCIScheme)
 		} else if containerStorageActionExists && bean.DockerRegistryIpsConfig == nil {
-			return false
+			return fmt.Errorf("Invalid payload! 'ipsConfig' is required.")
 		}
-	} else if bean.OCIRegistryConfig != nil || bean.IsPublic || bean.DockerRegistryIpsConfig == nil {
-		return false
+	} else if bean.OCIRegistryConfig != nil {
+		return fmt.Errorf("Invalid payload! 'ociRegistryConfig' should be empty.")
+	} else if bean.IsPublic {
+		return fmt.Errorf("Invalid payload! 'isPublic' should be FALSE.")
+	} else if bean.DockerRegistryIpsConfig == nil {
+		return fmt.Errorf("Invalid payload! 'ipsConfig' is required.")
 	}
-	return true
+	return nil
 }
 
 func (impl DockerRegRestHandlerImpl) SaveDockerRegistryConfig(w http.ResponseWriter, r *http.Request) {
@@ -173,10 +202,11 @@ func (impl DockerRegRestHandlerImpl) SaveDockerRegistryConfig(w http.ResponseWri
 		return
 	}
 	bean.User = userId
-	if !ValidateDockerArtifactStoreRequestBean(bean) {
+	requestErr := ValidateDockerArtifactStoreRequestBean(bean)
+	if requestErr != nil {
 		err = fmt.Errorf("invalid payload, missing or incorrect values for required fields")
 		impl.logger.Errorw("validation err, SaveDockerRegistryConfig", "err", err, "payload", bean)
-		common.WriteJsonResp(w, err, nil, http.StatusBadRequest)
+		common.WriteJsonResp(w, requestErr, nil, http.StatusBadRequest)
 		return
 	}
 
@@ -460,10 +490,11 @@ func (impl DockerRegRestHandlerImpl) UpdateDockerRegistryConfig(w http.ResponseW
 		return
 	}
 	bean.User = userId
-	if !ValidateDockerArtifactStoreRequestBean(bean) {
+	requestErr := ValidateDockerArtifactStoreRequestBean(bean)
+	if requestErr != nil {
 		err = fmt.Errorf("invalid payload, missing or incorrect values for required fields")
 		impl.logger.Errorw("validation err, SaveDockerRegistryConfig", "err", err, "payload", bean)
-		common.WriteJsonResp(w, err, nil, http.StatusBadRequest)
+		common.WriteJsonResp(w, requestErr, nil, http.StatusBadRequest)
 		return
 	}
 


### PR DESCRIPTION
# Description
Currently OCI registries can be added but it can be only added through `chart-store` >> `source` >> `OCI Registries` and there isn't any visibility of OCI registries in `Global Configs`
In this PR we provided the capability to pull OCI charts in EA mode and deploy it directly without having the CI/CD module.

Fixes https://github.com/devtron-labs/devtron/issues/4261

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

