### PR TITLE
chore: replace redundant boolean closure in makeAppStageStatus with id > 0

### DIFF
--- a/pkg/app/appDetails/read/AppDetailsReadService.go
+++ b/pkg/app/appDetails/read/AppDetailsReadService.go
@@ -142,13 +142,7 @@ func (impl *AppDetailsReadServiceImpl) makeAppStageStatus(stage int, stageName s
 	return AppView.AppStageStatus{
 		Stage:     stage,
 		StageName: stageName,
-		Status: func() bool {
-			if id > 0 {
-				return true
-			} else {
-				return false
-			}
-		}(),
-		Required: isRequired,
+		Status:    id > 0,
+		Required:  isRequired,
 	}
 }


### PR DESCRIPTION
# Description

`makeAppStageStatus` in `pkg/app/appDetails/read/AppDetailsReadService.go` built the `Status` field with an inline anonymous function that returned `true`/`false` from an `if id > 0` block. `AppStageStatus.Status` is a `bool`, so the closure is equivalent to the expression `id > 0`. This replaces it with `Status: id > 0`. Behavior is unchanged.

Fixes #6992

## How Has This Been Tested?

Verified locally with a table test for `makeAppStageStatus` covering `id` = 5, 1, 0 and -1, asserting the resulting `Status` along with the `Stage`, `StageName` and `Required` fields. It passes against both the original closure and the simplified expression, confirming the two are equivalent. `gofmt` and `go vet` are clean. The test is kept out of the change to match how the same redundant-branch cleanups were merged in this repo (for example #6668 and #6670 were source-only).

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I have updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?

```release-note

```
