### PR TITLE
fix: prevent exposure of internal-only attributes in API responses and requests

### DIFF
--- a/api/restHandler/AttributesRestHandlder.go
+++ b/api/restHandler/AttributesRestHandlder.go
@@ -19,14 +19,16 @@ package restHandler
 import (
 	"encoding/json"
 	"errors"
-	"github.com/devtron-labs/devtron/pkg/attributes/bean"
+	"fmt"
 	"net/http"
 	"strconv"
 
 	"github.com/devtron-labs/devtron/api/restHandler/common"
 	"github.com/devtron-labs/devtron/pkg/attributes"
+	"github.com/devtron-labs/devtron/pkg/attributes/bean"
 	"github.com/devtron-labs/devtron/pkg/auth/authorisation/casbin"
 	"github.com/devtron-labs/devtron/pkg/auth/user"
+	"github.com/devtron-labs/devtron/util/sliceUtil"
 	"github.com/gorilla/mux"
 	"go.uber.org/zap"
 )
@@ -57,6 +59,20 @@ func NewAttributesRestHandlerImpl(logger *zap.SugaredLogger, enforcer casbin.Enf
 	}
 	return userAuthHandler
 }
+
+// isInternalOnlyKey checks if the given key is internal-only and should not be exposed
+func (handler AttributesRestHandlerImpl) isInternalOnlyKey(key string) bool {
+	return bean.InternalOnlyKeys[key]
+}
+
+// filterInternalAttributes removes internal-only attributes from the list
+func (handler AttributesRestHandlerImpl) filterInternalAttributes(attributes []*bean.AttributesDto) []*bean.AttributesDto {
+	filtered := make([]*bean.AttributesDto, 0, len(attributes))
+	return sliceUtil.Filter(filtered, attributes, func(attr *bean.AttributesDto) bool {
+		return !handler.isInternalOnlyKey(attr.Key)
+	})
+}
+
 func (handler AttributesRestHandlerImpl) AddAttributes(w http.ResponseWriter, r *http.Request) {
 	userId, err := handler.userService.GetLoggedInUser(r)
 	if userId == 0 || err != nil {
@@ -75,6 +91,13 @@ func (handler AttributesRestHandlerImpl) AddAttributes(w http.ResponseWriter, r 
 	token := r.Header.Get("token")
 	if ok := handler.enforcer.Enforce(token, casbin.ResourceGlobal, casbin.ActionCreate, "*"); !ok {
 		common.WriteJsonResp(w, errors.New("unauthorized"), nil, http.StatusForbidden)
+		return
+	}
+
+	// Check if the key is internal-only (not allowed to be created via API)
+	if handler.isInternalOnlyKey(dto.Key) {
+		handler.logger.Warnw("attempt to create internal-only attribute", "key", dto.Key, "userId", userId)
+		common.WriteJsonResp(w, fmt.Errorf("forbidden: cannot create attribute with key: %q", dto.Key), nil, http.StatusForbidden)
 		return
 	}
 
@@ -105,6 +128,14 @@ func (handler AttributesRestHandlerImpl) UpdateAttributes(w http.ResponseWriter,
 	}
 
 	token := r.Header.Get("token")
+
+	// Check if the key is internal-only (not allowed to be created via API)
+	if handler.isInternalOnlyKey(dto.Key) {
+		handler.logger.Warnw("attempt to create internal-only attribute", "key", dto.Key, "userId", userId)
+		common.WriteJsonResp(w, fmt.Errorf("forbidden: cannot edit attribute with key: %q", dto.Key), nil, http.StatusForbidden)
+		return
+	}
+
 	if ok := handler.enforcer.Enforce(token, casbin.ResourceGlobal, casbin.ActionUpdate, "*"); !ok {
 		common.WriteJsonResp(w, errors.New("unauthorized"), nil, http.StatusForbidden)
 		return
@@ -145,6 +176,14 @@ func (handler AttributesRestHandlerImpl) GetAttributesById(w http.ResponseWriter
 		common.WriteJsonResp(w, err, nil, http.StatusInternalServerError)
 		return
 	}
+
+	// Filter out internal-only attributes
+	if res != nil && handler.isInternalOnlyKey(res.Key) {
+		handler.logger.Warnw("attempt to read internal-only attribute", "key", res.Key, "userId", userId)
+		common.WriteJsonResp(w, fmt.Errorf("forbidden: cannot read attribute with key: %q", res.Key), nil, http.StatusForbidden)
+		return
+	}
+
 	common.WriteJsonResp(w, nil, res, http.StatusOK)
 }
 
@@ -167,7 +206,10 @@ func (handler AttributesRestHandlerImpl) GetAttributesActiveList(w http.Response
 		common.WriteJsonResp(w, err, nil, http.StatusInternalServerError)
 		return
 	}
-	common.WriteJsonResp(w, nil, res, http.StatusOK)
+
+	// Filter out internal-only attributes from the list
+	filteredRes := handler.filterInternalAttributes(res)
+	common.WriteJsonResp(w, nil, filteredRes, http.StatusOK)
 }
 
 func (handler AttributesRestHandlerImpl) GetAttributesByKey(w http.ResponseWriter, r *http.Request) {
@@ -185,9 +227,17 @@ func (handler AttributesRestHandlerImpl) GetAttributesByKey(w http.ResponseWrite
 
 	vars := mux.Vars(r)
 	key := vars["key"]
+
+	// Check if the key is internal-only (not allowed to be read via API)
+	if handler.isInternalOnlyKey(key) {
+		handler.logger.Warnw("attempt to read internal-only attribute by key", "key", key, "userId", userId)
+		common.WriteJsonResp(w, fmt.Errorf("forbidden: cannot read attribute with key: %q", key), nil, http.StatusForbidden)
+		return
+	}
+
 	res, err := handler.attributesService.GetByKey(key)
 	if err != nil {
-		handler.logger.Errorw("service err, GetAttributesById", "err", err)
+		handler.logger.Errorw("service err, GetAttributesByKey", "key", key, "err", err)
 		common.WriteJsonResp(w, err, nil, http.StatusInternalServerError)
 		return
 	}
@@ -204,8 +254,14 @@ func (handler AttributesRestHandlerImpl) AddDeploymentEnforcementConfig(w http.R
 	var dto bean.AttributesDto
 	err = decoder.Decode(&dto)
 	if err != nil {
-		handler.logger.Errorw("request err, AddAttributes", "err", err, "payload", dto)
+		handler.logger.Errorw("request err, AddDeploymentEnforcementConfig", "err", err, "payload", dto)
 		common.WriteJsonResp(w, err, nil, http.StatusBadRequest)
+		return
+	}
+
+	// Check if the key is enforce deployment type config
+	if dto.Key != bean.ENFORCE_DEPLOYMENT_TYPE_CONFIG {
+		common.WriteJsonResp(w, fmt.Errorf("invalid key: %q", dto.Key), nil, http.StatusBadRequest)
 		return
 	}
 
@@ -215,10 +271,10 @@ func (handler AttributesRestHandlerImpl) AddDeploymentEnforcementConfig(w http.R
 		return
 	}
 
-	handler.logger.Infow("request payload, AddAttributes", "payload", dto)
+	handler.logger.Infow("request payload, AddDeploymentEnforcementConfig", "payload", dto)
 	resp, err := handler.attributesService.AddDeploymentEnforcementConfig(&dto)
 	if err != nil {
-		handler.logger.Errorw("service err, AddAttributes", "err", err, "payload", dto)
+		handler.logger.Errorw("service err, AddDeploymentEnforcementConfig", "err", err, "payload", dto)
 		common.WriteJsonResp(w, err, nil, http.StatusInternalServerError)
 		return
 	}

--- a/pkg/attributes/bean/bean.go
+++ b/pkg/attributes/bean/bean.go
@@ -24,6 +24,11 @@ const (
 	UserPreferencesResourcesKey           = "resources"
 )
 
+// InternalOnlyKeys are the internal attribute keys - cannot be read or written via API
+var InternalOnlyKeys = map[string]bool{
+	API_SECRET_KEY: true,
+}
+
 type AttributesDto struct {
 	Id     int    `json:"id"`
 	Key    string `json:"key,omitempty"`


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes https://github.com/devtron-labs/sprint-tasks/issues/2808
<!--
For example:
Fixes https://github.com/devtron-labs/<repo_name>/issues/<issue_number>
Fixes devtron-labs/<repo_name>#<issue_number>

PS: Please ensure that you've attached a valid issue that is OPEN
-->


<!--test-cases
## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added InternalOnlyKeys map in bean.go to define attributes restricted from API access, initially including API_SECRET_KEY.</li>
<li>Introduced isInternalOnlyKey and filterInternalAttributes methods in AttributesRestHandlerImpl to check and filter internal-only attributes.</li>
<li>Modified AddAttributes and UpdateAttributes methods to prevent creation or editing of internal-only attributes via API.</li>
<li>Updated GetAttributesById, GetAttributesActiveList, and GetAttributesByKey methods to block reading of internal-only attributes.</li>
<li>Enhanced logging in AddDeploymentEnforcementConfig and GetAttributesByKey for improved error reporting.</li>
</ul></div>