### PR TITLE
fix: Kubelink Requests getting Failed for gRPC method GetAppDetails

### DIFF
--- a/api/restHandler/app/appList/AppListingRestHandler.go
+++ b/api/restHandler/app/appList/AppListingRestHandler.go
@@ -980,6 +980,10 @@ func (handler AppListingRestHandlerImpl) getAppDetails(ctx context.Context, appI
 // TODO: move this to service
 func (handler AppListingRestHandlerImpl) fetchResourceTree(w http.ResponseWriter, r *http.Request, appId int, envId int, acdToken string, cdPipeline *pipelineConfig.Pipeline) (map[string]interface{}, error) {
 	var resourceTree map[string]interface{}
+	if !cdPipeline.DeploymentAppCreated {
+		handler.logger.Infow("deployment for this pipeline does not exist")
+		return resourceTree, nil
+	}
 	if len(cdPipeline.DeploymentAppName) > 0 && cdPipeline.EnvironmentId > 0 && util.IsAcdApp(cdPipeline.DeploymentAppType) {
 		// RBAC enforcer Ends
 		query := &application2.ResourcesQuery{

--- a/api/restHandler/app/appList/AppListingRestHandler.go
+++ b/api/restHandler/app/appList/AppListingRestHandler.go
@@ -981,7 +981,7 @@ func (handler AppListingRestHandlerImpl) getAppDetails(ctx context.Context, appI
 func (handler AppListingRestHandlerImpl) fetchResourceTree(w http.ResponseWriter, r *http.Request, appId int, envId int, acdToken string, cdPipeline *pipelineConfig.Pipeline) (map[string]interface{}, error) {
 	var resourceTree map[string]interface{}
 	if !cdPipeline.DeploymentAppCreated {
-		handler.logger.Infow("deployment for this pipeline does not exist")
+		handler.logger.Infow("deployment for this pipeline does not exist", "pipelineId", cdPipeline.Id)
 		return resourceTree, nil
 	}
 	if len(cdPipeline.DeploymentAppName) > 0 && cdPipeline.EnvironmentId > 0 && util.IsAcdApp(cdPipeline.DeploymentAppType) {


### PR DESCRIPTION
# Description

This issue was happening because we were fetching the app details of a helm app for an environment in which there was not even a single deployment triggered yet. Need to handle it from the code side by putting a check and not calling the GetAppDetail function in this case.

Fixes #5008 

## How Has This Been Tested?

- [x] Tested locally 
- [x] Tested by deploying in VM.


## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [x] I have added all the required unit/api test cases.