### PR TITLE
fix: nil pointer issue in manual sync api

### DIFF
--- a/api/restHandler/app/pipeline/status/PipelineStatusTimelineRestHandler.go
+++ b/api/restHandler/app/pipeline/status/PipelineStatusTimelineRestHandler.go
@@ -33,13 +33,18 @@ type PipelineStatusTimelineRestHandlerImpl struct {
 }
 
 func NewPipelineStatusTimelineRestHandlerImpl(logger *zap.SugaredLogger,
+	userService user.UserService,
 	pipelineStatusTimelineService status.PipelineStatusTimelineService, enforcerUtil rbac.EnforcerUtil,
-	enforcer casbin.Enforcer) *PipelineStatusTimelineRestHandlerImpl {
+	enforcer casbin.Enforcer, cdApplicationStatusUpdateHandler cron.CdApplicationStatusUpdateHandler,
+	pipeline pipeline.PipelineBuilder) *PipelineStatusTimelineRestHandlerImpl {
 	return &PipelineStatusTimelineRestHandlerImpl{
-		logger:                        logger,
-		pipelineStatusTimelineService: pipelineStatusTimelineService,
-		enforcerUtil:                  enforcerUtil,
-		enforcer:                      enforcer,
+		logger:                           logger,
+		userService:                      userService,
+		pipelineStatusTimelineService:    pipelineStatusTimelineService,
+		enforcerUtil:                     enforcerUtil,
+		enforcer:                         enforcer,
+		cdApplicationStatusUpdateHandler: cdApplicationStatusUpdateHandler,
+		pipeline:                         pipeline,
 	}
 }
 


### PR DESCRIPTION
# Description
The Manual Sync API for deployment status is throwing nil pointer deference.

Fixes https://github.com/devtron-labs/devtron/issues/4677

## How Has This Been Tested?
- [x] Deployment Status Timeline API
- [x] Deployment Status Manual Sync API

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

