### PR TITLE
feat: support idleReplicaCount=0 rendering in Rollout Deployment KEDA template

### DIFF
--- a/scripts/devtron-reference-helm-charts/deployment-chart_1-0-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_1-0-0/templates/keda-autoscaling.yaml
@@ -33,7 +33,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/deployment-chart_1-0-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_1-0-0/values.yaml
@@ -88,7 +88,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/deployment-chart_1-1-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_1-1-0/templates/keda-autoscaling.yaml
@@ -33,7 +33,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/deployment-chart_1-1-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_1-1-0/values.yaml
@@ -123,7 +123,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/deployment-chart_4-18-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_4-18-0/templates/keda-autoscaling.yaml
@@ -33,7 +33,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/deployment-chart_4-18-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_4-18-0/values.yaml
@@ -125,7 +125,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/deployment-chart_4-19-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_4-19-0/templates/keda-autoscaling.yaml
@@ -33,7 +33,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/deployment-chart_4-19-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_4-19-0/values.yaml
@@ -125,7 +125,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/deployment-chart_4-20-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_4-20-0/templates/keda-autoscaling.yaml
@@ -38,7 +38,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/deployment-chart_4-20-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_4-20-0/values.yaml
@@ -127,7 +127,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/deployment-chart_4-21-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_4-21-0/templates/keda-autoscaling.yaml
@@ -38,7 +38,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/deployment-chart_4-21-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_4-21-0/values.yaml
@@ -130,7 +130,7 @@ kedaAutoscaling:
   envSourceContainerName: "" # Optional. Default: .spec.template.spec.containers[0]
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
-  idleReplicaCount: 0
+#  idleReplicaCount: 0
   maxReplicaCount: 2
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.

--- a/scripts/devtron-reference-helm-charts/deployment-chart_4-21-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_4-21-0/values.yaml
@@ -130,6 +130,7 @@ kedaAutoscaling:
   envSourceContainerName: "" # Optional. Default: .spec.template.spec.containers[0]
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
+  idleReplicaCount: 0
   maxReplicaCount: 2
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.

--- a/scripts/devtron-reference-helm-charts/deployment-chart_4-22-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_4-22-0/templates/keda-autoscaling.yaml
@@ -38,7 +38,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/deployment-chart_4-22-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_4-22-0/values.yaml
@@ -131,7 +131,7 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0
+#  idleReplicaCount: 0
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/deployment-chart_4-22-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/deployment-chart_4-22-0/values.yaml
@@ -131,6 +131,7 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
+  idleReplicaCount: 0
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/gpu-workload-4-21-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/gpu-workload-4-21-0/templates/keda-autoscaling.yaml
@@ -38,7 +38,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/gpu-workload-4-21-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/gpu-workload-4-21-0/values.yaml
@@ -127,7 +127,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-11-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-11-0/templates/keda-autoscaling.yaml
@@ -17,7 +17,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-11-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-11-0/values.yaml
@@ -88,7 +88,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-12-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-12-0/templates/keda-autoscaling.yaml
@@ -17,7 +17,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-12-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-12-0/values.yaml
@@ -88,7 +88,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-13-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-13-0/templates/keda-autoscaling.yaml
@@ -17,7 +17,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-13-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-13-0/values.yaml
@@ -88,7 +88,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-14-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-14-0/templates/keda-autoscaling.yaml
@@ -17,7 +17,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-14-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-14-0/values.yaml
@@ -88,7 +88,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-15-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-15-0/templates/keda-autoscaling.yaml
@@ -17,7 +17,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-15-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-15-0/values.yaml
@@ -88,7 +88,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-16-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-16-0/templates/keda-autoscaling.yaml
@@ -17,7 +17,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-16-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-16-0/values.yaml
@@ -88,7 +88,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-17-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-17-0/templates/keda-autoscaling.yaml
@@ -17,7 +17,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-17-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-17-0/values.yaml
@@ -88,7 +88,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/templates/keda-autoscaling.yaml
@@ -17,7 +17,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-18-0/values.yaml
@@ -90,7 +90,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-19-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-19-0/templates/keda-autoscaling.yaml
@@ -33,7 +33,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-19-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-19-0/values.yaml
@@ -90,7 +90,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-20-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-20-0/templates/keda-autoscaling.yaml
@@ -38,7 +38,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/reference-chart_4-20-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_4-20-0/values.yaml
@@ -100,7 +100,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/reference-chart_5-0-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_5-0-0/templates/keda-autoscaling.yaml
@@ -38,7 +38,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/reference-chart_5-0-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_5-0-0/values.yaml
@@ -124,7 +124,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/reference-chart_5-1-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_5-1-0/templates/keda-autoscaling.yaml
@@ -38,7 +38,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/reference-chart_5-1-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_5-1-0/values.yaml
@@ -128,6 +128,7 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
+  idleReplicaCount: 0
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/reference-chart_5-1-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_5-1-0/values.yaml
@@ -128,7 +128,7 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0
+#  idleReplicaCount: 0
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/reference-chart_5-2-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_5-2-0/templates/keda-autoscaling.yaml
@@ -38,7 +38,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/reference-chart_5-2-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_5-2-0/values.yaml
@@ -87,6 +87,7 @@ autoscaling:
   enabled: false
   MinReplicas: 1
   MaxReplicas: 2
