### PR TITLE
fix: auto pre-cd not getting triggered (if cd is manual) after webhook ci event is captured

### DIFF
--- a/internal/sql/repository/pipelineConfig/PipelineRepository.go
+++ b/internal/sql/repository/pipelineConfig/PipelineRepository.go
@@ -44,6 +44,14 @@ func (t TriggerType) ToString() string {
 	return string(t)
 }
 
+func (t TriggerType) IsManual() bool {
+	return t == TRIGGER_TYPE_MANUAL
+}
+
+func (t TriggerType) IsAuto() bool {
+	return t == TRIGGER_TYPE_AUTOMATIC
+}
+
 const TRIGGER_TYPE_AUTOMATIC TriggerType = "AUTOMATIC"
 const TRIGGER_TYPE_MANUAL TriggerType = "MANUAL"
 
@@ -59,8 +67,8 @@ type Pipeline struct {
 	Deleted                       bool        `sql:"deleted,notnull"`
 	PreStageConfig                string      `sql:"pre_stage_config_yaml"`
 	PostStageConfig               string      `sql:"post_stage_config_yaml"`
-	PreTriggerType                TriggerType `sql:"pre_trigger_type"`                   // automatic, manual
-	PostTriggerType               TriggerType `sql:"post_trigger_type"`                  // automatic, manual
+	PreTriggerType                TriggerType `sql:"pre_trigger_type"`                   // automatic, manual; when a pre-cd task doesn't exist/removed in a cd then this field is updated as null
+	PostTriggerType               TriggerType `sql:"post_trigger_type"`                  // automatic, manual; when a post-cd task doesn't exist/removed in a cd then this field is updated as null
 	PreStageConfigMapSecretNames  string      `sql:"pre_stage_config_map_secret_names"`  // configmap names
 	PostStageConfigMapSecretNames string      `sql:"post_stage_config_map_secret_names"` // secret names
 	RunPreStageInEnv              bool        `sql:"run_pre_stage_in_env"`               // secret names

--- a/pkg/workflow/dag/WorkflowDagExecutor.go
+++ b/pkg/workflow/dag/WorkflowDagExecutor.go
@@ -472,7 +472,8 @@ func (impl *WorkflowDagExecutorImpl) handleWebhookExternalCiEvent(artifact *repo
 			err = &util.ApiError{Code: "401", HttpStatusCode: 401, UserMessage: "Unauthorized"}
 			return hasAnyTriggered, err
 		}
-		if pipeline.TriggerType == pipelineConfig.TRIGGER_TYPE_MANUAL {
+		isQualifiedForCdAutoTrigger := helper.IsCdQualifiedForAutoTriggerForWebhookCiEvent(pipeline)
+		if !isQualifiedForCdAutoTrigger {
 			impl.logger.Warnw("skipping deployment for manual trigger for webhook", "pipeline", pipeline)
 			continue
 		}

--- a/pkg/workflow/dag/helper/helper.go
+++ b/pkg/workflow/dag/helper/helper.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"github.com/devtron-labs/devtron/internal/sql/repository"
+	"github.com/devtron-labs/devtron/internal/sql/repository/pipelineConfig"
 )
 
 func GetMaterialInfoJson(materialInfo json.RawMessage) ([]byte, error) {
@@ -28,4 +29,19 @@ func UpdateScanStatusInCiArtifact(ciArtifact *repository.CiArtifact, isScanPlugi
 	if isScanningDoneViaPlugin {
 		ciArtifact.Scanned = true
 	}
+}
+
+// IsCdQualifiedForAutoTriggerForWebhookCiEvent returns bool, if a cd/pre-cd is qualified for auto trigger for a webhook ci event
+func IsCdQualifiedForAutoTriggerForWebhookCiEvent(pipeline *pipelineConfig.Pipeline) bool {
+	/*
+		A cd is qualified for auto trigger for webhookCiEvent if it satisfies below two conditions:-
+			1. If pre-cd exists and is set on auto.
+			2. If only cd exists and is set on auto.
+	*/
+	if len(pipeline.PreTriggerType) > 0 && pipeline.PreTriggerType.IsAuto() {
+		return true
+	} else if len(pipeline.PreTriggerType) == 0 && pipeline.TriggerType.IsAuto() {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes https://github.com/devtron-labs/sprint-tasks/issues/1941

<!--test-cases
## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

