### PR TITLE
fix: Auto trigger even if pre-cd fails

### DIFF
--- a/pkg/eventProcessor/bean/workflowEventBean.go
+++ b/pkg/eventProcessor/bean/workflowEventBean.go
@@ -40,6 +40,7 @@ type CdStageCompleteEvent struct {
 	PluginRegistryArtifactDetails map[string][]string          `json:"PluginRegistryArtifactDetails"`
 	PluginArtifacts               *PluginArtifacts             `json:"pluginArtifacts"`
 	IsArtifactUploaded            bool                         `json:"isArtifactUploaded"`
+	IsSuccess                     bool                         `json:"isSuccess"`
 }
 
 type UserDeploymentRequest struct {

--- a/pkg/eventProcessor/bean/workflowEventBean.go
+++ b/pkg/eventProcessor/bean/workflowEventBean.go
@@ -40,7 +40,7 @@ type CdStageCompleteEvent struct {
 	PluginRegistryArtifactDetails map[string][]string          `json:"PluginRegistryArtifactDetails"`
 	PluginArtifacts               *PluginArtifacts             `json:"pluginArtifacts"`
 	IsArtifactUploaded            bool                         `json:"isArtifactUploaded"`
-	IsSuccess                     bool                         `json:"isSuccess"`
+	IsFailed                      bool                         `json:"isFailed"`
 }
 
 type UserDeploymentRequest struct {

--- a/pkg/eventProcessor/in/WorkflowEventProcessorService.go
+++ b/pkg/eventProcessor/in/WorkflowEventProcessorService.go
@@ -172,10 +172,10 @@ func (impl *WorkflowEventProcessorImpl) SubscribeCDStageCompleteEvent() error {
 		wfr.IsArtifactUploaded = cdStageCompleteEvent.IsArtifactUploaded
 		if slices.Contains(cdWorkflowModelBean.WfrTerminalStatusList, wfr.Status) {
 			impl.logger.Debugw("event received from ci runner, updating workflow runner status as succeeded", "savedWorkflowRunnerId", wfr.Id, "oldStatus", wfr.Status, "podStatus", wfr.PodStatus)
-			if cdStageCompleteEvent.IsSuccess {
-				wfr.Status = string(v1alpha1.NodeSucceeded)
-			} else {
+			if cdStageCompleteEvent.IsFailed {
 				wfr.Status = string(v1alpha1.NodeFailed)
+			} else {
+				wfr.Status = string(v1alpha1.NodeSucceeded)
 			}
 			err = impl.cdWorkflowRunnerService.UpdateWfr(wfr, 1)
 			if err != nil {
@@ -217,7 +217,7 @@ func (impl *WorkflowEventProcessorImpl) SubscribeCDStageCompleteEvent() error {
 }
 
 func (impl *WorkflowEventProcessorImpl) handleCDStageCompleteEvent(triggerContext triggerBean.TriggerContext, cdStageCompleteEvent bean.CdStageCompleteEvent, wfr *cdWorkflowBean.CdWorkflowRunnerDto) {
-	if !cdStageCompleteEvent.IsSuccess {
+	if cdStageCompleteEvent.IsFailed {
 		impl.logger.Debugw("event received from ci runner, updating workflow runner status as failed, not taking any action", "savedWorkflowRunnerId", wfr.Id, "oldStatus", wfr.Status, "podStatus", wfr.PodStatus)
 		return
 	}

--- a/pkg/eventProcessor/in/WorkflowEventProcessorService.go
+++ b/pkg/eventProcessor/in/WorkflowEventProcessorService.go
@@ -170,44 +170,27 @@ func (impl *WorkflowEventProcessorImpl) SubscribeCDStageCompleteEvent() error {
 			return
 		}
 		wfr.IsArtifactUploaded = cdStageCompleteEvent.IsArtifactUploaded
-		if wfr.Status != string(v1alpha1.NodeSucceeded) {
+		if wfr.Status != string(v1alpha1.NodeSucceeded) && wfr.Status != string(v1alpha1.NodeFailed) {
 			impl.logger.Debugw("event received from ci runner, updating workflow runner status as succeeded", "savedWorkflowRunnerId", wfr.Id, "oldStatus", wfr.Status, "podStatus", wfr.PodStatus)
-			wfr.Status = string(v1alpha1.NodeSucceeded)
+			if cdStageCompleteEvent.IsSuccess {
+				wfr.Status = string(v1alpha1.NodeSucceeded)
+			} else {
+				wfr.Status = string(v1alpha1.NodeFailed)
+			}
 			err = impl.cdWorkflowRunnerService.UpdateWfr(wfr, 1)
 			if err != nil {
 				impl.logger.Errorw("update cd-wf-runner failed for id ", "cdWfrId", wfr.Id, "err", err)
 				return
 			}
+
+			triggerContext := triggerBean.TriggerContext{
+				ReferenceId: pointer.String(msg.MsgId),
+			}
+			impl.handleCDStageCompleteEvent(triggerContext, cdStageCompleteEvent, wfr)
 		} else {
 			err = impl.cdWorkflowRunnerService.UpdateIsArtifactUploaded(wfr.Id, cdStageCompleteEvent.IsArtifactUploaded)
 			if err != nil {
 				impl.logger.Errorw("error in updating isArtifactUploaded", "cdWfrId", wfr.Id, "err", err)
-				return
-			}
-		}
-
-		triggerContext := triggerBean.TriggerContext{
-			ReferenceId: pointer.String(msg.MsgId),
-		}
-		if wfr.WorkflowType == apiBean.CD_WORKFLOW_TYPE_PRE {
-			impl.logger.Debugw("received pre stage success event for workflow runner ", "wfId", strconv.Itoa(wfr.Id))
-			err = impl.workflowDagExecutor.HandlePreStageSuccessEvent(triggerContext, cdStageCompleteEvent)
-			if err != nil {
-				impl.logger.Errorw("deployment success event error", "err", err)
-				return
-			}
-		} else if wfr.WorkflowType == apiBean.CD_WORKFLOW_TYPE_POST {
-
-			pluginArtifacts := make(map[string][]string)
-			if cdStageCompleteEvent.PluginArtifacts != nil {
-				pluginArtifacts = cdStageCompleteEvent.PluginArtifacts.GetRegistryToUniqueContainerArtifactDataMapping()
-			}
-			globalUtil.MergeMaps(pluginArtifacts, cdStageCompleteEvent.PluginRegistryArtifactDetails)
-
-			impl.logger.Debugw("received post stage success event for workflow runner ", "wfId", strconv.Itoa(wfr.Id))
-			err = impl.workflowDagExecutor.HandlePostStageSuccessEvent(triggerContext, wfr, wfr.CdWorkflowId, cdStageCompleteEvent.CdPipelineId, cdStageCompleteEvent.TriggeredBy, pluginArtifacts)
-			if err != nil {
-				impl.logger.Errorw("deployment success event error", "err", err)
 				return
 			}
 		}
@@ -231,6 +214,37 @@ func (impl *WorkflowEventProcessorImpl) SubscribeCDStageCompleteEvent() error {
 		return err
 	}
 	return nil
+}
+
+func (impl *WorkflowEventProcessorImpl) handleCDStageCompleteEvent(triggerContext triggerBean.TriggerContext, cdStageCompleteEvent bean.CdStageCompleteEvent, wfr *cdWorkflowBean.CdWorkflowRunnerDto) {
+	if !cdStageCompleteEvent.IsSuccess {
+		impl.logger.Debugw("event received from ci runner, updating workflow runner status as failed, not taking any action", "savedWorkflowRunnerId", wfr.Id, "oldStatus", wfr.Status, "podStatus", wfr.PodStatus)
+		return
+	}
+
+	var err error
+	if wfr.WorkflowType == apiBean.CD_WORKFLOW_TYPE_PRE {
+		impl.logger.Debugw("received pre stage success event for workflow runner ", "wfId", strconv.Itoa(wfr.Id))
+		err = impl.workflowDagExecutor.HandlePreStageSuccessEvent(triggerContext, cdStageCompleteEvent)
+		if err != nil {
+			impl.logger.Errorw("deployment success event error", "err", err)
+			return
+		}
+	} else if wfr.WorkflowType == apiBean.CD_WORKFLOW_TYPE_POST {
+		impl.logger.Debugw("received post stage success event for workflow runner ", "wfId", strconv.Itoa(wfr.Id))
+
+		pluginArtifacts := make(map[string][]string)
+		if cdStageCompleteEvent.PluginArtifacts != nil {
+			pluginArtifacts = cdStageCompleteEvent.PluginArtifacts.GetRegistryToUniqueContainerArtifactDataMapping()
+		}
+		globalUtil.MergeMaps(pluginArtifacts, cdStageCompleteEvent.PluginRegistryArtifactDetails)
+
+		err = impl.workflowDagExecutor.HandlePostStageSuccessEvent(triggerContext, wfr, wfr.CdWorkflowId, cdStageCompleteEvent.CdPipelineId, cdStageCompleteEvent.TriggeredBy, pluginArtifacts)
+		if err != nil {
+			impl.logger.Errorw("deployment success event error", "err", err)
+			return
+		}
+	}
 }
 
 func (impl *WorkflowEventProcessorImpl) SubscribeTriggerBulkAction() error {

--- a/pkg/eventProcessor/in/WorkflowEventProcessorService.go
+++ b/pkg/eventProcessor/in/WorkflowEventProcessorService.go
@@ -170,7 +170,7 @@ func (impl *WorkflowEventProcessorImpl) SubscribeCDStageCompleteEvent() error {
 			return
 		}
 		wfr.IsArtifactUploaded = cdStageCompleteEvent.IsArtifactUploaded
-		if wfr.Status != string(v1alpha1.NodeSucceeded) && wfr.Status != string(v1alpha1.NodeFailed) {
+		if slices.Contains(cdWorkflowModelBean.WfrTerminalStatusList, wfr.Status) {
 			impl.logger.Debugw("event received from ci runner, updating workflow runner status as succeeded", "savedWorkflowRunnerId", wfr.Id, "oldStatus", wfr.Status, "podStatus", wfr.PodStatus)
 			if cdStageCompleteEvent.IsSuccess {
 				wfr.Status = string(v1alpha1.NodeSucceeded)

--- a/pkg/eventProcessor/in/WorkflowEventProcessorService.go
+++ b/pkg/eventProcessor/in/WorkflowEventProcessorService.go
@@ -170,7 +170,7 @@ func (impl *WorkflowEventProcessorImpl) SubscribeCDStageCompleteEvent() error {
 			return
 		}
 		wfr.IsArtifactUploaded = cdStageCompleteEvent.IsArtifactUploaded
-		if slices.Contains(cdWorkflowModelBean.WfrTerminalStatusList, wfr.Status) {
+		if !slices.Contains(cdWorkflowModelBean.WfrTerminalStatusList, wfr.Status) {
 			impl.logger.Debugw("event received from ci runner, updating workflow runner status as succeeded", "savedWorkflowRunnerId", wfr.Id, "oldStatus", wfr.Status, "podStatus", wfr.PodStatus)
 			if cdStageCompleteEvent.IsFailed {
 				wfr.Status = string(v1alpha1.NodeFailed)


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes https://github.com/devtron-labs/sprint-tasks/issues/1852
<!--
For example:
Fixes https://github.com/devtron-labs/<repo_name>/issues/<issue_number>
Fixes devtron-labs/<repo_name>#<issue_number>

PS: Please ensure that you've attached a valid issue that is OPEN
-->


<!--test-cases
## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

