### PR TITLE
fix: extra labels propagation based on k8s label regex matching

### DIFF
--- a/pkg/app/AppCrudOperationService.go
+++ b/pkg/app/AppCrudOperationService.go
@@ -613,16 +613,20 @@ func (impl AppCrudOperationServiceImpl) getExtraAppLabelsToPropagate(appId int, 
 		impl.logger.Errorw("error in finding app and project by appId", "appId", appId, "err", err)
 		return nil, err
 	}
-	extraAppLabels := make(map[string]string)
 	regexp := regexp.MustCompile(LabelMatchingRegex)
-	if regexp.MatchString(appName) {
-		extraAppLabels[bean3.AppNameDevtronLabel] = appName
-	}
-	if regexp.MatchString(envName) {
-		extraAppLabels[bean3.EnvNameDevtronLabel] = envName
-	}
-	if regexp.MatchString(appMetaInfo.Team.Name) {
-		extraAppLabels[bean3.ProjectNameDevtronLabel] = appMetaInfo.Team.Name
+	extraAppLabels := make(map[string]string)
+
+	extraAppLabels[bean3.AppNameDevtronLabel] = appName
+	extraAppLabels[bean3.EnvNameDevtronLabel] = envName
+	extraAppLabels[bean3.ProjectNameDevtronLabel] = appMetaInfo.Team.Name
+
+	extraAppLabels = sanitizeLabels(extraAppLabels)
+	for labelKey, labelValue := range extraAppLabels {
+		if regexp.MatchString(labelValue) {
+			extraAppLabels[labelKey] = labelValue
+		} else {
+			delete(extraAppLabels, labelKey)
+		}
 	}
 	return extraAppLabels, nil
 }

--- a/pkg/app/AppCrudOperationService.go
+++ b/pkg/app/AppCrudOperationService.go
@@ -625,7 +625,7 @@ func (impl AppCrudOperationServiceImpl) getExtraAppLabelsToPropagate(appId int, 
 		if regexp.MatchString(labelValue) {
 			extraAppLabels[labelKey] = labelValue
 		} else {
-			// in case extra labels doesn't are failing k8s official label matching regex  even after sanitization then
+			// in case extra labels are failing k8s official label matching regex  even after sanitization then
 			//delete the label as this can break deployments.
 			impl.logger.Warnw("extra label failed LabelMatchingRegex validation, regex:- ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", "labelKey", labelKey, "labelValue", labelValue)
 			delete(extraAppLabels, labelKey)

--- a/pkg/app/AppCrudOperationService.go
+++ b/pkg/app/AppCrudOperationService.go
@@ -613,11 +613,18 @@ func (impl AppCrudOperationServiceImpl) getExtraAppLabelsToPropagate(appId int, 
 		impl.logger.Errorw("error in finding app and project by appId", "appId", appId, "err", err)
 		return nil, err
 	}
-	return map[string]string{
-		bean3.AppNameDevtronLabel:     appName,
-		bean3.EnvNameDevtronLabel:     envName,
-		bean3.ProjectNameDevtronLabel: appMetaInfo.Team.Name,
-	}, nil
+	extraAppLabels := make(map[string]string)
+	regexp := regexp.MustCompile(LabelMatchingRegex)
+	if regexp.MatchString(appName) {
+		extraAppLabels[bean3.AppNameDevtronLabel] = appName
+	}
+	if regexp.MatchString(envName) {
+		extraAppLabels[bean3.EnvNameDevtronLabel] = envName
+	}
+	if regexp.MatchString(appMetaInfo.Team.Name) {
+		extraAppLabels[bean3.ProjectNameDevtronLabel] = appMetaInfo.Team.Name
+	}
+	return extraAppLabels, nil
 }
 
 func (impl AppCrudOperationServiceImpl) GetAppLabelsForDeployment(appId int, appName, envName string) ([]byte, error) {

--- a/pkg/app/AppCrudOperationService.go
+++ b/pkg/app/AppCrudOperationService.go
@@ -625,6 +625,9 @@ func (impl AppCrudOperationServiceImpl) getExtraAppLabelsToPropagate(appId int, 
 		if regexp.MatchString(labelValue) {
 			extraAppLabels[labelKey] = labelValue
 		} else {
+			// in case extra labels doesn't are failing k8s official label matching regex  even after sanitization then
+			//delete the label as this can break deployments.
+			impl.logger.Warnw("extra label failed LabelMatchingRegex validation, regex:- ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", "labelKey", labelKey, "labelValue", labelValue)
 			delete(extraAppLabels, labelKey)
 		}
 	}

--- a/pkg/app/helper.go
+++ b/pkg/app/helper.go
@@ -16,6 +16,8 @@
 
 package app
 
+const LabelMatchingRegex = "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"
+
 // MergeChildMapToParentMap merges child map of generic type map into parent map of generic type
 // and returns merged mapping, if parentMap is nil then nil is returned.
 func MergeChildMapToParentMap[T comparable, R any](parentMap map[T]R, toMergeMap map[T]R) map[T]R {

--- a/pkg/app/helper.go
+++ b/pkg/app/helper.go
@@ -16,6 +16,8 @@
 
 package app
 
+import "strings"
+
 const LabelMatchingRegex = "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"
 
 // MergeChildMapToParentMap merges child map of generic type map into parent map of generic type
@@ -30,4 +32,13 @@ func MergeChildMapToParentMap[T comparable, R any](parentMap map[T]R, toMergeMap
 		}
 	}
 	return parentMap
+}
+
+func sanitizeLabels(extraAppLabels map[string]string) map[string]string {
+	for lkey, lvalue := range extraAppLabels {
+		if strings.Contains(lvalue, " ") {
+			extraAppLabels[lkey] = strings.ReplaceAll(lvalue, " ", "_")
+		}
+	}
+	return extraAppLabels
 }

--- a/pkg/app/helper.go
+++ b/pkg/app/helper.go
@@ -18,7 +18,7 @@ package app
 
 import "strings"
 
-// LabelMatchingRegex is the official k8s label matching regex
+// LabelMatchingRegex is the official k8s label matching regex, pls refer https://github.com/kubernetes/apimachinery/blob/bfd2aff97e594f6aad77acbe2cbbe190acc93cbc/pkg/util/validation/validation.go#L167
 const LabelMatchingRegex = "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"
 
 // MergeChildMapToParentMap merges child map of generic type map into parent map of generic type

--- a/pkg/app/helper.go
+++ b/pkg/app/helper.go
@@ -18,6 +18,7 @@ package app
 
 import "strings"
 
+// LabelMatchingRegex is the official k8s label matching regex
 const LabelMatchingRegex = "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"
 
 // MergeChildMapToParentMap merges child map of generic type map into parent map of generic type


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This pr fixes the issue when there are wrong regex present for extra labels that we are propagating. For Old data present on clients project names were having spaces hence k8s was unable to pass the label validation check. 
 
Fixes #5219 
<!--
For example:
Fixes https://github.com/devtron-labs/devtron/issues/00001
Fixes devtron-labs/devtron#0001

PS: Please ensure that you've attached a valid issue that is OPEN
-->


<!--test-cases
## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

