### PR TITLE
fix: fix for while cloning app or workflow when external secret is present in any pipeline then that pipeline is not cloned

### DIFF
--- a/pkg/appClone/AppCloneService.go
+++ b/pkg/appClone/AppCloneService.go
@@ -548,19 +548,24 @@ func (impl *AppCloneServiceImpl) configDataClone(cfData []*bean3.ConfigData) []*
 	var copiedData []*bean3.ConfigData
 	for _, refdata := range cfData {
 		data := &bean3.ConfigData{
-			Name:               refdata.Name,
-			Type:               refdata.Type,
-			External:           refdata.External,
-			MountPath:          refdata.MountPath,
-			Data:               refdata.Data,
-			DefaultData:        refdata.DefaultData,
-			DefaultMountPath:   refdata.DefaultMountPath,
-			Global:             refdata.Global,
-			ExternalSecretType: refdata.ExternalSecretType,
-			FilePermission:     refdata.FilePermission,
-			SubPath:            refdata.SubPath,
-			ESOSubPath:         refdata.ESOSubPath,
-			MergeStrategy:      refdata.MergeStrategy,
+			Name:                  refdata.Name,
+			Type:                  refdata.Type,
+			External:              refdata.External,
+			MountPath:             refdata.MountPath,
+			Data:                  refdata.Data,
+			DefaultData:           refdata.DefaultData,
+			DefaultMountPath:      refdata.DefaultMountPath,
+			Global:                refdata.Global,
+			ExternalSecretType:    refdata.ExternalSecretType,
+			FilePermission:        refdata.FilePermission,
+			SubPath:               refdata.SubPath,
+			ESOSubPath:            refdata.ESOSubPath,
+			MergeStrategy:         refdata.MergeStrategy,
+			ESOSecretData:         refdata.ESOSecretData,
+			DefaultESOSecretData:  refdata.DefaultESOSecretData,
+			ExternalSecret:        refdata.ExternalSecret,
+			DefaultExternalSecret: refdata.DefaultExternalSecret,
+			RoleARN:               refdata.RoleARN,
 		}
 		copiedData = append(copiedData, data)
 	}


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
Fix for while cloning app or workflow when external secret is present in any pipeline then that pipeline is not cloned with error (both esoSecretData.esoDataFrom and esoSecretData.esoData can't be empty)
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes https://github.com/devtron-labs/sprint-tasks/issues/1897



<!--test-cases
## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

