### PR TITLE
feat: configure Devtron probes via Helm (#6964)

### DIFF
--- a/charts/devtron/README.md
+++ b/charts/devtron/README.md
@@ -138,3 +138,25 @@ example of DEX_CONFIG is
 **Please Note:**
 Ensure that the cluster has access to the DEFAULT_CACHE_BUCKET, DEFAULT_BUILD_LOGS_BUCKET, CHARTMUSEUM_STORAGE_AMAZON_BUCKET and AWS secrets backends (SSM & secrets manager)
 
+### Devtron probe configuration
+
+The liveness and readiness probe timings for the main Devtron deployment can be customized under `components.devtron` while retaining the `/health` endpoint configured by the chart:
+
+```yaml
+components:
+  devtron:
+    livenessProbe:
+      failureThreshold: 3
+      initialDelaySeconds: 60
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 5
+    readinessProbe:
+      failureThreshold: 3
+      initialDelaySeconds: 60
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 5
+```
+
+If these values are not overridden, the chart continues to use the existing probe timings from `values.yaml`.

--- a/charts/devtron/templates/devtron.yaml
+++ b/charts/devtron/templates/devtron.yaml
@@ -281,25 +281,17 @@ spec:
                   - ' curl -X POST -H "Content-Type: application/json" -d ''{"eventType":
                   "SIG_TERM"}'' localhost:8080/orchestrator/telemetry/summary'
           livenessProbe:
-            failureThreshold: 3
             httpGet:
               path: /health
               port: {{ $.Values.components.devtron.healthPort}}
               scheme: HTTP
-            initialDelaySeconds: 20
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 5
+{{ toYaml $.Values.components.devtron.livenessProbe | indent 12 }}
           readinessProbe:
-            failureThreshold: 3
             httpGet:
               path: /health
               port: {{ $.Values.components.devtron.healthPort}}
               scheme: HTTP
-            initialDelaySeconds: 20
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 5
+{{ toYaml $.Values.components.devtron.readinessProbe | indent 12 }}
           ports:
             - name: devtron
               containerPort: 8080

--- a/charts/devtron/values.yaml
+++ b/charts/devtron/values.yaml
@@ -107,6 +107,19 @@ components:
     imagePullPolicy: IfNotPresent
     customOverrides: {}
     healthPort: 8080
+    # Probe timings for the main Devtron deployment's /health endpoint.
+    livenessProbe:
+      failureThreshold: 3
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 5
+    readinessProbe:
+      failureThreshold: 3
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 5
     podSecurityContext:
       fsGroup: 1001
       runAsGroup: 1001


### PR DESCRIPTION
# Description

Expose the main Devtron deployment's liveness and readiness probe timing fields through Helm values so installations with slower startup behavior no longer need a post-install patch.

- adds `components.devtron.livenessProbe` and `components.devtron.readinessProbe`
- preserves the current timing defaults and `/health` handler
- documents a slow-start override example in the chart README

This provides a clean, validated implementation of the feature also attempted in the existing unreviewed draft #6965.

Fixes devtron-labs/devtron#6964

## How Has This Been Tested?

- [x] `helm lint` against the first-party chart templates (remote dependencies omitted)
- [x] `helm template --show-only templates/devtron.yaml` with default values
- [x] `helm template --show-only templates/devtron.yaml` with independent liveness and readiness overrides

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles. (Not applicable to a rendered Deployment setting.)
* [x] I have added all the required unit/api test cases. (No unit/API behavior changes; Helm rendering was validated.)

## Does this PR introduce a user-facing change?

```release-note
The `devtron-operator` Helm chart now supports `components.devtron.livenessProbe` and `components.devtron.readinessProbe` timing overrides for the main Devtron deployment.
```
