### PR TITLE
docs: correct mismatched godoc comment names

### DIFF
--- a/client/argocdServer/connection/Connection.go
+++ b/client/argocdServer/connection/Connection.go
@@ -132,7 +132,7 @@ func (impl *ArgoCDConnectionManagerImpl) ValidateGitOpsAndGetOrUpdateArgoCdUserD
 	return ""
 }
 
-// GetConnection - this function will call only for acd connection
+// GetGrpcClientConnection - this function will call only for acd connection
 func (impl *ArgoCDConnectionManagerImpl) GetGrpcClientConnection(grpcConfig *bean.ArgoGRPCConfig) *grpc.ClientConn {
 	//TODO: acdAuthConfig should be passed as arg in function
 	token, err := impl.getLatestDevtronArgoCdUserToken(grpcConfig)

--- a/client/cron/CiTriggerCron.go
+++ b/client/cron/CiTriggerCron.go
@@ -84,7 +84,7 @@ func GetCiTriggerCronConfig() (*CiTriggerCronConfig, error) {
 	return cfg, nil
 }
 
-// UpdateCiWorkflowStatusFailedCron this function will execute periodically
+// TriggerCiCron this function will execute periodically
 func (impl *CiTriggerCronImpl) TriggerCiCron() {
 	plugin, err := impl.globalPluginRepository.GetPluginByName(impl.cfg.PluginName)
 	if err != nil || len(plugin) == 0 {

--- a/pkg/deployment/manifest/deployedAppMetrics/DeployedAppMetrics.go
+++ b/pkg/deployment/manifest/deployedAppMetrics/DeployedAppMetrics.go
@@ -103,7 +103,7 @@ func (impl *DeployedAppMetricsServiceImpl) GetMetricsFlagForAPipelineByAppIdAndE
 	return isAppMetricsEnabled, nil
 }
 
-// CheckAndUpdateAppOrEnvLevelMetrics - this method checks whether chart being used supports metrics or not, is app level or env level and updates accordingly
+// CreateOrUpdateAppOrEnvLevelMetrics - this method checks whether chart being used supports metrics or not, is app level or env level and updates accordingly
 func (impl *DeployedAppMetricsServiceImpl) CreateOrUpdateAppOrEnvLevelMetrics(ctx context.Context, req *bean.DeployedAppMetricsRequest) error {
 	isAppMetricsSupported, err := impl.CheckIsAppMetricsSupported(req.ChartRefId)
 	if err != nil {

--- a/util/DeploymentUtil.go
+++ b/util/DeploymentUtil.go
@@ -81,7 +81,7 @@ func IntnRange(min, max int) int {
 	return rng.rand.Intn(max-min) + min
 }
 
-// IntnRange generates an int64 integer in range [min,max).
+// Int63nRange generates an int64 integer in range [min,max).
 // By design this should panic if input is invalid, <= 0.
 func Int63nRange(min, max int64) int64 {
 	rng.Lock()


### PR DESCRIPTION
A few exported functions had doc comments that began with a different function's name (Go convention is that a doc comment starts with the name of the symbol it documents). These look like copy/paste leftovers from renamed functions:

- `GetGrpcClientConnection` (client/argocdServer/connection): comment said `GetConnection`
- `TriggerCiCron` (client/cron): comment said `UpdateCiWorkflowStatusFailedCron`
- `CreateOrUpdateAppOrEnvLevelMetrics` (pkg/deployment/manifest/deployedAppMetrics): comment said `CheckAndUpdateAppOrEnvLevelMetrics`
- `Int63nRange` (util): comment said `IntnRange`

Comment-only change; no behavior change.