### PR TITLE
doc: Update Helm Installation Command

### DIFF
--- a/config.md
+++ b/config.md
@@ -45,18 +45,18 @@
 | ACD_TIMEOUT                            | 300                                                      | Argocd timeout. |
 | ACD_SKIP_VERIFY                        | true                                                     | Skip Argocd verification. |
 | GIT_WORKING_DIRECTORY                   | /tmp/gitops/                                             | Git working directory. |
-| CD_LIMIT_CI_CPU                        | 0.5                                                     | CI CPU limit for post-build workflow. |
-| CD_LIMIT_CI_MEM                        | 3G                                                      | CI memory limit for post-build workflow. |
-| CD_REQ_CI_CPU                          | 0.5                                                     | CI CPU request for post-build workflow. |
-| CD_REQ_CI_MEM                          | 1G                                                      | CI memory request for post-build workflow. |
-| CD_NODE_TAINTS_KEY                     | dedicated                                               | CI node taints key. |
-| CD_NODE_LABEL_SELECTOR                 | kubernetes.io/os=linux                                   | CI node label selector. |
-| CD_WORKFLOW_SERVICE_ACCOUNT             | cd-runner                                                | CI workflow service account. |
-| CD_NODE_TAINTS_VALUE                   | ci                                                      | CI node taints value. |
-| DEFAULT_CD_ARTIFACT_KEY_LOCATION       | devtron/cd-artifacts                                      | Default location for CI artifacts. |
-| CD_ARTIFACT_LOCATION_FORMAT            | %d/%d.zip                                                | Format for CI artifact locations. |
-| DEFAULT_CD_NAMESPACE                   | devtron-cd                                               | Default namespace for CI. |
-| DEFAULT_CD_TIMEOUT                     | 3600                                                    | Default timeout for CI. |
+| CD_LIMIT_CI_CPU                        | 0.5                                                     | CD CPU limit for post/pre-deploy workflow. |
+| CD_LIMIT_CI_MEM                        | 3G                                                      | CD memory limit for post/pre-deploy workflow. |
+| CD_REQ_CI_CPU                          | 0.5                                                     | CD CPU request for post/pre-deploy workflow. |
+| CD_REQ_CI_MEM                          | 1G                                                      | CD memory request for post/pre-deploy workflow. |
+| CD_NODE_TAINTS_KEY                     | dedicated                                               | CD node taints key. |
+| CD_NODE_LABEL_SELECTOR                 | kubernetes.io/os=linux                                   | CD node label selector. |
+| CD_WORKFLOW_SERVICE_ACCOUNT             | cd-runner                                                | CD workflow service account. |
+| CD_NODE_TAINTS_VALUE                   | ci                                                      | CD node taints value. |
+| DEFAULT_CD_ARTIFACT_KEY_LOCATION       | devtron/cd-artifacts                                      | Default location for CD artifacts. |
+| CD_ARTIFACT_LOCATION_FORMAT            | %d/%d.zip                                                | Format for CD artifact locations. |
+| DEFAULT_CD_NAMESPACE                   | devtron-cd                                               | Default namespace for CD. |
+| DEFAULT_CD_TIMEOUT                     | 3600                                                    | Default timeout for CD. |
 | ENABLE_BUILD_CONTEXT                   | true                                                    | Enable build context in Devtron. |
 | DEFAULT_CI_IMAGE                       | quay.io/devtron/ci-runner:d8d774c3-138-16238             | Default image for CI pods. |
 | WF_CONTROLLER_INSTANCE_ID               | devtron-runner                                           | Workflow controller instance ID. |

--- a/docs/setup/install/Install-devtron-on-Minikube-Microk8s-K3s-Kind.md
+++ b/docs/setup/install/Install-devtron-on-Minikube-Microk8s-K3s-Kind.md
@@ -28,6 +28,8 @@ Before we get started and install Devtron, you must set up the cluster in you se
 ```bash
 helm repo add devtron https://helm.devtron.ai
 
+helm repo update devtron
+
 helm install devtron devtron/devtron-operator \
 --create-namespace --namespace devtroncd \
 --set components.devtron.service.type=NodePort --set installer.arch=multi-arch
@@ -42,6 +44,8 @@ To install devtron on ``k3s`` cluster, run the following command:
 kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
 
 helm repo add devtron https://helm.devtron.ai
+
+helm repo update devtron
 
 helm install devtron devtron/devtron-operator \
 --create-namespace --namespace devtroncd \
@@ -119,6 +123,8 @@ source .bashrc
 
 ```bash
 helm repo add devtron https://helm.devtron.ai
