### PR TITLE
fix: Inconsistent behaviour on deploying application from application group v/s devtron cli tool after changing deploymentType 

### DIFF
--- a/internal/sql/repository/pipelineConfig/PipelineRepository.go
+++ b/internal/sql/repository/pipelineConfig/PipelineRepository.go
@@ -447,6 +447,7 @@ func (impl PipelineRepositoryImpl) FindActiveByEnvId(envId int) (pipelines []*Pi
 	err = impl.dbConnection.Model(&pipelines).Column("pipeline.*", "App", "Environment").
 		Where("environment_id = ?", envId).
 		Where("deleted = ?", false).
+		Where("deployment_app_delete_request = ?", false).
 		Select()
 	return pipelines, err
 }

--- a/internal/sql/repository/pipelineConfig/PipelineRepository.go
+++ b/internal/sql/repository/pipelineConfig/PipelineRepository.go
@@ -92,6 +92,7 @@ type PipelineRepository interface {
 	GetConnection() *pg.DB
 	FindAllPipelineInLast24Hour() (pipelines []*Pipeline, err error)
 	FindActiveByEnvId(envId int) (pipelines []*Pipeline, err error)
+	FindActivePipelineByEnvId(envId int) (pipelines []*Pipeline, err error)
 	FindActiveByEnvIds(envId []int) (pipelines []*Pipeline, err error)
 	FindActiveByInFilter(envId int, appIdIncludes []int) (pipelines []*Pipeline, err error)
 	FindActiveByNotFilter(envId int, appIdExcludes []int) (pipelines []*Pipeline, err error)
@@ -444,6 +445,14 @@ func (impl PipelineRepositoryImpl) FindAllPipelineInLast24Hour() (pipelines []*P
 	return pipelines, err
 }
 func (impl PipelineRepositoryImpl) FindActiveByEnvId(envId int) (pipelines []*Pipeline, err error) {
+	err = impl.dbConnection.Model(&pipelines).Column("pipeline.*", "App", "Environment").
+		Where("environment_id = ?", envId).
+		Where("deleted = ?", false).
+		Select()
+	return pipelines, err
+}
+
+func (impl PipelineRepositoryImpl) FindActivePipelineByEnvId(envId int) (pipelines []*Pipeline, err error) {
 	err = impl.dbConnection.Model(&pipelines).Column("pipeline.*", "App", "Environment").
 		Where("environment_id = ?", envId).
 		Where("deleted = ?", false).

--- a/pkg/appWorkflow/AppWorkflowService.go
+++ b/pkg/appWorkflow/AppWorkflowService.go
@@ -617,7 +617,7 @@ func (impl AppWorkflowServiceImpl) FindAppWorkflowsByEnvironmentId(request resou
 	if len(request.ResourceIds) > 0 {
 		pipelines, err = impl.pipelineRepository.FindActiveByInFilter(request.ParentResourceId, request.ResourceIds)
 	} else {
-		pipelines, err = impl.pipelineRepository.FindActiveByEnvId(request.ParentResourceId)
+		pipelines, err = impl.pipelineRepository.FindActivePipelineByEnvId(request.ParentResourceId)
 	}
 	if err != nil {
 		impl.Logger.Errorw("error in fetching pipelines", "envId", request.ParentResourceId, "err", err)


### PR DESCRIPTION
# Description

📜 Description
After changing deploymentType from argoCD to Helm or vice-versa and then triggering deployment from application groups breaks app details page, Build and Deploy page and workflow editor page for that particular application.

👟 Reproduction steps
Change the Application's Deploy Type from helm to argocd or vice-versa using devtctl tool.
Deploy the same application using application groups.
Go to the app details page, Build and Deploy page, or workflow editor page. All of them would be broken.

Fixes #4353

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [x] Tested locally 
- [x] Tested by deploying in VM.
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [x] I have added all the required unit/api test cases.