+  idleReplicaCount: 0
   # TargetCPUUtilizationPercentage: 90
   # TargetMemoryUtilizationPercentage: 80
   annotations: {}

--- a/scripts/devtron-reference-helm-charts/reference-chart_5-2-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/reference-chart_5-2-0/values.yaml
@@ -87,7 +87,6 @@ autoscaling:
   enabled: false
   MinReplicas: 1
   MaxReplicas: 2
-  idleReplicaCount: 0
   # TargetCPUUtilizationPercentage: 90
   # TargetMemoryUtilizationPercentage: 80
   annotations: {}

--- a/scripts/devtron-reference-helm-charts/statefulset-chart_4-18-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/statefulset-chart_4-18-0/templates/keda-autoscaling.yaml
@@ -17,7 +17,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/statefulset-chart_4-18-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/statefulset-chart_4-18-0/values.yaml
@@ -87,7 +87,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/statefulset-chart_4-19-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/statefulset-chart_4-19-0/templates/keda-autoscaling.yaml
@@ -17,7 +17,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/statefulset-chart_4-19-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/statefulset-chart_4-19-0/values.yaml
@@ -87,7 +87,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/statefulset-chart_5-0-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/statefulset-chart_5-0-0/templates/keda-autoscaling.yaml
@@ -23,7 +23,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/statefulset-chart_5-0-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/statefulset-chart_5-0-0/values.yaml
@@ -87,7 +87,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/statefulset-chart_5-1-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/statefulset-chart_5-1-0/templates/keda-autoscaling.yaml
@@ -42,7 +42,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/statefulset-chart_5-1-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/statefulset-chart_5-1-0/values.yaml
@@ -93,7 +93,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/statefulset-chart_5-2-0/templates/keda-autoscaling.yaml
+++ b/scripts/devtron-reference-helm-charts/statefulset-chart_5-2-0/templates/keda-autoscaling.yaml
@@ -42,7 +42,7 @@ spec:
 {{- if $.Values.kedaAutoscaling.cooldownPeriod }}
   cooldownPeriod: {{ $.Values.kedaAutoscaling.cooldownPeriod }}
 {{- end }}
-{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
+{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
   idleReplicaCount: {{ $.Values.kedaAutoscaling.idleReplicaCount }}
 {{- end }}
   minReplicaCount: {{ $.Values.kedaAutoscaling.minReplicaCount }}

--- a/scripts/devtron-reference-helm-charts/statefulset-chart_5-2-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/statefulset-chart_5-2-0/values.yaml
@@ -93,7 +93,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options

--- a/scripts/devtron-reference-helm-charts/workflow-chart_1-0-0/values.yaml
+++ b/scripts/devtron-reference-helm-charts/workflow-chart_1-0-0/values.yaml
@@ -86,7 +86,6 @@ kedaAutoscaling:
   cooldownPeriod: 300 # Optional. Default: 300 seconds
   minReplicaCount: 1 
   maxReplicaCount: 2
-  idleReplicaCount: 0 # Optional. Must be less than minReplicaCount
   pollingInterval: 30 # Optional. Default: 30 seconds
   # The fallback section is optional. It defines a number of replicas to fallback to if a scaler is in an error state.
   fallback: {} # Optional. Section to specify fallback options


### PR DESCRIPTION
fixes devtron-labs/devops-sprint#2127
## Type of change

- [x] Bug fix

## Description

### Problem Statement

When `kedaAutoscaling.idleReplicaCount` is configured with the value `0`, the generated KEDA `ScaledObject` does not render the `idleReplicaCount` field.

The existing Helm template uses the following condition:

```gotemplate
{{- if $.Values.kedaAutoscaling.idleReplicaCount }}
```

Since Helm evaluates `0` as a false value, the condition fails and the field is omitted from the rendered manifest.

As a result, users cannot explicitly configure:

```yaml
idleReplicaCount: 0
```

even when it is provided in the deployment template values.

### Root Cause

The template checks the truthiness of the value instead of checking whether the value is defined.

### Fix

Updated the template condition to explicitly check for `nil`:

```gotemplate
{{- if ne $.Values.kedaAutoscaling.idleReplicaCount nil }}
```

This ensures that:

- `idleReplicaCount: 0` is rendered correctly.
- Any non-zero value is also rendered.
- The field is omitted only when it is not configured.

Additionally, added the default `idleReplicaCount: 0` in `values.yaml` for consistency.

### Testing

- Updated the Rollout Deployment reference chart.
- Verified the rendered ScaledObject manifest includes:

```yaml
idleReplicaCount: 0
```

when configured in values.

### Impact

This change preserves existing behavior while correctly supporting explicit zero values for `idleReplicaCount`.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated KEDA autoscaling template to correctly handle idleReplicaCount when set to 0 by checking for nil instead of truthiness.</li>
<li>Added idleReplicaCount with a default value of 0 to the autoscaling configuration in values.yaml.</li>
</ul></div>