+
+helm repo update devtron
 
 helm install devtron devtron/devtron-operator \
 --create-namespace --namespace devtroncd \

--- a/docs/setup/install/install-devtron-helm-3.md
+++ b/docs/setup/install/install-devtron-helm-3.md
@@ -7,7 +7,9 @@ Install [Helm3](https://helm.sh/docs/intro/install/).
 ## Installing Devtron using Helm
 
 1. Add Devtron repository
-2. Install Devtron
+2. Update Devtron repository
+3. Install Devtron
+
 
 {% tabs %}
 {% tab title="Install with default configurations" %}
@@ -15,6 +17,8 @@ This installation will use Minio for storing build logs and cache.
 
 ```bash
 helm repo add devtron https://helm.devtron.ai
+
+helm repo update devtron
 
 helm install devtron devtron/devtron-operator --create-namespace --namespace devtroncd \
 --set installer.modules={cicd}
@@ -26,6 +30,7 @@ This installation will use AWS s3 buckets for storing build logs and cache. Refe
 
 ```bash
 helm repo add devtron https://helm.devtron.ai
+helm repo update devtron
 helm install devtron devtron/devtron-operator --create-namespace --namespace devtroncd \
 --set installer.modules={cicd} \
 --set configs.BLOB_STORAGE_PROVIDER=S3 \
@@ -42,6 +47,7 @@ Refer to the `Azure specific` parameters on the [Storage for Logs and Cache](./i
 
 ```bash
 helm repo add devtron https://helm.devtron.ai
+helm repo update devtron
 helm install devtron devtron/devtron-operator --create-namespace --namespace devtroncd \
 --set installer.modules={cicd} \
 --set secrets.AZURE_ACCOUNT_KEY=xxxxxxxxxx \

--- a/docs/setup/install/install-devtron-with-cicd-with-gitops.md
+++ b/docs/setup/install/install-devtron-with-cicd-with-gitops.md
@@ -15,6 +15,8 @@ Run the following command to install the latest version of Devtron with CI/CD al
 ```bash
 helm repo add devtron https://helm.devtron.ai
 
+helm repo update devtron
+
 helm install devtron devtron/devtron-operator \
 --create-namespace --namespace devtroncd \
 --set installer.modules={cicd} \
@@ -53,6 +55,8 @@ Run the following command to install Devtron along with MinIO for storing logs a
 ```bash
 helm repo add devtron https://helm.devtron.ai 
 
+helm repo update devtron
+
 helm install devtron devtron/devtron-operator \
 --create-namespace --namespace devtroncd \
 --set installer.modules={cicd} \
@@ -76,6 +80,8 @@ Run the following command to install Devtron along with AWS S3 buckets for stori
 ```bash
 helm repo add devtron https://helm.devtron.ai
 
+helm repo update devtron
+
 helm install devtron devtron/devtron-operator \
 --create-namespace --namespace devtroncd \
 --set installer.modules={cicd} \
@@ -91,6 +97,8 @@ helm install devtron devtron/devtron-operator \
 
 ```bash
 helm repo add devtron https://helm.devtron.ai
+
+helm repo update devtron
 
 helm install devtron devtron/devtron-operator \
 --create-namespace --namespace devtroncd \
@@ -109,6 +117,8 @@ helm install devtron devtron/devtron-operator \
 
 ```bash
 helm repo add devtron https://helm.devtron.ai
+
+helm repo update devtron
 
 helm install devtron devtron/devtron-operator \
 --create-namespace --namespace devtroncd \
@@ -135,6 +145,8 @@ Run the following command to install Devtron along with Azure Blob Storage for s
 ```bash
 helm repo add devtron https://helm.devtron.ai
 
+helm repo update devtron
+
 helm install devtron devtron/devtron-operator \
 --create-namespace --namespace devtroncd \
 --set installer.modules={cicd} \
@@ -157,6 +169,8 @@ Run the following command to install Devtron along with Google Cloud Storage for
 
 ```bash
 helm repo add devtron https://helm.devtron.ai
+
+helm repo update devtron
 
 helm install devtron devtron/devtron-operator \
 --create-namespace --namespace devtroncd \

--- a/docs/setup/install/install-devtron-with-cicd.md
+++ b/docs/setup/install/install-devtron-with-cicd.md
@@ -31,6 +31,8 @@ Run the following command to install the latest version of Devtron along with th
 ```bash
 helm repo add devtron https://helm.devtron.ai 
 
+helm repo update devtron
+
 helm install devtron devtron/devtron-operator \
 --create-namespace --namespace devtroncd \
 --set installer.modules={cicd}
@@ -72,6 +74,8 @@ Run the following command to install Devtron along with MinIO for storing logs a
 ```bash
 helm repo add devtron https://helm.devtron.ai 
 
+helm repo update devtron
+
 helm install devtron devtron/devtron-operator \
 --create-namespace --namespace devtroncd \
 --set installer.modules={cicd} \
@@ -94,6 +98,8 @@ Run the following command to install Devtron along with AWS S3 buckets for stori
 ```bash
 helm repo add devtron https://helm.devtron.ai
 
+helm repo update devtron
+
 helm install devtron devtron/devtron-operator \
 --create-namespace --namespace devtroncd \
 --set installer.modules={cicd} \
@@ -108,6 +114,8 @@ helm install devtron devtron/devtron-operator \
 
 ```bash
 helm repo add devtron https://helm.devtron.ai
+
+helm repo update devtron
 
 helm install devtron devtron/devtron-operator \
 --create-namespace --namespace devtroncd \
@@ -125,6 +133,8 @@ helm install devtron devtron/devtron-operator \
 
 ```bash
 helm repo add devtron https://helm.devtron.ai
+
+helm repo update devtron
 
 helm install devtron devtron/devtron-operator \
 --create-namespace --namespace devtroncd \
@@ -150,6 +160,8 @@ Run the following command to install Devtron along with Azure Blob Storage for s
 ```bash
 helm repo add devtron https://helm.devtron.ai
 
+helm repo update devtron
+
 helm install devtron devtron/devtron-operator \
 --create-namespace --namespace devtroncd \
 --set installer.modules={cicd} \
@@ -170,6 +182,8 @@ Run the following command to install Devtron along with Google Cloud Storage for
 
 ```bash
 helm repo add devtron https://helm.devtron.ai
+
+helm repo update devtron
 
 helm install devtron devtron/devtron-operator \
 --create-namespace --namespace devtroncd \

--- a/docs/setup/install/install-devtron.md
+++ b/docs/setup/install/install-devtron.md
@@ -14,6 +14,11 @@ Install [Helm](https://helm.sh/docs/intro/install/) if you have not installed it
 helm repo add devtron https://helm.devtron.ai
 ```
 
+## Update Helm Repo
+```bash
+helm repo update devtron
+```
+
 ## Install Helm Dashboard by Devtron
 
 **Note**: This installation command will not install CI/CD integration. For CI/CD, refer [install Devtron with CI/CD](https://docs.devtron.ai/install/install-devtron-with-cicd) section.

--- a/docs/setup/install/installation-configuration.md
+++ b/docs/setup/install/installation-configuration.md
@@ -137,6 +137,7 @@ Use the following command to configure MinIO for storing logs and cache.
 helm repo update
 
 helm upgrade devtron devtron/devtron-operator --namespace devtroncd \
+--reuse-values \
 --set installer.modules={cicd} \
 --set minio.enabled=true
 ```
@@ -153,6 +154,7 @@ Use the following command to configure AWS S3 bucket for storing build logs and 
 ```bash
 helm repo update
 helm upgrade devtron devtron/devtron-operator --namespace devtroncd \
+--reuse-values \
 --set installer.modules={cicd} \
 --set configs.BLOB_STORAGE_PROVIDER=S3 \
 --set configs.DEFAULT_CACHE_BUCKET=demo-s3-bucket \
@@ -167,6 +169,7 @@ helm upgrade devtron devtron/devtron-operator --namespace devtroncd \
 helm repo update
 
 helm upgrade devtron devtron/devtron-operator --namespace devtroncd \
+--reuse-values \
 --set installer.modules={cicd} \
 --set configs.BLOB_STORAGE_PROVIDER=S3 \
 --set configs.DEFAULT_CACHE_BUCKET=demo-s3-bucket \
@@ -183,6 +186,7 @@ helm upgrade devtron devtron/devtron-operator --namespace devtroncd \
 helm repo update
 
 helm upgrade devtron devtron/devtron-operator --namespace devtroncd \
+--reuse-values \
 --set installer.modules={cicd} \
 --set configs.BLOB_STORAGE_PROVIDER=S3 \
 --set configs.DEFAULT_CACHE_BUCKET=demo-s3-bucket \
@@ -203,6 +207,7 @@ Refer to the `Azure specific` parameters on the [Storage for Logs and Cache](#az
 ```bash
 helm repo update
 helm upgrade devtron devtron/devtron-operator --namespace devtroncd \
+--reuse-values \
 --set installer.modules={cicd} \
 --set secrets.AZURE_ACCOUNT_KEY=xxxxxxxxxx \
 --set configs.BLOB_STORAGE_PROVIDER=AZURE \
@@ -221,6 +226,7 @@ Refer to the `Google Cloud specific` parameters on the [Storage for Logs and Cac
 helm repo update
 
 helm upgrade devtron devtron/devtron-operator --namespace devtroncd \
+--reuse-values \
 --set installer.modules={cicd} \
 --set configs.BLOB_STORAGE_PROVIDER=GCP \
 --set secrets.BLOB_STORAGE_GCP_CREDENTIALS_JSON=eyJ0eXBlIjogInNlcnZpY2VfYWNjb3VudCIsInByb2plY3RfaWQiOiAiPHlvdXItcHJvamVjdC1pZD4iLCJwcml2YXRlX2tleV9pZCI6ICI8eW91ci1wcml2YXRlLWtleS1pZD4iLCJwcml2YXRlX2tleSI6ICI8eW91ci1wcml2YXRlLWtleT4iLCJjbGllbnRfZW1haWwiOiAiPHlvdXItY2xpZW50LWVtYWlsPiIsImNsaWVudF9pZCI6ICI8eW91ci1jbGllbnQtaWQ+IiwiYXV0aF91cmkiOiAiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tL28vb2F1dGgyL2F1dGgiLCJ0b2tlbl91cmkiOiAiaHR0cHM6Ly9vYXV0aDIuZ29vZ2xlYXBpcy5jb20vdG9rZW4iLCJhdXRoX3Byb3ZpZGVyX3g1MDlfY2VydF91cmwiOiAiaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vb2F1dGgyL3YxL2NlcnRzIiwiY2xpZW50X3g1MDlfY2VydF91cmwiOiAiPHlvdXItY2xpZW50LWNlcnQtdXJsPiJ9Cg== \


### PR DESCRIPTION
Description:
Refine the Helm installation process to ensure the latest version is installed, addressing an issue where an older version might be installed if the Helm repo is not updated. This modification includes adding the `helm repo update` command to refresh the repository before installation.

Changes:
- Previously: Helm repo was added, and installation was performed directly.
- Updated: Added `helm repo update devtron` command to ensure the latest version is fetched before installation.

```
helm repo add devtron https://helm.devtron.ai

helm repo update devtron

helm install devtron devtron/devtron-operator --create-namespace --namespace devtroncd \
--set installer.modules={cicd}
```

Additionally, the documentation now highlights the use of the `--reuse-values` flag during the helm upgrade command. This flag is essential for maintaining consistent configuration values without requiring explicit redefinition during upgrades.
