### PR TITLE
fix: fix for showing inaccurate data in template/list api while fetching previous deployments list in template/list api, output shown was cartesian product of deployment_template_history and wfr

### DIFF
--- a/api/bean/ConfigMapAndSecret.go
+++ b/api/bean/ConfigMapAndSecret.go
@@ -71,7 +71,7 @@ func (configSecretJson *ConfigSecretJson) SetReferencedSecrets(secrets []ConfigS
 	configSecretJson.Secrets = util.GetReferencedArray(secrets)
 }
 
-func GetTransformedDataForSecretData(data string, mode util.SecretTransformMode) (string, error) {
+func GetTransformedDataForSecretRootJsonData(data string, mode util.SecretTransformMode) (string, error) {
 	secretsJson := ConfigSecretRootJson{}
 	err := json.Unmarshal([]byte(data), &secretsJson)
 	if err != nil {

--- a/internal/sql/repository/DeploymentTemplateRepository.go
+++ b/internal/sql/repository/DeploymentTemplateRepository.go
@@ -71,12 +71,13 @@ func (impl DeploymentTemplateRepositoryImpl) FetchDeploymentHistoryWithChartRefs
 
 	query := "select p.id as pipeline_id, dth.id as deployment_template_history_id," +
 		"  wfr.id as wfr_id, wfr.finished_on, wfr.status, c.chart_ref_id, c.chart_version FROM cd_workflow_runner wfr" +
-		" JOIN cd_workflow wf ON wf.id = wfr.cd_workflow_id JOIN pipeline p ON p.id = wf.pipeline_id" +
-		" JOIN deployment_template_history dth ON dth.deployed_on = wfr.started_on " +
-		"JOIN pipeline_config_override pco ON pco.cd_workflow_id = wf.id " +
-		"JOIN chart_env_config_override ceco ON ceco.id = pco.env_config_override_id JOIN charts c " +
-		"ON c.id = ceco.chart_id where p.environment_id = ?  AND p.app_id = ? AND p.deleted = false  AND wfr.workflow_type = 'DEPLOY' " +
-		"ORDER BY wfr.id DESC LIMIT ? ;"
+		" JOIN deployment_template_history dth ON dth.deployed_on = wfr.started_on" +
+		" JOIN cd_workflow wf ON wf.id = wfr.cd_workflow_id" +
+		" JOIN pipeline p ON p.id = wf.pipeline_id AND p.id = dth.pipeline_id" +
+		" JOIN pipeline_config_override pco ON pco.cd_workflow_id = wf.id" +
+		" JOIN chart_env_config_override ceco ON ceco.id = pco.env_config_override_id JOIN charts c" +
+		" ON c.id = ceco.chart_id where p.environment_id = ?  AND p.app_id = ? AND p.deleted = false  AND wfr.workflow_type = 'DEPLOY'" +
+		" ORDER BY wfr.id DESC LIMIT ? ;"
 
 	_, err := impl.dbConnection.Query(&result, query, envId, appId, limit)
 	if err != nil {

--- a/pkg/bean/configSecretData.go
+++ b/pkg/bean/configSecretData.go
@@ -80,7 +80,7 @@ type ESOData struct {
 	Property  string `json:"property,omitempty"`
 }
 
-func GetTransformedDataForSecretData(data string, mode util.SecretTransformMode) (string, error) {
+func GetTransformedDataForSecretConfigData(data string, mode util.SecretTransformMode) (string, error) {
 	secretDataMap := make(map[string]*ConfigData)
 	err := json.Unmarshal([]byte(data), &secretDataMap)
 	if err != nil {

--- a/pkg/variables/ScopedVariableCMCSManager.go
+++ b/pkg/variables/ScopedVariableCMCSManager.go
@@ -293,7 +293,7 @@ func (impl *ScopedVariableCMCSManagerImpl) ResolveCMCS(ctx context.Context,
 		return nil, nil, nil, nil, err
 	}
 
-	decodedSecrets, err := serviceBean.GetTransformedDataForSecretData(string(mergedSecretJson), util.DecodeSecret)
+	decodedSecrets, err := serviceBean.GetTransformedDataForSecretConfigData(string(mergedSecretJson), util.DecodeSecret)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -304,7 +304,7 @@ func (impl *ScopedVariableCMCSManagerImpl) ResolveCMCS(ctx context.Context,
 		return nil, nil, nil, nil, err
 	}
 	variableMapCS = parsers.GetVariableMapForUsedVariables(scopedVariables, varNamesCS)
-	encodedSecretData, err = serviceBean.GetTransformedDataForSecretData(resolvedTemplateCS, util.EncodeSecret)
+	encodedSecretData, err = serviceBean.GetTransformedDataForSecretConfigData(resolvedTemplateCS, util.EncodeSecret)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -362,14 +362,14 @@ func (impl *ScopedVariableCMCSManagerImpl) ResolvedVariableForLastSaved(scope re
 	}
 
 	if secretDataByte != nil && len(varNamesCS) > 0 {
-		data, err := bean.GetTransformedDataForSecretData(string(secretDataByte), util.DecodeSecret)
+		data, err := bean.GetTransformedDataForSecretRootJsonData(string(secretDataByte), util.DecodeSecret)
 		if err != nil {
 			return resolvedCM, string(secretDataByte), variableSnapshotForCM, variableSnapshotForCS, err
 		}
 		parserRequest := parsers.CreateParserRequest(data, parsers.StringVariableTemplate, scopedVariables, true)
 		resolvedCSDecoded, err := impl.ParseTemplateWithScopedVariables(parserRequest)
 		variableSnapshotForCS = parsers.GetVariableMapForUsedVariables(scopedVariables, varNamesCS)
-		resolvedCS, err = bean.GetTransformedDataForSecretData(resolvedCSDecoded, util.EncodeSecret)
+		resolvedCS, err = bean.GetTransformedDataForSecretRootJsonData(resolvedCSDecoded, util.EncodeSecret)
 		if err != nil {
 			return resolvedCM, resolvedCM, variableSnapshotForCM, variableSnapshotForCS, err
 		}
@@ -408,12 +408,12 @@ func (impl *ScopedVariableCMCSManagerImpl) ResolvedVariableForSpecificType(confi
 		HistoryReferenceId:   secretHistoryId,
 		HistoryReferenceType: repository1.HistoryReferenceTypeSecret,
 	}
-	data, err := bean.GetTransformedDataForSecretData(string(secretDataByte), util.DecodeSecret)
+	data, err := bean.GetTransformedDataForSecretRootJsonData(string(secretDataByte), util.DecodeSecret)
 	if err != nil {
 		return "", "", nil, nil, err
 	}
 	variableMapCS, resolvedTemplateCS, err := impl.GetVariableSnapshotAndResolveTemplate(data, parsers.StringVariableTemplate, reference, true, true)
-	encodedSecretData, err := bean.GetTransformedDataForSecretData(resolvedTemplateCS, util.EncodeSecret)
+	encodedSecretData, err := bean.GetTransformedDataForSecretRootJsonData(resolvedTemplateCS, util.EncodeSecret)
 	if err != nil {
 		return "", "", nil, nil, err
 	}


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
This PR fixes the case when we show inaccurate data in template/list api while fetching previous deployments list in template/list api, output shown was cartesian product of deployment_template_history.deployed_on and wfr.started_on, because in case of SDH we store same deployed_on in wfr table for all the pipeline.
Fixes https://github.com/devtron-labs/devtron/issues/6035
<!--
For example:
Fixes https://github.com/devtron-labs/devtron/issues/00001
Fixes devtron-labs/devtron#0001

PS: Please ensure that you've attached a valid issue that is OPEN
-->


<!--test-cases
## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

