### PR TITLE
Introducing Devtron Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 <a href="https://twitter.com/DevtronL">Twitter</a>
 .
 <a href="https://www.youtube.com/channel/UCAHRp9qp0z1y9MMtQlcFtcw">YouTube</a>
+.
+<a href="https://gurubase.io/g/devtron">Ask Devtron Guru</a>
  
 </p>
 <p align="center">
@@ -32,6 +34,7 @@
 <a href="http://golang.org"><img src="https://img.shields.io/badge/Made%20with-Go-1f425f.svg" alt="made-with-Go"></a>
 <a href="http://devtron.ai/"><img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website devtron.ai"></a>
 <a href="https://twitter.com/intent/tweet?text=Devtron%20helps%20in%20simplifying%20software delivery%20workflow%20for%20Kubernetes,%20check%20it%20out!!%20&hashtags=OpenSource,Kubernetes,DevOps,CICD,go&url=https://github.com/devtron-labs/devtron%0a"><img src="https://img.shields.io/twitter/url/http/shields.io.svg?style=social" alt="Tweet"></a>
+<a href="https://gurubase.io/g/devtron"><img src="https://img.shields.io/badge/Gurubase-Ask%20Devtron%20Guru-006BFF" alt="Devtron Guru on Gurubase.io"></a>
  
 <p align="center">
 <a href="https://devtron.ai/devops-in-a-box.html">🔥 Want to accelerate K8s adoption? Introducing DevOps in a Box; Leave DevOps on Devtron 🔥


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Devtron Guru](https://gurubase.io/g/devtron) to Gurubase. Devtron Guru uses the data from this repo and data from the [docs](https://docs.devtron.ai/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Devtron Guru", which highlights that Devtron now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Devtron Guru in Gurubase, just let me know that's totally fine.