### PR TITLE
feat: Github Pull Request Closer PLugin

### DIFF
--- a/scripts/sql/226_Github_Pull_Request_Closer.down.sql
+++ b/scripts/sql/226_Github_Pull_Request_Closer.down.sql
@@ -1,0 +1,8 @@
+
+DELETE FROM plugin_step_variable where plugin_step_id=(SELECT ps.id FROM plugin_metadata p inner JOIN plugin_step ps on ps.plugin_id=p.id WHERE p.name='Github Pull Request Closer v1.0' and ps."index"=1 and ps.deleted=false);
+DELETE FROM plugin_stage_mapping where plugin_id=(SELECT id from plugin_metadata where name='Github Pull Request Closer v1.0');
+DELETE FROM plugin_step where plugin_id=(SELECT id FROM plugin_metadata WHERE name='Github Pull Request Closer v1.0');
+DELETE FROM plugin_tag_relation WHERE plugin_id=(SELECT id FROM plugin_metadata WHERE name='Github Pull Request Closer v1.0');
+DELETE FROM pipeline_stage_step_variable where pipeline_stage_step_id in (select id from pipeline_stage_step where name ='Github Pull Request Closer v1.0');
+DELETE FROM pipeline_stage_step WHERE name ='Github Pull Request Closer v1.0';
+DELETE FROM plugin_metadata where name='Github Pull Request Closer v1.0';

