### PR TITLE
fix(auth): normalize filter request and apply status filtering during bulk delete

### DIFF
--- a/pkg/auth/user/RoleGroupService.go
+++ b/pkg/auth/user/RoleGroupService.go
@@ -843,6 +843,9 @@ func (impl RoleGroupServiceImpl) BulkDeleteRoleGroups(request *bean2.BulkDeleteR
 		// setting the filtered user ids here for further processing
 		request.Ids = filteredGroupIds
 	}
+	if len(request.Ids) == 0 {
+		return true, nil
+	}
 
 	err := impl.deleteRoleGroupsByIds(request)
 	if err != nil {
@@ -854,6 +857,7 @@ func (impl RoleGroupServiceImpl) BulkDeleteRoleGroups(request *bean2.BulkDeleteR
 
 // getGroupIdsHonoringFilters get the filtered group ids according to the request filters and returns groupIds and error(not nil) if any exception is caught.
 func (impl *RoleGroupServiceImpl) getGroupIdsHonoringFilters(request *bean2.ListingRequest) ([]int32, error) {
+	impl.userCommonService.SetDefaultValuesIfNotPresent(request, true)
 	//query to get particular models respecting filters
 	query, queryParams := helper.GetQueryForGroupListingWithFilters(request)
 	models, err := impl.roleGroupRepository.GetAllExecutingQuery(query, queryParams)

--- a/pkg/auth/user/UserService.go
+++ b/pkg/auth/user/UserService.go
@@ -1470,6 +1470,9 @@ func (impl *UserServiceImpl) BulkDeleteUsers(request *userBean.BulkDeleteRequest
 		// setting the filtered user ids here for further processing
 		request.Ids = filteredUserIds
 	}
+	if len(request.Ids) == 0 {
+		return true, nil
+	}
 	err := impl.deleteUsersByIds(request)
 	if err != nil {
 		impl.logger.Errorw("error in BulkDeleteUsers", "err", err)
@@ -1480,6 +1483,12 @@ func (impl *UserServiceImpl) BulkDeleteUsers(request *userBean.BulkDeleteRequest
 
 // getUserIdsHonoringFilters get the filtered user ids according to the request filters and returns userIds and error(not nil) if any exception is caught.
 func (impl *UserServiceImpl) getUserIdsHonoringFilters(request *userBean.ListingRequest) ([]int32, error) {
+	// default values will be used if not provided
+	impl.userCommonService.SetDefaultValuesIfNotPresent(request, false)
+	// setting filter status type
+	setStatusFilterType(request)
+	// Recording time here for overall consistency
+	setCurrentTimeInUserInfo(request)
 	//query to get particular models respecting filters
 	query, queryParams := helper.GetQueryForUserListingWithFilters(request)
 	models, err := impl.userRepository.GetAllExecutingQuery(query, queryParams)

--- a/pkg/auth/user/repository/helper/UserRepositoryQueryBuilder_test.go
+++ b/pkg/auth/user/repository/helper/UserRepositoryQueryBuilder_test.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2024. Devtron Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helper
+
+import (
+	"testing"
+
+	bean2 "github.com/devtron-labs/devtron/pkg/auth/user/bean"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetQueryForUserListingWithFilters(t *testing.T) {
+	t.Run("QueryWithSearchKeyAndPagination", func(t *testing.T) {
+		req := &bean2.ListingRequest{
+			SearchKey:  "devtron",
+			SortBy:     bean2.Email,
+			SortOrder:  bean2.Asc,
+			Size:       20,
+			Offset:     0,
+			CountCheck: false,
+		}
+
+		query, params := GetQueryForUserListingWithFilters(req)
+		assert.Contains(t, query, "where active = true")
+		assert.Contains(t, query, "email_id ilike ?")
+		assert.Contains(t, query, "order by  email_id")
+		assert.Contains(t, query, "limit ? offset ?")
+		assert.Equal(t, 3, len(params))
+		assert.Equal(t, "%devtron%", params[0])
+		assert.Equal(t, 20, params[1])
+		assert.Equal(t, 0, params[2])
+	})
+
+	t.Run("CountCheckQuery", func(t *testing.T) {
+		req := &bean2.ListingRequest{
+			SearchKey:  "test",
+			CountCheck: true,
+		}
+
+		query, params := GetQueryForUserListingWithFilters(req)
+		assert.Contains(t, query, "select count(*)")
+		assert.Contains(t, query, "email_id ilike ?")
+		assert.NotContains(t, query, "limit ? offset ?")
+		assert.Equal(t, 1, len(params))
+		assert.Equal(t, "%test%", params[0])
+	})
+}
+
+func TestGetQueryForGroupListingWithFilters(t *testing.T) {
+	t.Run("GroupListingWithSearchKeyAndSorting", func(t *testing.T) {
+		req := &bean2.ListingRequest{
+			SearchKey:  "admin-group",
+			SortBy:     bean2.GroupName,
+			SortOrder:  bean2.Desc,
+			Size:       10,
+			Offset:     5,
+			CountCheck: false,
+		}
+
+		query, params := GetQueryForGroupListingWithFilters(req)
+		assert.Contains(t, query, "where active = ?")
+		assert.Contains(t, query, "name ilike ?")
+		assert.Contains(t, query, "order by name DESC")
+		assert.Contains(t, query, "limit ? offset ?")
+		assert.Equal(t, 4, len(params))
+		assert.Equal(t, true, params[0])
+		assert.Equal(t, "%admin-group%", params[1])
+		assert.Equal(t, 10, params[2])
+		assert.Equal(t, 5, params[3])
+	})
+}


### PR DESCRIPTION
Closes #7020

### Problem
When `DELETE /orchestrator/user/bulk` (and `DELETE /orchestrator/role-group/bulk`) was executed with a `listingRequest` filter (e.g. `{"listingRequest":{"searchKey":"","status":["inactive"]}}`), `getUserIdsHonoringFilters` and `getGroupIdsHonoringFilters` invoked the query builder without running default request normalization (`SetDefaultValuesIfNotPresent`) or setting status filter types (`setStatusFilterType`, `setCurrentTimeInUserInfo`). As a result, status filters were not applied and unbounded default scans could target all users instead of the filtered subset. Additionally, if the filter resolved to 0 IDs, the delete routines did not early-exit.

### Solution
1. In `getUserIdsHonoringFilters` (`pkg/auth/user/UserService.go`), invoked `SetDefaultValuesIfNotPresent`, `setStatusFilterType`, and `setCurrentTimeInUserInfo` before building the query.
2. In `getGroupIdsHonoringFilters` (`pkg/auth/user/RoleGroupService.go`), invoked `SetDefaultValuesIfNotPresent` before building the query.
3. Added early return guards in `BulkDeleteUsers` and `BulkDeleteRoleGroups` when resolved `request.Ids` is empty.
4. Added unit tests for query building with search, pagination, and count checks in `pkg/auth/user/repository/helper/UserRepositoryQueryBuilder_test.go`.