### PR TITLE
misc: adding codeowner for swagger api spec

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@ scripts/sql @prakarsh-dt @vikramdevtron @nishant-d @vivek-devtron
 scripts/utilities @prakarsh-dt @nishant-d @pawan-mehta-dt @vivek-devtron
 
 #Github Specific
-.github/ @prakarsh-dt @nishant-d @pawan-mehta-dt @vikramdevtron @tayalrishabh96
+.github/ @prakarsh-dt @nishant-d @pawan-mehta-dt @vikramdevtron @tayalrishabh96 @pawan-59 
 
 #swagger api specs 
 specs/ @prakarsh-dt  @pawan-mehta-dt @pawan-59 


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR updates the CODEOWNERS file by adding a new block for swagger API specifications. The change ensures that swagger-related files are automatically routed to designated team members for review, improving the code review process and maintaining quality standards.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>