### PR TITLE
fix: not able to add env in global configuration

### DIFF
--- a/pkg/cluster/EnvironmentService.go
+++ b/pkg/cluster/EnvironmentService.go
@@ -141,7 +141,7 @@ func (impl EnvironmentServiceImpl) Create(mappings *EnvironmentBean, userId int3
 
 	identifier := clusterBean.ClusterName + "__" + mappings.Namespace
 
-	model, err := impl.environmentRepository.FindByEnvNameOrIdentifierOrNamespace(mappings.Environment, identifier, mappings.Namespace)
+	model, err := impl.environmentRepository.FindByEnvNameOrIdentifierOrNamespace(mappings.ClusterId, mappings.Environment, identifier, mappings.Namespace)
 	if err != nil && err != pg.ErrNoRows {
 		impl.logger.Errorw("error in finding environment for update", "err", err)
 		return mappings, err

--- a/pkg/cluster/repository/EnvironmentRepository.go
+++ b/pkg/cluster/repository/EnvironmentRepository.go
@@ -63,7 +63,7 @@ type EnvironmentRepository interface {
 	FindByName(name string) (*Environment, error)
 	FindByIdentifier(identifier string) (*Environment, error)
 	FindByNameOrIdentifier(name string, identifier string) (*Environment, error)
-	FindByEnvNameOrIdentifierOrNamespace(envName string, identifier string, namespace string) (*Environment, error)
+	FindByEnvNameOrIdentifierOrNamespace(clusterId int, envName string, identifier string, namespace string) (*Environment, error)
 	FindByClusterId(clusterId int) ([]*Environment, error)
 	FindByIds(ids []*int) ([]*Environment, error)
 	FindByNamespaceAndClusterName(namespaces string, clusterName string) (*Environment, error)
@@ -183,14 +183,15 @@ func (repositoryImpl EnvironmentRepositoryImpl) FindByNameOrIdentifier(name stri
 	return environment, err
 }
 
-func (repositoryImpl EnvironmentRepositoryImpl) FindByEnvNameOrIdentifierOrNamespace(envName string, identifier string, namespace string) (*Environment, error) {
+func (repositoryImpl EnvironmentRepositoryImpl) FindByEnvNameOrIdentifierOrNamespace(clusterId int, envName string, identifier string, namespace string) (*Environment, error) {
 	environment := &Environment{}
 	err := repositoryImpl.dbConnection.
 		Model(environment).
 		Where("active = ?", true).
 		WhereGroup(func(query *orm.Query) (*orm.Query, error) {
-			query = query.Where("environment_identifier = ?", identifier).WhereOr("environment_name = ?", envName).
-				WhereOr("namespace = ?", namespace)
+			query = query.Where("environment_identifier = ?", identifier).
+				WhereOr("environment_name = ?", envName).
+				WhereOr("cluster_id = ? AND namespace = ?", clusterId, namespace)
 			return query, nil
 		}).
 		Limit(1).


### PR DESCRIPTION
# Description
Updated the sql query used in validating whether the namespace exists or not. Namespace is unique across a specific cluster and Environment name is unique across all cluster.

Fixes https://github.com/devtron-labs/devtron/issues/4329

## How Has This Been Tested?
- [x] env across cluster should be unique
- [x] namespace cannot be same within a cluster
- [x] namespace can be same across cluster 

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

