### PR TITLE
fix: nats consumer deleted on shutdown

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v1.8.0
 	github.com/devtron-labs/authenticator v0.4.35-0.20240607135426-c86e868ecee1
-	github.com/devtron-labs/common-lib v0.0.19
+	github.com/devtron-labs/common-lib v0.0.20
 	github.com/devtron-labs/go-bitbucket v0.9.60-beta
 	github.com/devtron-labs/protos v0.0.3-0.20240326053929-48e42d9d4534
 	github.com/evanphx/json-patch v5.7.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,8 @@ github.com/denisenkom/go-mssqldb v0.0.0-20190707035753-2be1aa521ff4 h1:YcpmyvADG
 github.com/denisenkom/go-mssqldb v0.0.0-20190707035753-2be1aa521ff4/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
 github.com/devtron-labs/authenticator v0.4.35-0.20240607135426-c86e868ecee1 h1:qdkpTAo2Kr0ZicZIVXfNwsGSshpc9OB9j9RzmKYdIwY=
 github.com/devtron-labs/authenticator v0.4.35-0.20240607135426-c86e868ecee1/go.mod h1:IkKPPEfgLCMR29he5yv2OCC6iM2R7K5/0AA3k8b9XNc=
-github.com/devtron-labs/common-lib v0.0.19 h1:vrTP4y3m824qKrfjcxe0FJCz5uZEsYEnFAeRnWm6+bI=
-github.com/devtron-labs/common-lib v0.0.19/go.mod h1:UZGPt1ep9Tnd9Ak2sibGSiLr7p3ijO2/JLT+h+pqBuU=
+github.com/devtron-labs/common-lib v0.0.20 h1:PH33VGmXZFx7U+rwXYnNXkB90sGbBTW0KHFonraJpG8=
+github.com/devtron-labs/common-lib v0.0.20/go.mod h1:UZGPt1ep9Tnd9Ak2sibGSiLr7p3ijO2/JLT+h+pqBuU=
 github.com/devtron-labs/go-bitbucket v0.9.60-beta h1:VEx1jvDgdtDPS6A1uUFoaEi0l1/oLhbr+90xOwr6sDU=
 github.com/devtron-labs/go-bitbucket v0.9.60-beta/go.mod h1:GnuiCesvh8xyHeMCb+twm8lBR/kQzJYSKL28ZfObp1Y=
 github.com/devtron-labs/protos v0.0.3-0.20240326053929-48e42d9d4534 h1:TElPRU69QedW7DIQiiQxtjwSQ6cK0fCTAMGvSLhP0ac=

--- a/pkg/deployment/trigger/devtronApps/TriggerService.go
+++ b/pkg/deployment/trigger/devtronApps/TriggerService.go
@@ -739,7 +739,7 @@ func (impl *TriggerServiceImpl) handleCDTriggerRelease(ctx context.Context, over
 
 func (impl *TriggerServiceImpl) auditDeploymentTriggerHistory(cdWfrId int, valuesOverrideResponse *app.ValuesOverrideResponse, ctx context.Context, triggeredAt time.Time, triggeredBy int32) (err error) {
 	if valuesOverrideResponse.Pipeline == nil || valuesOverrideResponse.EnvOverride == nil {
-		impl.logger.Warnw("unable to save histories for deployment trigger, invalid valuesOverrideResponse received", "pipelineId", valuesOverrideResponse.Pipeline.Id, "cdWfrId", cdWfrId)
+		impl.logger.Warnw("unable to save histories for deployment trigger, invalid valuesOverrideResponse received", "cdWfrId", cdWfrId)
 		return nil
 	}
 	err1 := impl.deployedConfigurationHistoryService.CreateHistoriesForDeploymentTrigger(ctx, valuesOverrideResponse.Pipeline, valuesOverrideResponse.PipelineStrategy, valuesOverrideResponse.EnvOverride, triggeredAt, triggeredBy)

--- a/vendor/github.com/devtron-labs/common-lib/pubsub-lib/NatsClient.go
+++ b/vendor/github.com/devtron-labs/common-lib/pubsub-lib/NatsClient.go
@@ -108,8 +108,8 @@ func (consumerConf NatsConsumerConfig) GetNatsMsgBufferSize() int {
 // }
 
 func NewNatsClient(logger *zap.SugaredLogger) (*NatsClient, error) {
-	connWg := new(sync.WaitGroup)
-	connWg.Add(1)
+	//connWg := new(sync.WaitGroup)
+	//connWg.Add(1)
 	cfg := &NatsClientConfig{}
 	err := env.Parse(cfg)
 	if err != nil {
@@ -131,7 +131,7 @@ func NewNatsClient(logger *zap.SugaredLogger) (*NatsClient, error) {
 		}),
 		nats.ClosedHandler(func(nc *nats.Conn) {
 			logger.Errorw("Nats Client Connection closed!", "Reason", nc.LastError())
-			connWg.Done()
+			//connWg.Done()
 		}))
 	if err != nil {
 		logger.Error("err", err)
@@ -149,7 +149,7 @@ func NewNatsClient(logger *zap.SugaredLogger) (*NatsClient, error) {
 		logger:     logger,
 		JetStrCtxt: js,
 		Conn:       nc,
-		ConnWg:     connWg,
+		//ConnWg:     connWg,
 	}
 	return natsClient, nil
 }

--- a/vendor/github.com/devtron-labs/common-lib/pubsub-lib/PubSubClientService.go
+++ b/vendor/github.com/devtron-labs/common-lib/pubsub-lib/PubSubClientService.go
@@ -78,11 +78,13 @@ func NewPubSubClientServiceImpl(logger *zap.SugaredLogger) (*PubSubClientService
 
 func (impl PubSubClientServiceImpl) ShutDown() error {
 	// Drain the connection, which will close it when done.
-	if err := impl.NatsClient.Conn.Drain(); err != nil {
-		return err
-	}
+	//if err := impl.NatsClient.Conn.Drain(); err != nil {
+	//	return err
+	//}
 	// Wait for the connection to be closed.
-	impl.NatsClient.ConnWg.Wait()
+	//impl.NatsClient.ConnWg.Wait()
+	// TODO: Currently the drain mechanism deletes the Ephemeral consumers.
+	//       Implement the fix for the Ephemeral consumers first to enable graceful shutdown.
 	return nil
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -381,7 +381,7 @@ github.com/devtron-labs/authenticator/jwt
 github.com/devtron-labs/authenticator/middleware
 github.com/devtron-labs/authenticator/oidc
 github.com/devtron-labs/authenticator/password
-# github.com/devtron-labs/common-lib v0.0.19
+# github.com/devtron-labs/common-lib v0.0.20
 ## explicit; go 1.21
 github.com/devtron-labs/common-lib/blob-storage
 github.com/devtron-labs/common-lib/cloud-provider-identifier


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Update on common-lib: Currently we create Ephemeral consumers by NATS Subscribe method. but with the introduction of NATS graceful shutdown using Drain() function. the NATS client deletes durable consumers that it created during QueueSubscribe(). Need to properly handle this condition first until then reverting the graceful shutdown implementation.

Fixes https://github.com/devtron-labs/devtron/issues/5323
<!--
For example:
Fixes https://github.com/devtron-labs/devtron/issues/00001
Fixes devtron-labs/devtron#0001

PS: Please ensure that you've attached a valid issue that is OPEN
-->


<!--test-cases
## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

