### PR TITLE
refactor(app): replace redundant boolean closure in makeAppStageStatus with id > 0 (#6992)

### DIFF
--- a/pkg/app/appDetails/read/AppDetailsReadService.go
+++ b/pkg/app/appDetails/read/AppDetailsReadService.go
@@ -142,13 +142,7 @@ func (impl *AppDetailsReadServiceImpl) makeAppStageStatus(stage int, stageName s
 	return AppView.AppStageStatus{
 		Stage:     stage,
 		StageName: stageName,
-		Status: func() bool {
-			if id > 0 {
-				return true
-			} else {
-				return false
-			}
-		}(),
-		Required: isRequired,
+		Status:    id > 0,
+		Required:  isRequired,
 	}
 }


### PR DESCRIPTION
Closes #6992

### Description
In \pkg/app/appDetails/read/AppDetailsReadService.go\, \makeAppStageStatus\ initialized the \Status\ field using an inline anonymous closure:

\\\go
Status: func() bool {
    if id > 0 {
        return true
    } else {
        return false
    }
}(),
\\\

This replaces the closure with the direct boolean expression \Status: id > 0\, removing the per-call function execution while preserving the exact boolean logic.