### PR TITLE
fix: update semverCompare kube version with proper Major.Minor.Patch-release placeholders for helm to compare

### DIFF
--- a/scripts/devtron-reference-helm-charts/cronjob-chart_1-2-0/templates/Cronjob.yaml
+++ b/scripts/devtron-reference-helm-charts/cronjob-chart_1-2-0/templates/Cronjob.yaml
@@ -25,7 +25,7 @@
   {{- end }}
 
 {{ if eq .Values.kind "CronJob" }}
-{{ if semverCompare "<1.21" .Capabilities.KubeVersion.GitVersion -}}
+{{ if semverCompare "<1.21.0-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: batch/v1beta1
 {{- else }}
 apiVersion: batch/v1
@@ -42,7 +42,7 @@ spec:
   schedule: {{ $.Values.cronjobConfigs.schedule | quote }}
   startingDeadlineSeconds: {{ $.Values.cronjobConfigs.startingDeadlineSeconds }}
   concurrencyPolicy: {{ $.Values.cronjobConfigs.concurrencyPolicy }}
-  {{ if semverCompare ">1.20" .Capabilities.KubeVersion.GitVersion -}}
+  {{ if semverCompare ">1.20.0-0" .Capabilities.KubeVersion.Version -}}
   suspend: {{ $.Values.cronjobConfigs.suspend }}
   {{- end }}
   successfulJobsHistoryLimit: {{ $.Values.cronjobConfigs.successfulJobsHistoryLimit }}

--- a/scripts/devtron-reference-helm-charts/cronjob-chart_1-2-0/templates/job.yaml
+++ b/scripts/devtron-reference-helm-charts/cronjob-chart_1-2-0/templates/job.yaml
@@ -40,7 +40,7 @@ spec:
   activeDeadlineSeconds: {{ .Values.jobConfigs.activeDeadlineSeconds }}
   parallelism: {{ .Values.jobConfigs.parallelism }}
   completions: {{ .Values.jobConfigs.completions }}
-  {{ if semverCompare ">1.20" .Capabilities.KubeVersion.GitVersion -}}
+  {{ if semverCompare ">1.20.0-0" .Capabilities.KubeVersion.Version -}}
   suspend: {{ .Values.jobConfigs.suspend }}
   {{- end }}
   ttlSecondsAfterFinished: {{ .Values.jobConfigs.ttlSecondsAfterFinished }}

--- a/scripts/devtron-reference-helm-charts/cronjob-chart_1-3-0/templates/cronjob.yaml
+++ b/scripts/devtron-reference-helm-charts/cronjob-chart_1-3-0/templates/cronjob.yaml
@@ -25,7 +25,7 @@
   {{- end }}
 
 {{ if eq .Values.kind "CronJob" }}
-{{ if semverCompare "<1.21" .Capabilities.KubeVersion.GitVersion -}}
+{{ if semverCompare "<1.21.0-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: batch/v1beta1
 {{- else }}
 apiVersion: batch/v1
@@ -42,7 +42,7 @@ spec:
   schedule: {{ $.Values.cronjobConfigs.schedule | quote }}
   startingDeadlineSeconds: {{ $.Values.cronjobConfigs.startingDeadlineSeconds }}
   concurrencyPolicy: {{ $.Values.cronjobConfigs.concurrencyPolicy }}
-  {{ if semverCompare ">1.20" .Capabilities.KubeVersion.GitVersion -}}
+  {{ if semverCompare ">1.20.0-0" .Capabilities.KubeVersion.Version -}}
   suspend: {{ $.Values.cronjobConfigs.suspend }}
   {{- end }}
   successfulJobsHistoryLimit: {{ $.Values.cronjobConfigs.successfulJobsHistoryLimit }}

--- a/scripts/devtron-reference-helm-charts/cronjob-chart_1-3-0/templates/job.yaml
+++ b/scripts/devtron-reference-helm-charts/cronjob-chart_1-3-0/templates/job.yaml
@@ -40,7 +40,7 @@ spec:
   activeDeadlineSeconds: {{ .Values.jobConfigs.activeDeadlineSeconds }}
   parallelism: {{ .Values.jobConfigs.parallelism }}
   completions: {{ .Values.jobConfigs.completions }}
-  {{ if semverCompare ">1.20" .Capabilities.KubeVersion.GitVersion -}}
+  {{ if semverCompare ">1.20.0-0" .Capabilities.KubeVersion.Version -}}
   suspend: {{ .Values.jobConfigs.suspend }}
   {{- end }}
   ttlSecondsAfterFinished: {{ .Values.jobConfigs.ttlSecondsAfterFinished }}

--- a/scripts/devtron-reference-helm-charts/cronjob-chart_1-4-0/templates/_job_template_spec.yaml
+++ b/scripts/devtron-reference-helm-charts/cronjob-chart_1-4-0/templates/_job_template_spec.yaml
@@ -3,7 +3,7 @@ backoffLimit: {{ $.Values.jobConfigs.backoffLimit }}
 activeDeadlineSeconds: {{ $.Values.jobConfigs.activeDeadlineSeconds }}
 parallelism: {{ $.Values.jobConfigs.parallelism }}
 completions: {{ $.Values.jobConfigs.completions }}
-{{- if semverCompare ">1.20" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">1.20.0-0" .Capabilities.KubeVersion.Version }}
 suspend: {{ $.Values.jobConfigs.suspend }}
 {{- end }}
 ttlSecondsAfterFinished: {{ $.Values.jobConfigs.ttlSecondsAfterFinished }}

--- a/scripts/devtron-reference-helm-charts/cronjob-chart_1-4-0/templates/cronjob.yaml
+++ b/scripts/devtron-reference-helm-charts/cronjob-chart_1-4-0/templates/cronjob.yaml
@@ -1,5 +1,5 @@
 {{- if eq .Values.kind "CronJob" }}
-{{- if semverCompare "<1.21" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "<1.21.0-0" .Capabilities.KubeVersion.Version }}
 apiVersion: batch/v1beta1
 {{- else }}
 apiVersion: batch/v1
@@ -16,7 +16,7 @@ spec:
   schedule: {{ $.Values.cronjobConfigs.schedule | quote }}
   startingDeadlineSeconds: {{ $.Values.cronjobConfigs.startingDeadlineSeconds }}
   concurrencyPolicy: {{ $.Values.cronjobConfigs.concurrencyPolicy }}
-  {{- if semverCompare ">1.20" .Capabilities.KubeVersion.GitVersion }}
+  {{- if semverCompare ">1.20.0-0" .Capabilities.KubeVersion.Version }}
   suspend: {{ $.Values.cronjobConfigs.suspend }}
   {{- end }}
   successfulJobsHistoryLimit: {{ $.Values.cronjobConfigs.successfulJobsHistoryLimit }}

--- a/scripts/devtron-reference-helm-charts/cronjob-chart_1-5-0/templates/_job_template_spec.yaml
+++ b/scripts/devtron-reference-helm-charts/cronjob-chart_1-5-0/templates/_job_template_spec.yaml
@@ -12,7 +12,7 @@ parallelism: {{ $.Values.jobConfigs.parallelism }}
 {{- if $.Values.jobConfigs.completions }}
 completions: {{ $.Values.jobConfigs.completions }}
 {{- end }}
-{{- if semverCompare ">1.20" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">1.20.0-0" .Capabilities.KubeVersion.Version }}
 {{- if $.Values.jobConfigs.suspend }}
 suspend: {{ $.Values.jobConfigs.suspend }}
 {{- end }}

--- a/scripts/devtron-reference-helm-charts/cronjob-chart_1-5-0/templates/cronjob.yaml
+++ b/scripts/devtron-reference-helm-charts/cronjob-chart_1-5-0/templates/cronjob.yaml
@@ -1,5 +1,5 @@
 {{- if eq .Values.kind "CronJob" }}
-{{- if semverCompare "<1.21" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "<1.21.0-0" .Capabilities.KubeVersion.Version }}
 apiVersion: batch/v1beta1
 {{- else }}
 apiVersion: batch/v1
@@ -23,7 +23,7 @@ spec:
   {{- if $.Values.cronjobConfigs.concurrencyPolicy }}
   concurrencyPolicy: {{ $.Values.cronjobConfigs.concurrencyPolicy }}
   {{- end }}
-  {{- if semverCompare ">1.20" .Capabilities.KubeVersion.GitVersion }}
+  {{- if semverCompare ">1.20.0-0" .Capabilities.KubeVersion.Version }}
   {{- if $.Values.cronjobConfigs.suspend }}
   suspend: {{ $.Values.cronjobConfigs.suspend }}
   {{- end }}


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
This pr addresses the issue where .Capabilities.KubeVersion.GitVersion in case of eks, gke clusters were evaluated to be something like v1.25.16-eks-randomstring (with pre-release tag), but our cronjob/job charts were not having proper patch and pre-release placeholders for helm to compare, hence even though the server version would be > 1.20 (say 1.25) but the semverCompare check was failing because of the failing condition that if serverVersion has pre-release tag and constraint doesn't then helm considers them as incompatible. Hence have updated the condition.

This pr also updates the semverCompare serverVersion parameter to .Capabilities.KubeVersion.Version, instead of Capabilities.KubeVersion.GitVersion , since GitVersion is deprecated.

Fixes #
<!--
For example:
Fixes https://github.com/devtron-labs/devtron/issues/00001
Fixes devtron-labs/devtron#0001

PS: Please ensure that you've attached a valid issue that is OPEN
-->


<!--test-cases
## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

