### PR TITLE
fix: chart repo delete routing

### DIFF
--- a/api/chartRepo/ChartRepositoryRouter.go
+++ b/api/chartRepo/ChartRepositoryRouter.go
@@ -48,6 +48,6 @@ func (router ChartRepositoryRouterImpl) Init(configRouter *mux.Router) {
 		HandlerFunc(router.chartRepositoryRestHandler.UpdateChartRepo).Methods("POST")
 	configRouter.Path("/validate").
 		HandlerFunc(router.chartRepositoryRestHandler.ValidateChartRepo).Methods("POST")
-	configRouter.Path("/").
+	configRouter.Path("").
 		HandlerFunc(router.chartRepositoryRestHandler.DeleteChartRepo).Methods("DELETE")
 }


### PR DESCRIPTION
# Description
Fixed chart-repos delete issue on Safari with an Error response `an EOF (Bad response)`. This issue was due to URL redirection from the browser.


![image](https://github.com/devtron-labs/devtron/assets/68757539/ec7b263c-aa46-4d70-a073-1961576fa263)

Fixes https://github.com/devtron-labs/devtron/issues/4582


## How Has This Been Tested?
- [x] Delete Chart Repo

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

