### PR TITLE
fix: stabilize single-node k3s storage configuration

### DIFF
--- a/charts/devtron/README.md
+++ b/charts/devtron/README.md
@@ -34,6 +34,22 @@ helm install devtron devtron/devtron-operator \
 --set installer.modules={cicd}
 ```
 
+### Choose the StorageClass
+
+Devtron PVCs use the cluster's default StorageClass unless `global.storageClass`
+is set. Set it explicitly when Devtron should not use the default class. For
+example, a resource-constrained, single-node k3s installation can keep its core
+data on the local-path provisioner even when Longhorn is the cluster default:
+
+```bash
+helm install devtron devtron/devtron-operator \
+--create-namespace --namespace devtroncd \
+--set-string global.storageClass=local-path
+```
+
+The selected StorageClass must already exist. This setting only affects newly
+created PVCs; changing it does not migrate existing volumes.
+
 ### Install with Helm (Beta)
 
 We also release beta versions of devtron every few days before the stable release for people who would like to explore and test beta features before everyone else. If you want to install a fresh devtron from beta release channel, use the chart in our official devtron repository.
@@ -137,4 +153,3 @@ example of DEX_CONFIG is
 
 **Please Note:**
 Ensure that the cluster has access to the DEFAULT_CACHE_BUCKET, DEFAULT_BUILD_LOGS_BUCKET, CHARTMUSEUM_STORAGE_AMAZON_BUCKET and AWS secrets backends (SSM & secrets manager)
-

--- a/charts/devtron/templates/_helpers.tpl
+++ b/charts/devtron/templates/_helpers.tpl
@@ -93,7 +93,7 @@ If storageClass is defined in values.yaml under global.storageClass, use that.
 */}}
 {{- define "common.storageclass" -}}
 {{- if $.Values.global.storageClass }}
-storageClassName: {{ $.Values.global.storageClass }}
+storageClassName: {{ $.Values.global.storageClass | quote }}
 {{- end }}
 {{- end -}}
 

--- a/charts/devtron/values.yaml
+++ b/charts/devtron/values.yaml
@@ -33,7 +33,9 @@ global:
   nodeSelector: {}
   tolerations: []
   imagePullSecrets: []
-  # Set the storage class to be used for PVCs (would use default sc if not specified)
+  # Set the storage class used by Devtron PVCs. When empty, the cluster's default
+  # StorageClass is used. Set this explicitly when the default class is not
+  # appropriate for Devtron (for example, local-path on a single-node k3s setup).
   storageClass: ""
   # Add Proxy Configs to be propagated to all the Devtron Microservices.
   configs: {}

--- a/docs/setup/getting-started/getting-started.md
+++ b/docs/setup/getting-started/getting-started.md
@@ -58,7 +58,8 @@ The minimum requirements for installing `Helm Dashboard by Devtron` and `Devtron
 > Refer to the [Override Configurations](../install/override-default-devtron-installation-configs.md) section for more information.
 
 **Note:**
-* Please make sure that the recommended resources are available on your Kubernetes cluster before you proceed with Devtron installation.
+* Please make sure that the recommended resources are available on your Kubernetes cluster before you proceed with Devtron installation. These are free resources for Devtron workloads; Kubernetes and add-ons such as Longhorn need additional capacity.
+* A single-node cluster does not provide Longhorn's recommended production topology. For a resource-constrained k3s evaluation cluster, use the `local-path` StorageClass for Devtron as described in the [k3s installation guide](../install/Install-devtron-on-Minikube-Microk8s-K3s-Kind.md#for-minikube-microk8s-k3s-kind). For production Longhorn sizing and topology, follow the [Longhorn best practices](https://longhorn.io/docs/latest/best-practices/).
 * It is NOT recommended to use brustable CPU VMs (T series in AWS, B Series in Azure and E2/N1 in GCP) for Devtron installation to experience consistency in performance.
  
 
