### PR TITLE
fix: buildx driver opt using k8s driver even if not enabled

### DIFF
--- a/pkg/infraConfig/service/infraConfigService.go
+++ b/pkg/infraConfig/service/infraConfigService.go
@@ -730,6 +730,9 @@ func (impl *InfraConfigServiceImpl) sanitizeUpdatableConfigurations(updatableInf
 func (impl *InfraConfigServiceImpl) getAppliedInfraConfigForProfile(appliedProfileConfig, defaultProfileConfig *v1.ProfileBeanDto, variableSnapshots map[string]map[string]string, targetPlatformsList []string) (map[string]*v1.InfraConfig, error) {
 	resp := make(map[string]*v1.InfraConfig)
 	for _, targetPlatform := range targetPlatformsList {
+		if !appliedProfileConfig.GetBuildxDriverType().IsPlatformSupported(targetPlatform) {
+			continue
+		}
 		appliedConfiguration := impl.getAppliedConfigurationForTargetPlatform(appliedProfileConfig, defaultProfileConfig, targetPlatform)
 		infraConfigForTrigger, err := impl.getInfraConfigurationForTrigger(appliedConfiguration)
 		if err != nil {

--- a/pkg/infraConfig/units/bean/memory_unit_type.go
+++ b/pkg/infraConfig/units/bean/memory_unit_type.go
@@ -41,6 +41,8 @@ const (
 
 func (memoryUnitStr MemoryUnitStr) GetUnitSuffix() UnitType {
 	switch memoryUnitStr {
+	case MILLIBYTE:
+		return MilliByte
 	case BYTE:
 		return Byte
 	case KIBYTE:


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes https://github.com/devtron-labs/sprint-tasks/issues/1867
<!--
For example:
Fixes https://github.com/devtron-labs/<repo_name>/issues/<issue_number>
Fixes devtron-labs/<repo_name>#<issue_number>

PS: Please ensure that you've attached a valid issue that is OPEN
-->


<!--test-cases
## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