--- a/scripts/sql/226_Github_Pull_Request_Closer.up.sql
+++ b/scripts/sql/226_Github_Pull_Request_Closer.up.sql
@@ -1,0 +1,81 @@
+INSERT INTO plugin_metadata (id,name,description,type,icon,deleted,created_on,created_by,updated_on,updated_by)
+VALUES (nextval('id_seq_plugin_metadata'),'Github Pull Request Closer v1.0','Closing Pull Requests in Github ','PRESET','https://raw.githubusercontent.com/YashasviDevtron/Practicetask/main/GithubReleasePR.png',false,'now()',1,'now()',1);
+
+INSERT INTO plugin_tag_relation ("id", "tag_id", "plugin_id", "created_on", "created_by", "updated_on", "updated_by") VALUES (nextval('id_seq_plugin_tag_relation'), (SELECT id FROM plugin_tag WHERE name='Github'), (SELECT id FROM plugin_metadata WHERE name='Github Pull Request Closer v1.0'),'now()', 1, 'now()', 1);
+
+
+INSERT INTO plugin_stage_mapping (id,plugin_id,stage_type,created_on,created_by,updated_on,updated_by)VALUES (nextval('id_seq_plugin_stage_mapping'),
+(SELECT id from plugin_metadata where name='Github Pull Request Closer v1.0'), 0,'now()',1,'now()',1);
+
+INSERT INTO "plugin_pipeline_script" ("id", "script","type","deleted","created_on", "created_by", "updated_on", "updated_by")
+VALUES ( nextval('id_seq_plugin_pipeline_script'),
+E'#!/bin/bash
+set -e
+    source_type=$(echo "$CI_CD_EVENT" | jq -r \'.commonWorkflowRequest.ciProjectDetails[0].sourceType\')
+     if [ "$source_type" == "WEBHOOK" ]; then
+        echo "Source type is Pull Request. Running script..."
+       
+        var1_json=$(jq -n --arg value "$PreviousOutput" \'$value\')
+        var2_json=$(jq -n --arg value "$CurrentInputMatch" \'$value\')
+        
+        if [ "$var1_json" == "$var2_json" ]; then
+            echo "Variables match!"
+
+            git_repository=$(echo "$CI_CD_EVENT" | jq -r \'.commonWorkflowRequest.ciProjectDetails[0].gitRepository\')
+          if [[ $git_repository =~ ^git@ ]]; then
+                username=$(echo "$git_repository" | cut -d \':\' -f 2 | cut -d \'/\' -f 1)
+                repo_name=$(echo "$git_repository" | cut -d \'/\' -f 2 | cut -d \'.\' -f 1)
+        elif [[ $git_repository =~ ^https:// ]]; then
+            username=$(echo "$git_repository" | awk -F/ \'{print $4}\')
+            repo_name=$(echo "$git_repository" | awk -F/ \'{print $5}\' | cut -d \'.\' -f 1)
+        else
+            echo "Invalid Git URL format."
+        fi
+
+        token=$(echo "$CI_CD_EVENT" | jq -r \'.commonWorkflowRequest.ciProjectDetails[0].gitOptions.password\')
+        repo_url=$(echo "$CI_CD_EVENT" | jq -r \'.commonWorkflowRequest.ciProjectDetails[0].WebhookData.data."git url"\')
+        owner_repo=$(echo "$repo_url" | awk -F/ \'{print $(NF-3)"/"$(NF-2)}\')
+        number=$(echo "$repo_url" | awk -F/ \'{print $(NF)}\')
+        
+        output=$(curl -sS https://webi.sh/gh | sh)
+        source ~/.config/envman/PATH.env > /dev/null 2>&1
+
+        echo "$token" | gh auth login --with-token
+        pr_state=$(gh pr view "$number" --repo "$owner_repo" --json state | jq -r \'.state\')
+
+        if [ "$pr_state" == "closed" ]; then
+            echo "Pull request is already closed."
+        else
+            echo "Pull request is not closed. Closing PR..."
+            if gh pr close "$repo_url"; then
+                echo "Pull request closed successfully."
+            else
+                echo "Failed to close the pull request."
+                exit 1
+            fi
+        fi
+        PullRequestNumber=$number
+    export PullRequestNumber
+    echo "Pull Request Number: $PullRequestNumber"
+        else
+             echo "Pattern does not match" 
+        fi
+    else
+        echo "Source type is not Pull Request. Skipping plugin execution."
+    fi',
+    'SHELL',
+    'f',
+    'now()',
+    1,
+    'now()',
+    1
+);
+
+INSERT INTO "plugin_step" ("id", "plugin_id","name","description","index","step_type","script_id","deleted", "created_on", "created_by", "updated_on", "updated_by") VALUES (nextval('id_seq_plugin_step'), (SELECT id FROM plugin_metadata WHERE name='Github Pull Request Closer v1.0'),'Step 1','Step 1 - Github Pull Request Closer v1.0','1','INLINE',(SELECT last_value FROM id_seq_plugin_pipeline_script),'f','now()', 1, 'now()', 1);
+
+INSERT INTO plugin_step_variable (id,plugin_step_id,name,format,description,is_exposed,allow_empty_value,default_value,value,variable_type,value_type,previous_step_index,variable_step_index,variable_step_index_in_plugin,reference_variable_name,deleted,created_on,created_by,updated_on,updated_by) 
+VALUES 
+(nextval('id_seq_plugin_step_variable'),(SELECT ps.id FROM plugin_metadata p inner JOIN plugin_step ps on ps.plugin_id=p.id WHERE p.name='Github Pull Request Closer v1.0' and ps."index"=1 and ps.deleted=false),'PreviousOutput','STRING','Take the output variable obtained from the last script execution.','t','f',null,null,'INPUT','NEW',null,1,null,null,'f','now()',1,'now()',1),
+(nextval('id_seq_plugin_step_variable'),(SELECT ps.id FROM plugin_metadata p inner JOIN plugin_step ps on ps.plugin_id=p.id WHERE p.name='Github Pull Request Closer v1.0' and ps."index"=1 and ps.deleted=false),'CurrentInputMatch','STRING','Enter the value to be compared.','t','f',null,null,'INPUT','NEW',null,1,null,null,'f','now()',1,'now()',1),
+(nextval('id_seq_plugin_step_variable'),(SELECT ps.id FROM plugin_metadata p inner JOIN plugin_step ps on ps.plugin_id=p.id WHERE p.name='Github Pull Request Closer v1.0' and ps."index"=1 and ps.deleted=false),'PullRequestNumber','STRING','It displays the unique identifier (PR number) assigned to the GitHub Pull Request.','t','f',null,null,'OUTPUT','NEW',null,1,null,null,'f','now()',1,'now()',1);
+


### PR DESCRIPTION
This plugin is useful when there's a need to test a custom script or functionality associated with a PR, and once the testing is successful, the PR can be closed automatically.