@@ -76,5 +77,4 @@ Choose one of the options as per your requirements:
 | **Upgrade Devtron to latest version** | You can upgrade Devtron in one of the following ways:<ul><li>[Upgrade Devtron using Helm](../../setup/upgrade/README.md#upgrade-devtron-using-helm)</ul></li><ul><li>[Upgrade Devtron from UI](../../setup/upgrade/upgrade-devtron-ui.md)</ul></li> |
 
 **Note**: If you have questions, please let us know on our discord channel. [![Join Discord](https://img.shields.io/badge/Join%20us%20on-Discord-e01563.svg)](https://discord.gg/jsRG5qx2gp)
-
 

--- a/docs/setup/install/Install-devtron-on-Minikube-Microk8s-K3s-Kind.md
+++ b/docs/setup/install/Install-devtron-on-Minikube-Microk8s-K3s-Kind.md
@@ -5,7 +5,7 @@ You can install and try Devtron on a high-end machine or a Cloud VM. If you inst
 ## Prerequisites
 
 1. 2 vCPUs
-2. 4GB+ of free memory
+2. 4GB+ of free memory after Kubernetes and storage add-ons are running
 3. 20GB+ free disk space
 
 Before you get started, you must set up a cluster in your server and finish the following actions:
@@ -54,9 +54,16 @@ helm repo update devtron
 
 helm install devtron devtron/devtron-operator \
 --create-namespace --namespace devtroncd \
---set components.devtron.service.type=NodePort
+--set components.devtron.service.type=NodePort \
+--set-string global.storageClass=local-path
 
 ```
+
+The explicit StorageClass keeps Devtron's stateful components on k3s local
+storage even if a distributed provisioner such as Longhorn is the cluster
+default. On a multi-node cluster sized for Longhorn, omit
+`--set-string global.storageClass=local-path` to use the default class, or set
+`global.storageClass` to a dedicated Longhorn StorageClass.
 {% endtab %}
 
 {% endtabs %}

--- a/docs/setup/install/installation-configuration.md
+++ b/docs/setup/install/installation-configuration.md
@@ -30,6 +30,29 @@ Devtron provides ways to control how much `memory` or `CPU` can be allocated to 
  
 **`Small`**: To configure the small resources (e.g. to manage less than 10 apps on Devtron ) based on the requirements, append the Devtron installation command with  `-f https://raw.githubusercontent.com/devtron-labs/devtron/main/charts/devtron/resources-small.yaml`.
 
+## Configure Persistent Storage
+
+By default, Devtron PVCs use the cluster's default StorageClass. You can pin all
+Devtron PVCs to an existing class with `global.storageClass`:
+
+```bash
+helm install devtron devtron/devtron-operator \
+--create-namespace --namespace devtroncd \
+--set-string global.storageClass=local-path
+```
+
+| Parameter | Description | Default |
+| :--- | :--- | :--- |
+| **global.storageClass** | Existing StorageClass used for Devtron PVCs | Cluster default StorageClass |
+
+Set the value during the initial installation. Kubernetes does not allow the
+StorageClass of an existing PVC to be changed, so updating this value later
+does not migrate existing data. On resource-constrained, single-node k3s
+clusters, explicitly selecting `local-path` prevents a default distributed
+StorageClass from consuming the capacity reserved for Devtron. Production
+Longhorn installations should follow Longhorn's recommended node and resource
+sizing.
+
 ## Configure Overrides
 
 For `Helm` installation this section refers to _**customOverrides**_ section of `values.yaml`. In this section you can override values of devtron-cm which you want to keep persistent. For example:

--- a/scripts/ci/test-devtron-storage-class.sh
+++ b/scripts/ci/test-devtron-storage-class.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+set -eu
+
+ROOT=$(git rev-parse --show-toplevel)
+CHART="$ROOT/charts/devtron"
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' 0 1 2 15
+
+STAGED_CHART="$WORK_DIR/devtron"
+RENDERED="$WORK_DIR/rendered.yaml"
+mkdir -p "$STAGED_CHART"
+cp -R "$CHART/." "$STAGED_CHART/"
+
+# First-party PVC templates do not need the chart's remote dependencies. Keep
+# this regression test deterministic and runnable without network access.
+awk '
+    /^dependencies:[[:space:]]*$/ { skip = 1; next }
+    skip && /^[A-Za-z][A-Za-z0-9_-]*:[[:space:]]*/ { skip = 0 }
+    !skip { print }
+' "$STAGED_CHART/Chart.yaml" >"$STAGED_CHART/Chart.yaml.local"
+mv "$STAGED_CHART/Chart.yaml.local" "$STAGED_CHART/Chart.yaml"
+rm -rf "$STAGED_CHART/charts" "$STAGED_CHART/Chart.lock"
+
+helm template storage-test "$STAGED_CHART" \
+    --namespace devtroncd \
+    --set-string global.storageClass=ci-storage \
+    --set 'installer.modules={cicd}' \
+    --set minio.enabled=true \
+    --set monitoring.grafana.enabled=true \
+    --set devtronEnterprise.enabled=true \
+    --set devtronEnterprise.finops.enabled=true >"$RENDERED"
+
+storage_class_counts=$(awk '
+    $1 == "storageClassName:" { total++ }
+    $1 == "storageClassName:" && $2 == "\"ci-storage\"" { matching++ }
+    END { print total + 0, matching + 0 }
+' "$RENDERED")
+
+if test "$storage_class_counts" != "6 6"; then
+    printf 'expected explicit StorageClass on all 6 Devtron PVCs, found: %s\n' \
+        "$storage_class_counts" >&2
+    exit 1
+fi
+
+printf 'explicit StorageClass rendered on all Devtron PVCs\n'


### PR DESCRIPTION
## Summary

- pin the documented single-node k3s installation to the lightweight `local-path` StorageClass, even when Longhorn is the cluster default
- clarify that Devtron's memory requirements are free capacity in addition to Kubernetes and storage add-ons, and document the production Longhorn topology caveat
- quote explicit StorageClass values and add a deterministic render regression covering PostgreSQL, Git Sensor, NATS, MinIO, Grafana, and TimescaleDB PVCs
- document that `global.storageClass` must be chosen before PVC creation and does not migrate existing volumes

## Why

The reported 6 GB single-node host provides 6 GB total, while the documented Devtron CI/CD profile needs 6 GB of available capacity and Longhorn has its own node and memory requirements. Allowing Devtron to inherit a default distributed StorageClass on that resource-constrained topology adds storage control-plane and replica pressure, which manifests as pods repeatedly becoming unavailable.

The supported evaluation path now selects k3s local storage explicitly. Multi-node installations sized for Longhorn can continue using the default class or select a dedicated Longhorn StorageClass through `global.storageClass`.

Fixes #6272

## Testing

- `./scripts/ci/test-devtron-storage-class.sh`
- `helm lint` against the first-party chart with remote dependencies stripped (passes with the existing `engine` metadata and deprecated CronJob warnings)
- `git diff --check origin/main...HEAD`