### PR TITLE
chore: Remove the annotation hook from devtron-nats-test-request-reply pod

### DIFF
--- a/charts/devtron/Chart.yaml
+++ b/charts/devtron/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - argocd
   - Hyperion
 engine: gotpl
-version: 0.22.66
+version: 0.22.67
 sources:
   - https://github.com/devtron-labs/charts
 dependencies:

--- a/charts/devtron/templates/nats-server.yaml
+++ b/charts/devtron/templates/nats-server.yaml
@@ -263,8 +263,6 @@ metadata:
     app.kubernetes.io/name: nats
     app.kubernetes.io/instance: devtron-nats
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": test
 spec:
   containers:
     - name: nats-box


### PR DESCRIPTION


# Description
**Remove the test hook annotation from devtron-nats-test-request-reply pod from nats-server.yaml .**




## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

