### PR TITLE
fix: unblock external Postgres pre-install hook

### DIFF
--- a/charts/devtron/templates/migrator.yaml
+++ b/charts/devtron/templates/migrator.yaml
@@ -562,7 +562,6 @@ spec:
         app: database-creator
     spec:
       {{- include "common.schedulerConfig" (dict "nodeSelector" $.Values.components.migrator.nodeSelector "tolerations" $.Values.components.migrator.tolerations "imagePullSecrets" $.Values.components.migrator.imagePullSecrets "global" $.Values.global) | indent 6 }}
-      serviceAccountName: devtron-default-sa
       containers:
         - command:
             - /bin/sh


### PR DESCRIPTION
## Summary
- let the external PostgreSQL database-creator hook use the namespace default service account
- remove its dependency on `devtron-default-sa`, which Helm creates only after pre-install hooks finish

## Root cause
The database creator runs as a `pre-install` hook, while `devtron-default-sa` is a normal release resource. Kubernetes therefore rejects the hook pod before Helm has created that service account.

## Validation
- `helm lint` with CICD, Argo CD, and external PostgreSQL enabled
- rendered the migrator template and verified the database creator is present without a release service-account dependency
- verified the database creator remains absent when external PostgreSQL is disabled

Closes #6973