### PR TITLE
perf(sql): add index on ci_workflow's status - FindByStatusesIn

### DIFF
--- a/scripts/sql/36504600_add_ci_workflow_active_status_index.down.sql
+++ b/scripts/sql/36504600_add_ci_workflow_active_status_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_ci_workflow_active_status;

--- a/scripts/sql/36504600_add_ci_workflow_active_status_index.up.sql
+++ b/scripts/sql/36504600_add_ci_workflow_active_status_index.up.sql
@@ -1,0 +1,24 @@
+-- Supports CiWorkflowRepositoryImpl.FindByStatusesIn, called every 5 minutes by
+-- the CI workflow status cron (UpdateCiWorkflowStatusFailure) to find builds
+-- stuck in Starting/Running so they can be timed out. With no index on status,
+-- this does a full sequential scan of ci_workflow (tens of millions of rows in
+-- production) on every run.
+--
+-- Partial index scoped to only the two statuses this query filters on, so it
+-- stays small (proportional to active build count, not total table size) and
+-- cheap to maintain on INSERT/UPDATE, regardless of how large ci_workflow grows.
+--
+-- Note: CREATE INDEX CONCURRENTLY cannot run inside a transaction (golang-migrate
+-- wraps each migration in a transaction). We use plain CREATE INDEX IF NOT EXISTS
+-- here so the migration is idempotent. For large existing ci_workflow tables,
+-- operators SHOULD create this index manually with CONCURRENTLY BEFORE deploying
+-- this release, to avoid blocking writes during pod startup (~2 minutes to build
+-- on a table with 40 million rows, benchmarked locally):
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_ci_workflow_active_status
+--     ON ci_workflow (status) WHERE status IN ('Starting', 'Running');
+--
+-- Once the index exists, this migration is a no-op (IF NOT EXISTS).
+
+CREATE INDEX IF NOT EXISTS idx_ci_workflow_active_status
+  ON ci_workflow (status) WHERE status IN ('Starting', 'Running');


### PR DESCRIPTION
# Description

Scans only active rows instead of the whole table. Stays fast regardless of table growth or cache state. Write overhead proportional to active build count

<!--
For example:
Fixes https://github.com/devtron-labs/<repo_name>/issues/<issue_number>
Fixes devtron-labs/<repo_name>#<issue_number>

PS: Please ensure that you've attached a valid issue that is OPEN
-->

Fixes: https://github.com/devtron-labs/sprint-tasks/issues/2943


<!--test-cases
## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```
