### PR TITLE
fix: remove duplicate role lookup branch

### DIFF
--- a/pkg/auth/user/repository/UserAuthRepository.go
+++ b/pkg/auth/user/repository/UserAuthRepository.go
@@ -1149,10 +1149,6 @@ func (impl UserAuthRepositoryImpl) GetRoleForOtherEntity(team, app, env, act, ac
 
 		}
 		_, err = impl.dbConnection.Query(&model, query, queryParams...)
-	} else if team == "" && app == "" && env == "" && act == "" {
-		return model, nil
-	} else {
-		return model, nil
 	}
 	if err != nil {
 		impl.Logger.Errorw("error in getting role for other entity", "err", err, "app", app, "act", act, "accessType", accessType, "team", team)


### PR DESCRIPTION
## Summary
- Remove a redundant if/else branch in role lookup where both branches returned the same value.
- Let unmatched inputs fall through to the existing return path without changing behavior.

Fixes #6031

## Validation
- git diff --check
- go test ./pkg/auth/user/repository (interrupted after several minutes with no output in this environment)