### PR TITLE
misc: Add support for direct CI pipeline status in workflow status retrieval

### DIFF
--- a/pkg/pipeline/CiHandler.go
+++ b/pkg/pipeline/CiHandler.go
@@ -20,6 +20,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/devtron-labs/common-lib/utils"
 	"github.com/devtron-labs/common-lib/utils/workFlow"
 	cdWorkflowBean "github.com/devtron-labs/devtron/internal/sql/repository/pipelineConfig/bean/workflow/cdWorkflow"
@@ -32,11 +38,6 @@ import (
 	util2 "github.com/devtron-labs/devtron/pkg/pipeline/util"
 	"github.com/devtron-labs/devtron/pkg/pipeline/workflowStatus"
 	"github.com/devtron-labs/devtron/pkg/workflow/workflowStatusLatest"
-	"regexp"
-	"slices"
-	"strconv"
-	"strings"
-	"time"
 
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	bean2 "github.com/devtron-labs/devtron/api/bean"
@@ -1064,6 +1065,7 @@ func (impl *CiHandlerImpl) FetchCiStatusForTriggerViewForEnvironment(request res
 
 	linkedPipelineDetails := make(map[int]*pipelineConfig.CiPipeline) // linkedPipelineId -> pipeline object
 	parentToLinkedMap := make(map[int][]int)                          // parentPipelineId -> []linkedPipelineId
+	directCiPipelineIds := make(map[int]bool)                         // pipeline IDs that are direct (non-linked) CI pipelines in this env
 
 	for _, ciPipeline := range ciPipelines {
 		appObject := objects[ciPipeline.Id] // here only app permission have to check
@@ -1079,6 +1081,8 @@ func (impl *CiHandlerImpl) FetchCiStatusForTriggerViewForEnvironment(request res
 			linkedPipelineDetails[ciPipeline.Id] = ciPipeline
 			// Add to slice of linked pipelines for this parent
 			parentToLinkedMap[ciPipelineId] = append(parentToLinkedMap[ciPipelineId], ciPipeline.Id)
+		} else {
+			directCiPipelineIds[ciPipelineId] = true
 		}
 	}
 
@@ -1105,6 +1109,12 @@ func (impl *CiHandlerImpl) FetchCiStatusForTriggerViewForEnvironment(request res
 			// create workflow status for each linked pipeline
 			for _, linkedPipelineId := range linkedPipelineIds {
 				ciWorkflowStatus := adapter.GetCiWorkflowStatusForLinkedCiPipeline(linkedPipelineId, linkedPipelineDetails[linkedPipelineId].Name, ciWorkflow)
+				ciWorkflowStatuses = append(ciWorkflowStatuses, ciWorkflowStatus)
+			}
+			// parent pipeline itself also needs a status entry when it is a direct CI pipeline
+			// in this env (App A's CI that App B links to — both have CD in the same env)
+			if directCiPipelineIds[ciWorkflow.CiPipelineId] {
+				ciWorkflowStatus := adapter.GetCiWorkflowStatusFromCiWorkflow(ciWorkflow)
 				ciWorkflowStatuses = append(ciWorkflowStatuses, ciWorkflowStatus)
 			}
 		} else {


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes https://github.com/devtron-labs/sprint-tasks/issues/2901
<!--
For example:
Fixes https://github.com/devtron-labs/<repo_name>/issues/<issue_number>
Fixes devtron-labs/<repo_name>#<issue_number>

PS: Please ensure that you've attached a valid issue that is OPEN
-->


<!--test-cases
## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have performed a self-review of my own code.
* [X] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

