### PR TITLE
fix: fix for failure to trigger cd set on auto after pre-cd is success which is also on auto which got triggered after ci 

### DIFF
--- a/pkg/pipeline/CdHandler.go
+++ b/pkg/pipeline/CdHandler.go
@@ -778,6 +778,7 @@ func (impl *CdHandlerImpl) converterWFR(wfr pipelineConfig.CdWorkflowRunner) pip
 		workflow.Image = wfr.CdWorkflow.CiArtifact.Image
 		workflow.PipelineId = wfr.CdWorkflow.PipelineId
 		workflow.CiArtifactId = wfr.CdWorkflow.CiArtifactId
+		// TODO: FIXME :- if wfr status is terminal then only migrate isArtifactUploaded flag.
 		isArtifactUploaded, isMigrationRequired := wfr.GetIsArtifactUploaded()
 		if isMigrationRequired {
 			// Migrate isArtifactUploaded. For old records, set isArtifactUploaded -> Uploaded


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
This pr handles the case when cd is set on auto and pre cd is also on auto, when ci completes then pre cd is triggered but cd is not triggered automatically, here handleCDStageCompleteEvent function was not placed correctly, this pr makes this func. independent of the check that terminal state of a workflow is reached or not also contains minor comments.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes https://github.com/devtron-labs/sprint-tasks/issues/1879

<!--test-cases
## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

