### PR TITLE
feat: common-lib version update

### DIFF
--- a/api/router/pubsub/ApplicationStatusHandler.go
+++ b/api/router/pubsub/ApplicationStatusHandler.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/devtron-labs/common-lib/pubsub-lib/model"
 	"github.com/devtron-labs/devtron/pkg/app"
 	"time"
 
@@ -89,7 +90,7 @@ type ApplicationDetail struct {
 }
 
 func (impl *ApplicationStatusHandlerImpl) Subscribe() error {
-	callback := func(msg *pubsub.PubSubMsg) {
+	callback := func(msg *model.PubSubMsg) {
 		impl.logger.Debugw("APP_STATUS_UPDATE_REQ", "stage", "raw", "data", msg.Data)
 		applicationDetail := ApplicationDetail{}
 		err := json.Unmarshal([]byte(msg.Data), &applicationDetail)
@@ -170,7 +171,7 @@ func (impl *ApplicationStatusHandlerImpl) Subscribe() error {
 }
 
 func (impl *ApplicationStatusHandlerImpl) SubscribeDeleteStatus() error {
-	callback := func(msg *pubsub.PubSubMsg) {
+	callback := func(msg *model.PubSubMsg) {
 		impl.logger.Debug("received app delete event")
 
 		impl.logger.Debugw("APP_STATUS_DELETE_REQ", "stage", "raw", "data", msg.Data)

--- a/api/router/pubsub/CiEventHandler.go
+++ b/api/router/pubsub/CiEventHandler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	"github.com/caarlos0/env/v6"
 	pubsub "github.com/devtron-labs/common-lib/pubsub-lib"
+	"github.com/devtron-labs/common-lib/pubsub-lib/model"
 	"github.com/devtron-labs/devtron/internal/sql/repository"
 	"github.com/devtron-labs/devtron/internal/sql/repository/pipelineConfig"
 	"github.com/devtron-labs/devtron/pkg/pipeline"
@@ -95,7 +96,7 @@ func NewCiEventHandlerImpl(logger *zap.SugaredLogger, pubsubClient *pubsub.PubSu
 }
 
 func (impl *CiEventHandlerImpl) Subscribe() error {
-	callback := func(msg *pubsub.PubSubMsg) {
+	callback := func(msg *model.PubSubMsg) {
 		impl.logger.Debugw("ci complete event received")
 		//defer msg.Ack()
 		ciCompleteEvent := CiCompleteEvent{}

--- a/api/router/pubsub/GitWebhookHandler.go
+++ b/api/router/pubsub/GitWebhookHandler.go
@@ -19,6 +19,7 @@ package pubsub
 
 import (
 	"encoding/json"
+	"github.com/devtron-labs/common-lib/pubsub-lib/model"
 
 	pubsub "github.com/devtron-labs/common-lib/pubsub-lib"
 	"github.com/devtron-labs/devtron/client/gitSensor"
@@ -52,7 +53,7 @@ func NewGitWebhookHandler(logger *zap.SugaredLogger, pubsubClient *pubsub.PubSub
 }
 
 func (impl *GitWebhookHandlerImpl) Subscribe() error {
-	callback := func(msg *pubsub.PubSubMsg) {
+	callback := func(msg *model.PubSubMsg) {
 		//defer msg.Ack()
 		ciPipelineMaterial := gitSensor.CiPipelineMaterial{}
 		err := json.Unmarshal([]byte(string(msg.Data)), &ciPipelineMaterial)

--- a/api/router/pubsub/WorkflowStatusUpdateHandler.go
+++ b/api/router/pubsub/WorkflowStatusUpdateHandler.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	pubsub "github.com/devtron-labs/common-lib/pubsub-lib"
+	"github.com/devtron-labs/common-lib/pubsub-lib/model"
 	"github.com/devtron-labs/devtron/api/bean"
 	client "github.com/devtron-labs/devtron/client/events"
 	"github.com/devtron-labs/devtron/internal/sql/repository/pipelineConfig"
@@ -69,7 +70,7 @@ func NewWorkflowStatusUpdateHandlerImpl(logger *zap.SugaredLogger, pubsubClient 
 }
 
 func (impl *WorkflowStatusUpdateHandlerImpl) Subscribe() error {
-	callback := func(msg *pubsub.PubSubMsg) {
+	callback := func(msg *model.PubSubMsg) {
 		impl.logger.Debug("received wf update request")
 		//defer msg.Ack()
 		wfStatus := v1alpha1.WorkflowStatus{}
@@ -102,7 +103,7 @@ func (impl *WorkflowStatusUpdateHandlerImpl) Subscribe() error {
 }
 
 func (impl *WorkflowStatusUpdateHandlerImpl) SubscribeCD() error {
-	callback := func(msg *pubsub.PubSubMsg) {
+	callback := func(msg *model.PubSubMsg) {
 		impl.logger.Debug("received cd wf update request")
 		//defer msg.Ack()
 		wfStatus := v1alpha1.WorkflowStatus{}

--- a/client/cron/CdApplicationStatusUpdateHandler.go
+++ b/client/cron/CdApplicationStatusUpdateHandler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	pubsub "github.com/devtron-labs/common-lib/pubsub-lib"
+	"github.com/devtron-labs/common-lib/pubsub-lib/model"
 	"github.com/devtron-labs/devtron/api/bean"
 	client2 "github.com/devtron-labs/devtron/client/events"
 	"github.com/devtron-labs/devtron/internal/middleware"
@@ -116,7 +117,7 @@ func NewCdApplicationStatusUpdateHandlerImpl(logger *zap.SugaredLogger, appServi
 }
 
 func (impl *CdApplicationStatusUpdateHandlerImpl) Subscribe() error {
-	callback := func(msg *pubsub.PubSubMsg) {
+	callback := func(msg *model.PubSubMsg) {
 		statusUpdateEvent := pipeline.ArgoPipelineStatusSyncEvent{}
 		var err error
 		var cdPipeline *pipelineConfig.Pipeline

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v1.8.0
 	github.com/devtron-labs/authenticator v0.4.32
-	github.com/devtron-labs/common-lib v0.0.8-0.20231204083642-08f7f57000d9
+	github.com/devtron-labs/common-lib v0.0.7-beta8
 	github.com/devtron-labs/protos v0.0.0-20230503113602-282404f70fd2
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32

--- a/go.sum
+++ b/go.sum
@@ -293,8 +293,8 @@ github.com/denisenkom/go-mssqldb v0.0.0-20190707035753-2be1aa521ff4 h1:YcpmyvADG
 github.com/denisenkom/go-mssqldb v0.0.0-20190707035753-2be1aa521ff4/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
 github.com/devtron-labs/authenticator v0.4.32 h1:JAIJ0WqTXWj2nW7b8so9wunNICQn7O1Qpkk8INpatcs=
 github.com/devtron-labs/authenticator v0.4.32/go.mod h1:ozNfT8WcruiSgnUbyp48WVfc41++W6xYXhKFp67lNTU=
-github.com/devtron-labs/common-lib v0.0.8-0.20231204083642-08f7f57000d9 h1:zIYeYpnj2vB6P17xtpbgEsagmgJpSN4kzJMd8UJ/WR0=
-github.com/devtron-labs/common-lib v0.0.8-0.20231204083642-08f7f57000d9/go.mod h1:x6OdUIo2z9kxXtBfz7fJEfD4s8kiAtEmlApozOf7ECM=
+github.com/devtron-labs/common-lib v0.0.7-beta8 h1:qjSaktLbTJS+KxuI+/4jIGhRz23/jFe+wRlnJ9MKjbw=
+github.com/devtron-labs/common-lib v0.0.7-beta8/go.mod h1:x6OdUIo2z9kxXtBfz7fJEfD4s8kiAtEmlApozOf7ECM=
 github.com/devtron-labs/protos v0.0.0-20230503113602-282404f70fd2 h1:/IEIsJTxDZ3hv8uOoCaqdWCXqcv7nCAgX9AP/v84dUY=
 github.com/devtron-labs/protos v0.0.0-20230503113602-282404f70fd2/go.mod h1:l85jxWHlcSo910hdUfRycL40yGzC6glE93V1sVxVPto=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=

--- a/pkg/appStore/deployment/fullMode/AppStoreDeploymentFullModeService.go
+++ b/pkg/appStore/deployment/fullMode/AppStoreDeploymentFullModeService.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/devtron-labs/common-lib/pubsub-lib"
+	"github.com/devtron-labs/common-lib/pubsub-lib/model"
 	"path"
 	"regexp"
 	"time"
@@ -503,7 +504,7 @@ func (impl AppStoreDeploymentFullModeServiceImpl) UpdateRequirementYaml(installA
 
 func (impl AppStoreDeploymentFullModeServiceImpl) SubscribeHelmInstallStatus() error {
 
-	callback := func(msg *pubsub_lib.PubSubMsg) {
+	callback := func(msg *model.PubSubMsg) {
 
 		impl.logger.Debug("received helm install status event - HELM_INSTALL_STATUS", "data", msg.Data)
 		helmInstallNatsMessage := &appStoreBean.HelmReleaseStatusConfig{}

--- a/pkg/appStore/deployment/service/InstalledAppService.go
+++ b/pkg/appStore/deployment/service/InstalledAppService.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
+	"github.com/devtron-labs/common-lib/pubsub-lib/model"
 	util4 "github.com/devtron-labs/common-lib/utils/k8s"
 	k8sCommonBean "github.com/devtron-labs/common-lib/utils/k8s/commonBean"
 	k8sObjectUtils "github.com/devtron-labs/common-lib/utils/k8sObjectsUtil"
@@ -621,7 +622,7 @@ func (impl *InstalledAppServiceImpl) triggerDeploymentEvent(installAppVersions [
 }
 
 func (impl *InstalledAppServiceImpl) Subscribe() error {
-	callback := func(msg *pubsub.PubSubMsg) {
+	callback := func(msg *model.PubSubMsg) {
 		impl.logger.Debug("cd stage event received")
 		//defer msg.Ack()
 		deployPayload := &appStoreBean.DeployPayload{}

--- a/pkg/bulkAction/BulkUpdateService.go
+++ b/pkg/bulkAction/BulkUpdateService.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	pubsub "github.com/devtron-labs/common-lib/pubsub-lib"
+	"github.com/devtron-labs/common-lib/pubsub-lib/model"
 	"github.com/devtron-labs/devtron/api/bean"
 	client "github.com/devtron-labs/devtron/api/helm-app"
 	openapi "github.com/devtron-labs/devtron/api/helm-app/openapiClient"
@@ -1421,7 +1422,7 @@ func (impl BulkUpdateServiceImpl) BulkDeploy(request *BulkApplicationForEnvironm
 
 func (impl BulkUpdateServiceImpl) SubscribeToCdBulkTriggerTopic() error {
 
-	callback := func(msg *pubsub.PubSubMsg) {
+	callback := func(msg *model.PubSubMsg) {
 		impl.logger.Infow("Event received",
 			"topic", pubsub.CD_BULK_DEPLOY_TRIGGER_TOPIC,
 			"msg", msg.Data)

--- a/pkg/pipeline/WorkflowDagExecutor.go
+++ b/pkg/pipeline/WorkflowDagExecutor.go
@@ -26,6 +26,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	blob_storage "github.com/devtron-labs/common-lib/blob-storage"
+	"github.com/devtron-labs/common-lib/pubsub-lib/model"
 	util5 "github.com/devtron-labs/common-lib/utils/k8s"
 	"github.com/devtron-labs/common-lib/utils/k8s/health"
 	client2 "github.com/devtron-labs/devtron/api/helm-app"
@@ -409,7 +410,7 @@ func NewWorkflowDagExecutorImpl(Logger *zap.SugaredLogger, pipelineRepository pi
 }
 
 func (impl *WorkflowDagExecutorImpl) Subscribe() error {
-	callback := func(msg *pubsub.PubSubMsg) {
+	callback := func(msg *model.PubSubMsg) {
 		impl.logger.Debug("cd stage event received")
 		//defer msg.Ack()
 		cdStageCompleteEvent := CdStageCompleteEvent{}
@@ -448,7 +449,7 @@ func (impl *WorkflowDagExecutorImpl) Subscribe() error {
 	return nil
 }
 
-func (impl *WorkflowDagExecutorImpl) extractOverrideRequestFromCDAsyncInstallEvent(msg *pubsub.PubSubMsg) (*bean.AsyncCdDeployEvent, *client2.AppIdentifier, error) {
+func (impl *WorkflowDagExecutorImpl) extractOverrideRequestFromCDAsyncInstallEvent(msg *model.PubSubMsg) (*bean.AsyncCdDeployEvent, *client2.AppIdentifier, error) {
 	CDAsyncInstallNatsMessage := &bean.AsyncCdDeployEvent{}
 	err := json.Unmarshal([]byte(msg.Data), CDAsyncInstallNatsMessage)
 	if err != nil {
@@ -727,7 +728,7 @@ func (impl *WorkflowDagExecutorImpl) processDevtronAsyncHelmInstallRequest(CDAsy
 }
 
 func (impl *WorkflowDagExecutorImpl) SubscribeDevtronAsyncHelmInstallRequest() error {
-	callback := func(msg *pubsub.PubSubMsg) {
+	callback := func(msg *model.PubSubMsg) {
 		impl.logger.Debug("received Devtron App helm async install request event, SubscribeDevtronAsyncHelmInstallRequest", "data", msg.Data)
 		CDAsyncInstallNatsMessage, appIdentifier, err := impl.extractOverrideRequestFromCDAsyncInstallEvent(msg)
 		if err != nil {
@@ -2581,7 +2582,7 @@ func (impl *WorkflowDagExecutorImpl) triggerNatsEventForBulkAction(cdWorkflows [
 }
 
 func (impl *WorkflowDagExecutorImpl) subscribeTriggerBulkAction() error {
-	callback := func(msg *pubsub.PubSubMsg) {
+	callback := func(msg *model.PubSubMsg) {
 		impl.logger.Debug("subscribeTriggerBulkAction event received")
 		//defer msg.Ack()
 		cdWorkflow := new(pipelineConfig.CdWorkflow)
@@ -2639,7 +2640,7 @@ func (impl *WorkflowDagExecutorImpl) subscribeTriggerBulkAction() error {
 }
 
 func (impl *WorkflowDagExecutorImpl) subscribeHibernateBulkAction() error {
-	callback := func(msg *pubsub.PubSubMsg) {
+	callback := func(msg *model.PubSubMsg) {
 		impl.logger.Debug("subscribeHibernateBulkAction event received")
 		//defer msg.Ack()
 		deploymentGroupAppWithEnv := new(DeploymentGroupAppWithEnv)
@@ -2794,9 +2795,9 @@ func (impl *WorkflowDagExecutorImpl) TriggerHelmAsyncRelease(overrideRequest *be
 	}
 
 	event := &bean.AsyncCdDeployEvent{
-		ValuesOverrideRequest: overrideRequest,
-		TriggeredAt:           triggeredAt,
-		TriggeredBy:           triggeredBy,
+		//ValuesOverrideRequest: overrideRequest,
+		TriggeredAt: triggeredAt,
+		TriggeredBy: triggeredBy,
 	}
 	payload, err := json.Marshal(event)
 	if err != nil {

--- a/vendor/github.com/devtron-labs/common-lib/pubsub-lib/PubSubClientService.go
+++ b/vendor/github.com/devtron-labs/common-lib/pubsub-lib/PubSubClientService.go
@@ -2,31 +2,26 @@ package pubsub_lib
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/caarlos0/env"
+	"github.com/devtron-labs/common-lib/pubsub-lib/model"
 	"github.com/devtron-labs/common-lib/utils"
 	"github.com/nats-io/nats.go"
 	"go.uber.org/zap"
+	"runtime/debug"
 	"sync"
 	"time"
 )
 
 type PubSubClientService interface {
 	Publish(topic string, msg string) error
-	Subscribe(topic string, callback func(msg *PubSubMsg)) error
-}
-
-type PubSubMsg struct {
-	Data string
-}
-
-type LogsConfig struct {
-	DefaultLogTimeLimit int64 `env:"DEFAULT_LOG_TIME_LIMIT" envDefault:"1"`
+	Subscribe(topic string, callback func(msg *model.PubSubMsg)) error
 }
 
 type PubSubClientServiceImpl struct {
 	Logger     *zap.SugaredLogger
 	NatsClient *NatsClient
-	logsConfig *LogsConfig
+	logsConfig *model.LogsConfig
 }
 
 func NewPubSubClientServiceImpl(logger *zap.SugaredLogger) *PubSubClientServiceImpl {
@@ -34,7 +29,7 @@ func NewPubSubClientServiceImpl(logger *zap.SugaredLogger) *PubSubClientServiceI
 	if err != nil {
 		logger.Fatalw("error occurred while creating nats client stopping now!!")
 	}
-	logsConfig := &LogsConfig{}
+	logsConfig := &model.LogsConfig{}
 	err = env.Parse(logsConfig)
 	if err != nil {
 		logger.Errorw("error occurred while parsing LogsConfig", "err", err)
@@ -68,7 +63,7 @@ func (impl PubSubClientServiceImpl) Publish(topic string, msg string) error {
 	return nil
 }
 
-func (impl PubSubClientServiceImpl) Subscribe(topic string, callback func(msg *PubSubMsg)) error {
+func (impl PubSubClientServiceImpl) Subscribe(topic string, callback func(msg *model.PubSubMsg)) error {
 	impl.Logger.Infow("Subscribed to pubsub client", "topic", topic)
 	natsTopic := GetNatsTopic(topic)
 	streamName := natsTopic.streamName
@@ -128,7 +123,7 @@ func (impl PubSubClientServiceImpl) Subscribe(topic string, callback func(msg *P
 	return nil
 }
 
-func (impl PubSubClientServiceImpl) startListeningForEvents(processingBatchSize int, channel chan *nats.Msg, callback func(msg *PubSubMsg)) {
+func (impl PubSubClientServiceImpl) startListeningForEvents(processingBatchSize int, channel chan *nats.Msg, callback func(msg *model.PubSubMsg)) {
 	wg := new(sync.WaitGroup)
 
 	for index := 0; index < processingBatchSize; index++ {
@@ -139,7 +134,7 @@ func (impl PubSubClientServiceImpl) startListeningForEvents(processingBatchSize 
 	impl.Logger.Warn("msgs received Done from Nats side, going to end listening!!")
 }
 
-func (impl PubSubClientServiceImpl) processMessages(wg *sync.WaitGroup, channel chan *nats.Msg, callback func(msg *PubSubMsg)) {
+func (impl PubSubClientServiceImpl) processMessages(wg *sync.WaitGroup, channel chan *nats.Msg, callback func(msg *model.PubSubMsg)) {
 	defer wg.Done()
 	for msg := range channel {
 		impl.processMsg(msg, callback)
@@ -147,12 +142,47 @@ func (impl PubSubClientServiceImpl) processMessages(wg *sync.WaitGroup, channel 
 }
 
 // TODO need to extend msg ack depending upon response from callback like error scenario
-func (impl PubSubClientServiceImpl) processMsg(msg *nats.Msg, callback func(msg *PubSubMsg)) {
+func (impl PubSubClientServiceImpl) processMsg(msg *nats.Msg, callback func(msg *model.PubSubMsg)) {
 	timeLimitInMillSecs := impl.logsConfig.DefaultLogTimeLimit * 1000
 	t1 := time.Now()
 	defer impl.printTimeDiff(t1, msg, timeLimitInMillSecs)
-	defer msg.Ack()
-	subMsg := &PubSubMsg{Data: string(msg.Data)}
+	impl.TryCatchCallBack(msg, callback)
+}
+
+func (impl PubSubClientServiceImpl) publishPanicError(msg *nats.Msg, panicErr error) (err error) {
+	impl.Logger.Warnw("found panic error", "subject", msg.Subject, "payload", string(msg.Data))
+	publishPanicEvent := model.PublishPanicEvent{
+		Topic: PANIC_ON_PROCESSING_TOPIC,
+		Payload: model.PanicEventIdentifier{
+			Topic:     msg.Subject,
+			Data:      string(msg.Data),
+			PanicInfo: panicErr.Error(),
+		},
+	}
+	data, err := json.Marshal(publishPanicEvent.Payload)
+	if err != nil {
+		impl.Logger.Errorw("error in marshalling data! unable to publish panic error", "err", err)
+		return err
+	}
+	err = impl.Publish(publishPanicEvent.Topic, string(data))
+	if err != nil {
+		impl.Logger.Errorw("error in publishing panic error", "err", err)
+		return err
+	}
+	return nil
+}
+
+func (impl PubSubClientServiceImpl) TryCatchCallBack(msg *nats.Msg, callback func(msg *model.PubSubMsg)) {
+	subMsg := &model.PubSubMsg{Data: string(msg.Data)}
+	defer func() {
+		msg.Ack()
+		// panic recovery
+		if panicInfo := recover(); panicInfo != nil {
+			err := fmt.Errorf("%v\nPanic Logs:\n%s", panicInfo, string(debug.Stack()))
+			impl.publishPanicError(msg, err)
+			return
+		}
+	}()
 	callback(subMsg)
 }
 

--- a/vendor/github.com/devtron-labs/common-lib/pubsub-lib/model/PubSubClientBean.Go.go
+++ b/vendor/github.com/devtron-labs/common-lib/pubsub-lib/model/PubSubClientBean.Go.go
@@ -1,0 +1,20 @@
+package model
+
+type PubSubMsg struct {
+	Data string
+}
+
+type LogsConfig struct {
+	DefaultLogTimeLimit int64 `env:"DEFAULT_LOG_TIME_LIMIT" envDefault:"1"`
+}
+
+type PublishPanicEvent struct {
+	Topic   string               `json:"topic"`
+	Payload PanicEventIdentifier `json:"payload"`
+}
+
+type PanicEventIdentifier struct {
+	Topic     string `json:"topic"`
+	Data      string `json:"data"`
+	PanicInfo string `json:"panicInfo"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -349,10 +349,11 @@ github.com/devtron-labs/authenticator/jwt
 github.com/devtron-labs/authenticator/middleware
 github.com/devtron-labs/authenticator/oidc
 github.com/devtron-labs/authenticator/password
-# github.com/devtron-labs/common-lib v0.0.8-0.20231204083642-08f7f57000d9
+# github.com/devtron-labs/common-lib v0.0.7-beta8
 ## explicit; go 1.20
 github.com/devtron-labs/common-lib/blob-storage
 github.com/devtron-labs/common-lib/pubsub-lib
+github.com/devtron-labs/common-lib/pubsub-lib/model
 github.com/devtron-labs/common-lib/utils
 github.com/devtron-labs/common-lib/utils/bean
 github.com/devtron-labs/common-lib/utils/http


### PR DESCRIPTION
# Description:
In case of pub sub client if the callback process throws panic, the consumer micro service gets killed abruptly. Also the faulty event doesn't get acknowledged and marked for redelivery in the message queue. This causes an issue where our micro service gets multiple restarts as we process the faulty event in an infinite loop.

To tackle this issue we can recover panic gracefully and publish an event with the required informations and logs for quick support/ fix. Also graceful recovery will ensure no downtime for the consumer service.

Fixes https://github.com/devtron-labs/devtron/issues/4395

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

