### PR TITLE
misc: skip for sync PRs, remove issue opened check for pr validator

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -11,3 +11,4 @@ types:
   - doc
   - release
   - misc
+  - sync

--- a/.github/workflows/pr-issue-validator.yaml
+++ b/.github/workflows/pr-issue-validator.yaml
@@ -53,7 +53,7 @@ jobs:
 
         set -x    
         # Skip validation for documentation or chore PRs
-        if [[ "$TITLE" =~ ^(doc:|docs:|chore:|misc:|Release:|release:) ]]; then
+        if [[ "$TITLE" =~ ^(doc:|docs:|chore:|misc:|Release:|release:|Sync:|sync:) ]]; then
           echo "Skipping validation for docs/chore PR."
           echo "PR NUMBER-: $PRNUM "
           gh pr edit $PRNUM --remove-label "PR:Issue-verification-failed"
@@ -140,32 +140,16 @@ jobs:
             --header "authorization: Bearer ${{ secrets.GH_PR_VALIDATOR_TOKEN }}" \
             "$issue_api_url"| jq '.state'|tr -d \")
           fi
-          echo "Issue Status: $issue_status"
 
-          # Check if the issue is still open.
-          if [[ "$issue_status" == open ]]; then
-            echo "Issue #$issue_num is opened."
-            if [[ $forked == true ]]; then
-              echo "PR:Ready-to-Review, exiting gracefully"
-              exit 0
-            fi
-            # Remove the 'Issue-verification-failed' label (if present) and add 'Ready-to-Review'.
-            gh pr edit $PRNUM --remove-label "PR:Issue-verification-failed"
-            gh pr edit $PRNUM --add-label "PR:Ready-to-Review"
-          else
-            echo "Issue #$issue_num is closed. Please link an open issue to proceed."
-              if [[ $forked == true ]]; then
-                echo "PR:Ready-to-Review, exiting gracefully"
-                exit 0
-              fi
-            # Add a comment to the PR indicating the issue is not linked correctly.
-            gh pr comment $PRNUM --body "PR is  linked to a closed issue. Please link an open issue to proceed."
-
-            # Add the 'Issue-verification-failed' label and remove 'Ready-to-Review'.
-            gh pr edit $PRNUM --add-label "PR:Issue-verification-failed"
-            gh pr edit $PRNUM --remove-label "PR:Ready-to-Review"
-            exit 1
+          echo "Issue #$issue_num status is : $issue_status."
+          if [[ $forked == true ]]; then
+            echo "PR:Ready-to-Review, exiting gracefully"
+            exit 0
           fi
+          # Remove the 'Issue-verification-failed' label (if present) and add 'Ready-to-Review'.
+          gh pr edit $PRNUM --remove-label "PR:Issue-verification-failed"
+          gh pr edit $PRNUM --add-label "PR:Ready-to-Review"
+          
         else
           echo "Issue not found. Invalid URL or issue number."
           # Add a comment to the PR indicating the issue is not linked correctly.

--- a/.github/workflows/pr-issue-validator.yaml
+++ b/.github/workflows/pr-issue-validator.yaml
@@ -140,16 +140,33 @@ jobs:
             --header "authorization: Bearer ${{ secrets.GH_PR_VALIDATOR_TOKEN }}" \
             "$issue_api_url"| jq '.state'|tr -d \")
           fi
-
-          echo "Issue #$issue_num status is : $issue_status."
-          if [[ $forked == true ]]; then
+          echo "Issue Number : $issue_num Status: $issue_status"
+          # Check if the issue is still open.
+          # if [[ "$issue_status" == open ]]; then
+            # echo "Issue #$issue_num is opened."
+            if [[ $forked == true ]]; then
+              echo "PR:Ready-to-Review, exiting gracefully"
+              exit 0
+            fi
+            # Remove the 'Issue-verification-failed' label (if present) and add 'Ready-to-Review'.
+            gh pr edit $PRNUM --remove-label "PR:Issue-verification-failed"
+            gh pr edit $PRNUM --add-label "PR:Ready-to-Review"
             echo "PR:Ready-to-Review, exiting gracefully"
             exit 0
-          fi
-          # Remove the 'Issue-verification-failed' label (if present) and add 'Ready-to-Review'.
-          gh pr edit $PRNUM --remove-label "PR:Issue-verification-failed"
-          gh pr edit $PRNUM --add-label "PR:Ready-to-Review"
-          
+          # else
+            # echo "Issue #$issue_num is closed. Please link an open issue to proceed."
+              # if [[ $forked == true ]]; then
+                # echo "PR:Ready-to-Review, exiting gracefully"
+                # exit 0
+              # fi
+            # Add a comment to the PR indicating the issue is not linked correctly.
+            # gh pr comment $PRNUM --body "PR is  linked to a closed issue. Please link an open issue to proceed."
+
+            # Add the 'Issue-verification-failed' label and remove 'Ready-to-Review'.
+            # gh pr edit $PRNUM --add-label "PR:Issue-verification-failed"
+            # gh pr edit $PRNUM --remove-label "PR:Ready-to-Review"
+            # exit 1
+          #fi
         else
           echo "Issue not found. Invalid URL or issue number."
           # Add a comment to the PR indicating the issue is not linked correctly.


### PR DESCRIPTION
Changes made.

1. Added sync in semantic.yml
2. PR with sync: will be skipped for validation
3. Removed the condition of issue to be opened for a valid PR 