### PR TITLE
fix: atlan-poc-internal-app-flux-listing

### DIFF
--- a/pkg/appStore/installedApp/repository/InstalledAppRepository.go
+++ b/pkg/appStore/installedApp/repository/InstalledAppRepository.go
@@ -18,6 +18,9 @@ package repository
 
 import (
 	"fmt"
+	"strconv"
+	"time"
+
 	"github.com/devtron-labs/common-lib/utils/k8s/health"
 	"github.com/devtron-labs/devtron/internal/sql/repository/app"
 	"github.com/devtron-labs/devtron/internal/sql/repository/pipelineConfig/bean/timelineStatus"
@@ -34,8 +37,6 @@ import (
 	"github.com/go-pg/pg"
 	"github.com/go-pg/pg/orm"
 	"go.uber.org/zap"
-	"strconv"
-	"time"
 )
 
 // InstalledApps TODO: remove the deprecated column GitOpsRepoName
@@ -765,7 +766,7 @@ func (impl *InstalledAppRepositoryImpl) GetAppAndEnvDetailsForDeploymentAppTypeI
 	var installedApps []*InstalledApps
 	err := impl.dbConnection.
 		Model(&installedApps).
-		Column("installed_apps.id", "App.app_name", "App.display_name", "Environment.cluster_id", "Environment.namespace").
+		Column("installed_apps.id", "App.app_name", "App.display_name", "Environment.cluster_id", "Environment.namespace", "Environment.environment_name").
 		Join("LEFT JOIN deployment_config dc on dc.active=true and dc.app_id = installed_apps.app_id and dc.environment_id=installed_apps.environment_id").
 		Where("environment.cluster_id in (?)", pg.In(clusterIds)).
 		Where("(installed_apps.deployment_app_type = ? or dc.deployment_app_type = ?)", deploymentAppType, deploymentAppType).

--- a/pkg/fluxApplication/FluxApplicationService.go
+++ b/pkg/fluxApplication/FluxApplicationService.go
@@ -3,6 +3,9 @@ package fluxApplication
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+
 	"github.com/devtron-labs/common-lib/utils/k8s/commonBean"
 	"github.com/devtron-labs/devtron/api/connector"
 	"github.com/devtron-labs/devtron/api/helm-app/gRPC"
@@ -15,12 +18,11 @@ import (
 	"github.com/devtron-labs/devtron/pkg/appStore/installedApp/repository"
 	"github.com/devtron-labs/devtron/pkg/cluster"
 	"github.com/devtron-labs/devtron/pkg/fluxApplication/bean"
+	util2 "github.com/devtron-labs/devtron/util"
 	"github.com/devtron-labs/devtron/util/sliceUtil"
 	"github.com/gogo/protobuf/proto"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
-	"io"
-	"net/http"
 )
 
 type FluxApplicationService interface {
@@ -126,7 +128,7 @@ func (impl *FluxApplicationServiceImpl) ListFluxApplications(ctx context.Context
 		if _, ok := installedAppMap[key]; !ok {
 			installedAppMap[key] = make(map[string]bool)
 		}
-		deploymentAppName := fmt.Sprintf("%s-%s", i.App.AppName, i.Environment.Namespace)
+		deploymentAppName := util2.BuildDeployedAppName(i.App.AppName, i.Environment.Name)
 		installedAppMap[key][deploymentAppName] = true
 	}
 	if !noStream {


### PR DESCRIPTION
Fixes devtron-labs/sprint-tasks#2904

<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

• While constructing the map for helm apps, we are building the deploymentAppVariable inline as seen in line 142, which is a combination of appName + namespace.
• This name has to map with deployedApp.Name as seen in line 175. Only then the value will be excluded.
• I can also see a BuildDeployedAppName in DeploymentUtil.go which consists of a combination of appName + environmentName.
• The key is getting constructed in a wrong fashion which is leading to this bug.

<!--
For example:
Fixes https://github.com/devtron-labs/<repo_name>/issues/<issue_number>
Fixes devtron-labs/<repo_name>#<issue_number>

PS: Please ensure that you've attached a valid issue that is OPEN
-->


<!--test-cases
## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated InstalledAppRepository to include environment_name in the database query for deployment app details.</li>
<li>Refactored FluxApplicationService to use a utility function for building deployment app names instead of manual string formatting.</li>
<li>Cleaned up and reordered imports in both modified files.</li>
</ul></div>