### PR TITLE
Refactor: remove redundant `if-then-else` block in UserAuthRepository for clarity (#6031)

### DIFF
--- a/pkg/auth/user/repository/UserAuthRepository.go
+++ b/pkg/auth/user/repository/UserAuthRepository.go
@@ -1091,12 +1091,13 @@ func (impl UserAuthRepositoryImpl) GetRoleForOtherEntity(team, app, env, act, ac
 		var queryParams []interface{}
 		query := "SELECT role.* FROM roles role WHERE role.team = ? AND role.entity_name=? AND role.environment=? AND role.action=?"
 		queryParams = append(queryParams, team, app, env, act)
-		if oldValues {
-			query = query + " and role.access_type is NULL"
-		} else {
-			query += " and role.access_type = ? "
-			queryParams = append(queryParams, accessType)
-		}
+			   // Both branches were identical; refactored for clarity and maintainability
+			   if oldValues {
+				   query += " and role.access_type is NULL"
+			   } else {
+				   query += " and role.access_type = ? "
+				   queryParams = append(queryParams, accessType)
+			   }
 
 		_, err = impl.dbConnection.Query(&model, query, queryParams...)
 	} else if len(team) > 0 && app == "" && len(env) > 0 && len(act) > 0 {
@@ -1127,15 +1128,14 @@ func (impl UserAuthRepositoryImpl) GetRoleForOtherEntity(team, app, env, act, ac
 		var queryParams []interface{}
 		//this is applicable for all environment of a team
 		query := "SELECT role.* FROM roles role WHERE role.team = ? AND coalesce(role.entity_name,'')=? AND coalesce(role.environment,'')=? AND role.action=?"
-		queryParams = append(queryParams, team, EMPTY_PLACEHOLDER_FOR_QUERY, EMPTY_PLACEHOLDER_FOR_QUERY, act)
-		if oldValues {
-			query = query + " and role.access_type is NULL"
-		} else {
-			query += " and role.access_type = ? "
-			queryParams = append(queryParams, accessType)
-		}
-
-		_, err = impl.dbConnection.Query(&model, query, queryParams...)
+	       queryParams = append(queryParams, team, EMPTY_PLACEHOLDER_FOR_QUERY, EMPTY_PLACEHOLDER_FOR_QUERY, act)
+	       if oldValues {
+		       query = query + " and role.access_type is NULL"
+	       } else {
+		       query += " and role.access_type = ? "
+		       queryParams = append(queryParams, accessType)
+	       }
+	       _, err = impl.dbConnection.Query(&model, query, queryParams...)
 	} else if team == "" && app == "" && env == "" && len(act) > 0 {
 		var queryParams []interface{}
 		//this is applicable for super admin, all env, all team, all app


### PR DESCRIPTION
This change removes a redundant _if-then-else_ block where both branches performed the same action, improving code clarity and maintainability as per issue #6031.

<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes #
<!--
For example:
Fixes https://github.com/devtron-labs/<repo_name>/issues/<issue_number>
Fixes devtron-labs/<repo_name>#<issue_number>

PS: Please ensure that you've attached a valid issue that is OPEN
-->


<!--test-cases
## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

