### PR TITLE
fix: panic in app clone service for [linked ci, external ci, linked cd] cases

### DIFF
--- a/pkg/appClone/AppCloneService.go
+++ b/pkg/appClone/AppCloneService.go
@@ -935,6 +935,8 @@ func (impl *AppCloneServiceImpl) CreateCiPipeline(req *cloneCiPipelineRequest) (
 			DockerRepository: templateOverride.DockerRepository,
 			CiBuildConfig:    ciBuildConfig,
 		}
+	} else if refCiPipeline.IsExternal {
+		ciPatchReq.CiPipeline.IsDockerConfigOverridden = false
 	}
 	return impl.pipelineBuilder.PatchCiPipeline(ciPatchReq)
 }


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
For [linked ci, external ci, linked cd] cases, in app clone we were not setting ci build config data which is correct, but we were trying to access the same data in pipeline template creation without checking these types. The type was checked later when doing db operation. Moved the check before setting to avoid nil pointer panic.

Fixes #4520

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

