### PR TITLE
fix: allow separate Bitbucket REST username for API-token GitOps auth

### DIFF
--- a/pkg/deployment/gitOps/git/GitServiceBitbucket.go
+++ b/pkg/deployment/gitOps/git/GitServiceBitbucket.go
@@ -52,7 +52,16 @@ type GitBitbucketClient struct {
 }
 
 func NewGitBitbucketClient(username, token, host string, logger *zap.SugaredLogger, gitOpsHelper *GitOpsHelper, tlsConfig *tls.Config) GitBitbucketClient {
-	coreClient := bitbucket.NewBasicAuth(username, token)
+	// Bitbucket API tokens (the replacement for deprecated app passwords, CHANGE-3222)
+	// authenticate the REST API with the Atlassian account email, whereas git-over-HTTPS
+	// uses the Bitbucket username. gitops_config stores a single username (consumed by
+	// go-git for clone/push), so allow overriding just the REST client's username via
+	// BITBUCKET_REST_USERNAME. When unset, behaviour is unchanged.
+	restUsername := username
+	if v := os.Getenv("BITBUCKET_REST_USERNAME"); v != "" {
+		restUsername = v
+	}
+	coreClient := bitbucket.NewBasicAuth(restUsername, token)
 	httpClient := util.GetHTTPClientWithTLSConfig(tlsConfig)
 	coreClient.HttpClient = httpClient
 	logger.Infow("bitbucket client created", "clientDetails", coreClient)


### PR DESCRIPTION
Bitbucket deprecated app passwords (CHANGE-3222); git-over-HTTPS now returns HTTP 410. Their replacement, API tokens, authenticate the two surfaces Devtron uses with different usernames:

  - git-over-HTTPS (go-git): the Bitbucket username (or x-bitbucket-api-token-auth)
  - Bitbucket Cloud REST API: the Atlassian account email

A single GitOps deploy uses both -- go-git clone/push for the chart, and the REST API (WriteFileBlob) to commit values -- but gitops_config stores a single username. With an API token no single username satisfies both: the Bitbucket username fails REST with 401, and the email fails git with exit status 128. App passwords worked for both surfaces, which is why this only surfaces after the deprecation.

Add an optional BITBUCKET_REST_USERNAME env override, applied only to the Bitbucket REST client. When unset, behaviour is unchanged. When set to the Atlassian email, REST calls (repo create, WriteFileBlob, GetCommits, repo-exists) authenticate correctly while go-git keeps using the configured GitOps username, so both surfaces work with a single API token.

<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes #
<!--
For example:
Fixes https://github.com/devtron-labs/<repo_name>/issues/<issue_number>
Fixes devtron-labs/<repo_name>#<issue_number>

PS: Please ensure that you've attached a valid issue that is OPEN
-->


<!--test-cases
## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

