### PR TITLE
doc: Redirection added for old SSO doc link

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -70,3 +70,4 @@ redirects:
     user-guide/use-cases/connect-django-with-mysql-database: resources/use-cases/connect-django-with-mysql-database
     user-guide/telemetry: resources/telemetry
     getting-started/global-configurations/container-registries: user-guide/global-configurations/container-registries.md
+    getting-started/global-configurations/sso-login: user-guide/global-configurations/sso-login.md


### PR DESCRIPTION
<img width="893" alt="image" src="https://github.com/devtron-labs/devtron/assets/141001279/fa50f266-b126-478e-b0c1-f791f7dbfa47">

<img width="1199" alt="image" src="https://github.com/devtron-labs/devtron/assets/141001279/244ef69b-530d-4b5b-b021-72c744c324d8">

As shown in the above snapshots, the link was pointing to a non-existing/old URL. Therefore, appropriate redirection has been added.