### PR TITLE
doc: Added kubectl port-fwd section in RB

### DIFF
--- a/docs/user-guide/resource-browser.md
+++ b/docs/user-guide/resource-browser.md
@@ -478,10 +478,11 @@ Devtron helps in reducing the challenges and simplifying the maintenance of kube
 
 ### Steps
 
-{% hint style="info" %}
-### Prerequisite
-An [API token with necessary permissions](./global-configurations/authorization/api-tokens.md) for the user(s) to access the cluster.
-{% endhint %}
+**Prerequisite**: An [API token with necessary permissions](./global-configurations/authorization/api-tokens.md) for the user(s) to access the cluster. 
+
+If you are not a super-admin and can't generate a token yourself, you can use the session token (argocd.token) using the Developer Tools available in your web browser as shown below.
+
+![Figure 22: Using Session Token](https://devtron-public-asset.s3.us-east-2.amazonaws.com/images/kubernetes-resource-browser/argocd-token-v1.gif)
 
 1. Go to `~/.kube` folder on your local machine and open the `config` file. Or you may create one with the following content:
 
@@ -493,15 +494,15 @@ An [API token with necessary permissions](./global-configurations/authorization/
   - cluster:
       insecure-skip-tls-verify: true
       server: https://<devtron proxy url for cluster>
-    name: <cluster_name>
+    name: default-cluster
   contexts:
   - context:
-      cluster: <cluster_name>
-      user: <user_name>
-    name: <context_name>
-  current-context: <context_name>
+      cluster: default-cluster
+      user: admin
+    name: default-cluster
+  current-context: default-cluster
   users:
-  - name: <user_name>
+  - name: admin
     user:
       token: <devtron token>
   ```
@@ -509,11 +510,11 @@ An [API token with necessary permissions](./global-configurations/authorization/
 
 2. Enter the cluster URL provided by Devtron in the `server` field, and API token (you generated) in the `token` field. 
 
-  ![Figure 22: Editing Kubeconfig File](https://devtron-public-asset.s3.us-east-2.amazonaws.com/images/kubernetes-resource-browser/kubeconfig.gif)
+  ![Figure 23: Editing Kubeconfig File](https://devtron-public-asset.s3.us-east-2.amazonaws.com/images/kubernetes-resource-browser/kubeconfig.gif)
 
 3. Test the connection to the cluster by running any kubectl command, e.g., `kubectl get ns` or `kubectl get po -A`
 
 4. Once you have successfully connected to the cluster, you may run the port-forward command. Refer [kubectl port-forward](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_port-forward/) to see a few examples.
 
-  ![Figure 23: Example - Port Forwarding](https://devtron-public-asset.s3.us-east-2.amazonaws.com/images/kubernetes-resource-browser/port-forward.gif)
+  ![Figure 24: Example - Port Forwarding](https://devtron-public-asset.s3.us-east-2.amazonaws.com/images/kubernetes-resource-browser/port-forward.gif)
 

--- a/docs/user-guide/resource-browser.md
+++ b/docs/user-guide/resource-browser.md
@@ -480,7 +480,7 @@ Devtron helps in reducing the challenges and simplifying the maintenance of kube
 
 **Prerequisite**: An [API token with necessary permissions](./global-configurations/authorization/api-tokens.md) for the user(s) to access the cluster. 
 
-If you are not a super-admin and can't generate a token yourself, you can use the session token (argocd.token) using the Developer Tools available in your web browser as shown below.
+If you are not a super-admin and can't generate a token yourself, you can find the session token (argocd.token) using the Developer Tools available in your web browser as shown below.
 
 ![Figure 22: Using Session Token](https://devtron-public-asset.s3.us-east-2.amazonaws.com/images/kubernetes-resource-browser/argocd-token-v1.gif)
 

--- a/docs/user-guide/resource-browser.md
+++ b/docs/user-guide/resource-browser.md
@@ -449,3 +449,71 @@ spec:
          - containerPort: 80
 ```
 {% endcode %}
+
+---
+
+## Port Forwarding
+
+### Introduction
+
+Assume your applications are running in a Kubernetes cluster on cloud. Now, if you wish to test or debug them on your local machine, you can perform [port fowarding](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/). Basically, it creates a tunnel between a port on your machine and a port on a resource within your cluster. Therefore, you can access applications running inside the cluster as though they are running locally on your machine.
+
+But first, you would need access to that cluster. Traditionally, the kubeconfig file (`./kube/config`) helps you connect with the cluster. 
+
+![Figure 21: Kubeconfig File](https://devtron-public-asset.s3.us-east-2.amazonaws.com/images/kubernetes-resource-browser/kubeconfig.jpg)
+
+### Challenges in Kubeconfig
+
+Kubeconfig becomes painstakingly difficult to maintain especially when it comes to:
+* Granting or revoking access to the cluster for multiple people
+* Changing the permissions and subsequently the access token
+* Adding/Updating/Deleting the entries of cluster URLs and tokens
+* Keeping a record of multiple kubeconfig files
+
+### Our Solution
+
+Devtron helps in reducing the challenges and simplifying the maintenance of kubeconfig file through:
+* **Devtron's Proxy URL for Cluster** - A standardized URL that you can use in the place of your Kubernetes cluster URL.
+* **Devtron's Access Token** - A kubectl-compatible token which can be generated and centrally maintained from [Global Configurations → Authorization → API tokens](./global-configurations/authorization/api-tokens.md).
+
+### Steps
+
+{% hint style="info" %}
+### Prerequisite
+An [API token with necessary permissions](./global-configurations/authorization/api-tokens.md) for the user(s) to access the cluster.
+{% endhint %}
+
+1. Go to `~/.kube` folder on your local machine and open the `config` file. Or you may create one with the following content:
+
+  {% code title="kubeconfig" overflow="wrap" lineNumbers="true" %}
+  ```yaml
+  apiVersion: v1
+  kind: Config
+  clusters:
+  - cluster:
+      insecure-skip-tls-verify: true
+      server: https://<devtron proxy url for cluster>
+    name: <cluster_name>
+  contexts:
+  - context:
+      cluster: <cluster_name>
+      user: <user_name>
+    name: <context_name>
+  current-context: <context_name>
+  users:
+  - name: <user_name>
+    user:
+      token: <devtron token>
+  ```
+  {% endcode %}
+
+2. Enter the cluster URL provided by Devtron in the `server` field, and API token (you generated) in the `token` field. 
+
+  ![Figure 22: Editing Kubeconfig File](https://devtron-public-asset.s3.us-east-2.amazonaws.com/images/kubernetes-resource-browser/kubeconfig.gif)
+
+3. Test the connection to the cluster by running any kubectl command, e.g., `kubectl get ns` or `kubectl get po -A`
+
+4. Once you have successfully connected to the cluster, you may run the port-forward command. Refer [kubectl port-forward](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_port-forward/) to see a few examples.
+
+  ![Figure 23: Example - Port Forwarding](https://devtron-public-asset.s3.us-east-2.amazonaws.com/images/kubernetes-resource-browser/port-forward.gif)
+

--- a/docs/user-guide/resource-browser.md
+++ b/docs/user-guide/resource-browser.md
@@ -456,7 +456,7 @@ spec:
 
 ### Introduction
 
-Assume your applications are running in a Kubernetes cluster on cloud. Now, if you wish to test or debug them on your local machine, you can perform [port fowarding](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/). Basically, it creates a tunnel between a port on your machine and a port on a resource within your cluster. Therefore, you can access applications running inside the cluster as though they are running locally on your machine.
+Assume your applications are running in a Kubernetes cluster on cloud. Now, if you wish to test or debug them on your local machine, you can perform [port forwarding](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/). It creates a tunnel between a port on your machine and a port on a resource within your cluster. Therefore, you can access applications running inside the cluster as though they are running locally on your machine.
 
 But first, you would need access to that cluster. Traditionally, the kubeconfig file (`./kube/config`) helps you connect with the cluster. 
 
@@ -473,7 +473,7 @@ Kubeconfig becomes painstakingly difficult to maintain especially when it comes 
 ### Our Solution
 
 Devtron helps in reducing the challenges and simplifying the maintenance of kubeconfig file through:
-* **Devtron's Proxy URL for Cluster** - A standardized URL that you can use in the place of your Kubernetes cluster URL.
+* **Devtron's Proxy URL for Cluster** - A standardized URL that you can use in place of your Kubernetes cluster URL.
 * **Devtron's Access Token** - A kubectl-compatible token which can be generated and centrally maintained from [Global Configurations → Authorization → API tokens](./global-configurations/authorization/api-tokens.md).
 
 ### Steps

--- a/docs/user-guide/resource-browser.md
+++ b/docs/user-guide/resource-browser.md
@@ -493,22 +493,28 @@ If you are not a super-admin and can't generate a token yourself, you can find t
   clusters:
   - cluster:
       insecure-skip-tls-verify: true
-      server: https://<devtron proxy url for cluster>
-    name: default-cluster
+      server: https://<devtron_host_name>/orchestrator/k8s/proxy/cluster/<cluster_name>
+    name: devtron-cluster
   contexts:
   - context:
-      cluster: default-cluster
+      cluster: devtron-cluster
       user: admin
-    name: default-cluster
-  current-context: default-cluster
+    name: devtron-cluster
+  current-context: devtron-cluster
   users:
   - name: admin
     user:
-      token: <devtron token>
+      token: <devtron_token>
   ```
   {% endcode %}
 
-2. Enter the cluster URL provided by Devtron in the `server` field, and API token (you generated) in the `token` field. 
+2. Edit the following placeholders in the `server` field and the `token` field:
+
+  | Placeholder         | Description                         | Example                                         |
+  | ------------------- | ----------------------------------- | ----------------------------------------------- |
+  | <devtron_host_name> | Hostname of the Devtron server      | demo.devtron.ai                                 |
+  | <cluster_name>      | Name of the cluster (or cluster ID) | devtron-cluster                                 |
+  | <devtron_token>     | API token or session token          | \-                                              |
 
   ![Figure 23: Editing Kubeconfig File](https://devtron-public-asset.s3.us-east-2.amazonaws.com/images/kubernetes-resource-browser/kubeconfig.gif)
 


### PR DESCRIPTION
- Section created in resource browser doc
- Added snaps and gifs wherever required
- Included sample kubeconfig content
- Linked to official kubectl docs wherever required
- Added session token method for non-superadmins