### PR TITLE
fix: reverted application status, in case hibernation failed due to some reason

### DIFF
--- a/api/restHandler/app/appList/AppListingRestHandler.go
+++ b/api/restHandler/app/appList/AppListingRestHandler.go
@@ -1024,7 +1024,7 @@ func (handler AppListingRestHandlerImpl) fetchResourceTree(w http.ResponseWriter
 		}
 
 		if resp.Status == string(health.HealthStatusHealthy) {
-			status, err := handler.appListingService.ISLastReleaseStopType(appId, envId)
+			status, err := handler.appListingService.IsApplicationHibernating(appId, envId)
 			if err != nil {
 				handler.logger.Errorw("service err, FetchAppDetailsV2", "err", err, "app", appId, "env", envId)
 			} else if status {
@@ -1075,7 +1075,7 @@ func (handler AppListingRestHandlerImpl) fetchResourceTree(w http.ResponseWriter
 			resourceTree["releaseStatus"] = releaseStatus
 			resourceTree["status"] = applicationStatus
 			if applicationStatus == argoApplication.Healthy {
-				status, err := handler.appListingService.ISLastReleaseStopType(appId, envId)
+				status, err := handler.appListingService.IsApplicationHibernating(appId, envId)
 				if err != nil {
 					handler.logger.Errorw("service err, FetchAppDetailsV2", "err", err, "app", appId, "env", envId)
 				} else if status {

--- a/pkg/app/mocks/AppListingService.go
+++ b/pkg/app/mocks/AppListingService.go
@@ -482,7 +482,7 @@ func (_m *AppListingService) GraphAPI(appId int, envId int) error {
 }
 
 // ISLastReleaseStopType provides a mock function with given fields: appId, envId
-func (_m *AppListingService) ISLastReleaseStopType(appId int, envId int) (bool, error) {
+func (_m *AppListingService) IsApplicationHibernating(appId int, envId int) (bool, error) {
 	ret := _m.Called(appId, envId)
 
 	var r0 bool

--- a/pkg/deployment/deployedApp/DeployedAppService.go
+++ b/pkg/deployment/deployedApp/DeployedAppService.go
@@ -7,6 +7,7 @@ import (
 	util5 "github.com/devtron-labs/common-lib/utils/k8s"
 	bean2 "github.com/devtron-labs/devtron/api/bean"
 	"github.com/devtron-labs/devtron/internal/sql/models"
+	"github.com/devtron-labs/devtron/internal/sql/repository/chartConfig"
 	"github.com/devtron-labs/devtron/internal/sql/repository/pipelineConfig"
 	"github.com/devtron-labs/devtron/pkg/cluster/repository"
 	"github.com/devtron-labs/devtron/pkg/deployment/deployedApp/bean"
@@ -22,12 +23,13 @@ type DeployedAppService interface {
 }
 
 type DeployedAppServiceImpl struct {
-	logger               *zap.SugaredLogger
-	k8sCommonService     k8s.K8sCommonService
-	cdTriggerService     devtronApps.TriggerService
-	envRepository        repository.EnvironmentRepository
-	pipelineRepository   pipelineConfig.PipelineRepository
-	cdWorkflowRepository pipelineConfig.CdWorkflowRepository
+	logger                     *zap.SugaredLogger
+	k8sCommonService           k8s.K8sCommonService
+	cdTriggerService           devtronApps.TriggerService
+	envRepository              repository.EnvironmentRepository
+	pipelineRepository         pipelineConfig.PipelineRepository
+	cdWorkflowRepository       pipelineConfig.CdWorkflowRepository
+	pipelineOverrideRepository chartConfig.PipelineOverrideRepository
 }
 
 func NewDeployedAppServiceImpl(logger *zap.SugaredLogger,
@@ -35,14 +37,16 @@ func NewDeployedAppServiceImpl(logger *zap.SugaredLogger,
 	cdTriggerService devtronApps.TriggerService,
 	envRepository repository.EnvironmentRepository,
 	pipelineRepository pipelineConfig.PipelineRepository,
-	cdWorkflowRepository pipelineConfig.CdWorkflowRepository) *DeployedAppServiceImpl {
+	cdWorkflowRepository pipelineConfig.CdWorkflowRepository,
+	pipelineOverrideRepository chartConfig.PipelineOverrideRepository) *DeployedAppServiceImpl {
 	return &DeployedAppServiceImpl{
-		logger:               logger,
-		k8sCommonService:     k8sCommonService,
-		cdTriggerService:     cdTriggerService,
-		envRepository:        envRepository,
-		pipelineRepository:   pipelineRepository,
-		cdWorkflowRepository: cdWorkflowRepository,
+		logger:                     logger,
+		k8sCommonService:           k8sCommonService,
+		cdTriggerService:           cdTriggerService,
+		envRepository:              envRepository,
+		pipelineRepository:         pipelineRepository,
+		cdWorkflowRepository:       cdWorkflowRepository,
+		pipelineOverrideRepository: pipelineOverrideRepository,
 	}
 }
 

--- a/pkg/deployment/manifest/ManifestCreationService.go
+++ b/pkg/deployment/manifest/ManifestCreationService.go
@@ -202,9 +202,6 @@ func (impl *ManifestCreationServiceImpl) GetValuesOverrideForTrigger(overrideReq
 			return nil, err
 		}
 	}
-
-	return valuesOverrideResponse, fmt.Errorf("this is a custom error")
-
 	// Conditional Block based on PipelineOverrideCreated --> end
 	valuesOverrideResponse.PipelineOverride = pipelineOverride
 

--- a/pkg/deployment/manifest/ManifestCreationService.go
+++ b/pkg/deployment/manifest/ManifestCreationService.go
@@ -202,6 +202,9 @@ func (impl *ManifestCreationServiceImpl) GetValuesOverrideForTrigger(overrideReq
 			return nil, err
 		}
 	}
+
+	return valuesOverrideResponse, fmt.Errorf("this is a custom error")
+
 	// Conditional Block based on PipelineOverrideCreated --> end
 	valuesOverrideResponse.PipelineOverride = pipelineOverride
 

--- a/pkg/deployment/trigger/devtronApps/TriggerService.go
+++ b/pkg/deployment/trigger/devtronApps/TriggerService.go
@@ -408,7 +408,7 @@ func (impl *TriggerServiceImpl) ManualCdTrigger(triggerContext bean.TriggerConte
 
 		if isVulnerable == true {
 			// if image vulnerable, update timeline status and return
-			if err = impl.cdWorkflowCommonService.MarkCurrentDeploymentFailed(runner, errors.New(pipelineConfig.FOUND_VULNERABILITY), overrideRequest.UserId); err != nil {
+			if err = impl.cdWorkflowCommonService.MarkCurrentDeploymentFailed(runner, errors.New(pipelineConfig.FOUND_VULNERABILITY), overrideRequest.UserId, cdPipeline.Id); err != nil {
 				impl.logger.Errorw("error while updating current runner status to failed, TriggerDeployment", "wfrId", runner.Id, "err", err)
 			}
 			return 0, fmt.Errorf("found vulnerability for image digest %s", artifact.ImageDigest)
@@ -421,7 +421,7 @@ func (impl *TriggerServiceImpl) ManualCdTrigger(triggerContext bean.TriggerConte
 		span.End()
 		// if releaseErr found, then the mark current deployment Failed and return
 		if releaseErr != nil {
-			err := impl.cdWorkflowCommonService.MarkCurrentDeploymentFailed(runner, releaseErr, overrideRequest.UserId)
+			err := impl.cdWorkflowCommonService.MarkCurrentDeploymentFailed(runner, releaseErr, overrideRequest.UserId, cdPipeline.Id)
 			if err != nil {
 				impl.logger.Errorw("error while updating current runner status to failed, updatePreviousDeploymentStatus", "cdWfr", runner.Id, "err", err)
 			}
@@ -607,7 +607,7 @@ func (impl *TriggerServiceImpl) TriggerAutomaticDeployment(request bean.TriggerR
 		}
 	}
 	if isVulnerable == true {
-		if err = impl.cdWorkflowCommonService.MarkCurrentDeploymentFailed(runner, errors.New(pipelineConfig.FOUND_VULNERABILITY), triggeredBy); err != nil {
+		if err = impl.cdWorkflowCommonService.MarkCurrentDeploymentFailed(runner, errors.New(pipelineConfig.FOUND_VULNERABILITY), triggeredBy, pipeline.Id); err != nil {
 			impl.logger.Errorw("error while updating current runner status to failed, TriggerDeployment", "wfrId", runner.Id, "err", err)
 		}
 		return nil
@@ -616,7 +616,7 @@ func (impl *TriggerServiceImpl) TriggerAutomaticDeployment(request bean.TriggerR
 	releaseErr := impl.TriggerCD(artifact, cdWf.Id, savedWfr.Id, pipeline, triggeredAt)
 	// if releaseErr found, then the mark current deployment Failed and return
 	if releaseErr != nil {
-		err := impl.cdWorkflowCommonService.MarkCurrentDeploymentFailed(runner, releaseErr, triggeredBy)
+		err := impl.cdWorkflowCommonService.MarkCurrentDeploymentFailed(runner, releaseErr, triggeredBy, pipeline.Id)
 		if err != nil {
 			impl.logger.Errorw("error while updating current runner status to failed, updatePreviousDeploymentStatus", "cdWfr", runner.Id, "err", err)
 		}

--- a/pkg/eventProcessor/in/WorkflowEventProcessorService.go
+++ b/pkg/eventProcessor/in/WorkflowEventProcessorService.go
@@ -709,7 +709,7 @@ func (impl *WorkflowEventProcessorImpl) handleConcurrentOrInvalidRequest(overrid
 			}
 			if !isLatest {
 				impl.logger.Warnw("skipped deployment as the workflow runner is not the latest one", "cdWfrId", cdWfrId)
-				err := impl.cdWorkflowCommonService.MarkCurrentDeploymentFailed(cdWfr, errors.New(pipelineConfig.NEW_DEPLOYMENT_INITIATED), overrideRequest.UserId)
+				err := impl.cdWorkflowCommonService.MarkCurrentDeploymentFailed(cdWfr, errors.New(pipelineConfig.NEW_DEPLOYMENT_INITIATED), overrideRequest.UserId, pipelineObj.Id)
 				if err != nil {
 					impl.logger.Errorw("error while updating current runner status to failed, handleConcurrentOrInvalidRequest", "cdWfr", cdWfrId, "err", err)
 					return toSkipProcess, err
@@ -833,7 +833,7 @@ func (impl *WorkflowEventProcessorImpl) RemoveReleaseContextForPipeline(cdPipeli
 		if err != nil {
 			impl.logger.Errorw("err on fetching cd workflow runner, RemoveReleaseContextForPipeline", "err", err)
 		}
-		if err = impl.cdWorkflowCommonService.MarkCurrentDeploymentFailed(cdWfr, errors.New("CD pipeline has been deleted"), cdPipelineDeleteEvent.TriggeredBy); err != nil {
+		if err = impl.cdWorkflowCommonService.MarkCurrentDeploymentFailed(cdWfr, errors.New("CD pipeline has been deleted"), cdPipelineDeleteEvent.TriggeredBy, cdPipelineDeleteEvent.PipelineId); err != nil {
 			impl.logger.Errorw("error while updating current runner status to failed, RemoveReleaseContextForPipeline", "cdWfr", cdWfr.Id, "err", err)
 		}
 		releaseContext.CancelContext()

--- a/pkg/workflow/dag/WorkflowDagExecutor.go
+++ b/pkg/workflow/dag/WorkflowDagExecutor.go
@@ -308,7 +308,7 @@ func (impl *WorkflowDagExecutorImpl) handleAsyncTriggerReleaseError(releaseErr e
 		// if context deadline is exceeded fetch release status and UpdateWorkflowRunnerStatusForDeployment
 		if isWfrUpdated := impl.UpdateWorkflowRunnerStatusForDeployment(appIdentifier, cdWfr, false); !isWfrUpdated {
 			// updating cdWfr to failed
-			if err := impl.cdWorkflowCommonService.MarkCurrentDeploymentFailed(cdWfr, fmt.Errorf("Deployment timeout: release %s took more than %d mins", appIdentifier.ReleaseName, impl.appServiceConfig.DevtronChartInstallRequestTimeout), overrideRequest.UserId); err != nil {
+			if err := impl.cdWorkflowCommonService.MarkCurrentDeploymentFailed(cdWfr, fmt.Errorf("Deployment timeout: release %s took more than %d mins", appIdentifier.ReleaseName, impl.appServiceConfig.DevtronChartInstallRequestTimeout), overrideRequest.UserId, overrideRequest.PipelineId); err != nil {
 				impl.logger.Errorw("error while updating current runner status to failed, handleAsyncTriggerReleaseError", "cdWfr", cdWfr.Id, "err", err)
 			}
 		}
@@ -330,14 +330,14 @@ func (impl *WorkflowDagExecutorImpl) handleAsyncTriggerReleaseError(releaseErr e
 		impl.logger.Infow("updated workflow runner status for helm app", "wfr", cdWfr)
 		return
 	case context.Canceled.Error():
-		if err := impl.cdWorkflowCommonService.MarkCurrentDeploymentFailed(cdWfr, errors.New(pipelineConfig.NEW_DEPLOYMENT_INITIATED), overrideRequest.UserId); err != nil {
+		if err := impl.cdWorkflowCommonService.MarkCurrentDeploymentFailed(cdWfr, errors.New(pipelineConfig.NEW_DEPLOYMENT_INITIATED), overrideRequest.UserId, overrideRequest.PipelineId); err != nil {
 			impl.logger.Errorw("error while updating current runner status to failed, handleAsyncTriggerReleaseError", "cdWfr", cdWfr.Id, "err", err)
 		}
 		return
 	case "":
 		return
 	default:
-		if err := impl.cdWorkflowCommonService.MarkCurrentDeploymentFailed(cdWfr, releaseErr, overrideRequest.UserId); err != nil {
+		if err := impl.cdWorkflowCommonService.MarkCurrentDeploymentFailed(cdWfr, releaseErr, overrideRequest.UserId, overrideRequest.PipelineId); err != nil {
 			impl.logger.Errorw("error while updating current runner status to failed, handleAsyncTriggerReleaseError", "cdWfr", cdWfr.Id, "err", err)
 		}
 		return


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

stored status in pco for failed hibernation, and while determining application status, alongwith checking last deployment type we are now also checking the status

Fixes #4950
<!--
For example:
Fixes https://github.com/devtron-labs/devtron/issues/00001
Fixes devtron-labs/devtron#0001

PS: Please ensure that you've attached a valid issue that is OPEN
-->


<!--test-cases
## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

