### PR TITLE
chore: strip debug symbols from binary to reduce image size by 77 MB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ export
 
 build: clean wire
 	$(ENVVAR) GOOS=$(GOOS) go build -o devtron \
-			-ldflags="-X 'github.com/devtron-labs/devtron/util.GitCommit=${GIT_COMMIT}' \
+			-ldflags="-s -w -X 'github.com/devtron-labs/devtron/util.GitCommit=${GIT_COMMIT}' \
 			-X 'github.com/devtron-labs/devtron/util.BuildTime=${BUILD_TIME}' \
 			-X 'github.com/devtron-labs/devtron/util.ServerMode=${SERVER_MODE_FULL}'"
 


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><p dir="ltr">One line in the Makefile <code>build</code> target. <code>-s -w</code> added to the existing <code>-ldflags</code>, alongside the <code>-X</code> injections for GitCommit, BuildTime and ServerMode, which are unchanged.</p>
<p dir="ltr">The binary was the largest single contributor to image size. <code>file</code> reported it as <code>with debug_info, not stripped</code>, and <code>go tool nm</code> counted 721,193 symbols. Section sizes from <code>readelf</code>: <code>.symtab</code> and <code>.strtab</code> at roughly 42 MB, the eleven <code>.debug_*</code> sections at roughly 35 MB.</p>
<div dir="ltr">

| | Before | After | Change |
|---|---:|---:|---:|
| Binary | 277,213,440 B | 199,579,560 B | -77,633,880 B (-28.0%) |
| Image | 462 MB | 385 MB | -77 MB (-16.7%) |

</div>
<h2 dir="ltr">How Has This Been Tested?</h2>
<ul dir="ltr">
<li>Built both images with <code>docker build</code>, once on <code>main</code> and once with the change.</li>
<li><code>file</code> on the new binary reports <code>stripped</code> with no <code>debug_info</code>. <code>readelf -S | grep -cE "debug|symtab"</code> returns 0.</li>
<li>Confirmed the <code>-X</code> injections survive stripping: <code>strings</code> on the stripped binary still returns the injected build timestamp <code>2026-09-08T06:45:08Z</code>.</li>
<li>Ran the stripped image directly. It initialises, builds the wire graph, and panics on the expected <code>dial tcp 127.0.0.1:5432: connect: connection refused</code> with no database present. Same behaviour as the unstripped build.</li>
<li>Panic traces still resolve function names, files and line numbers (<code>main.main()</code> at <code>main.go:42</code>, <code>sql.NewDbConnection</code> at <code>connection.go:83</code>), since Go symbolises from pclntab rather than <code>.symtab</code>.</li>
</ul>
<p dir="ltr"><strong>Tradeoff:</strong> <code>-w</code> drops DWARF, so attaching delve to the shipped image would no longer give source-level debugging. Runtime panics and stack traces are unaffected, as above. Flagging in case anything in the release workflow depends on debugging the published image.</p>
<p dir="ltr"><strong>Out of scope, with reasoning in #2539:</strong> the perl dependency chain (git hard-depends on it, so <code>--no-install-recommends</code> would not remove it, and it would risk breaking SSH clone URLs by dropping <code>openssh-client</code>), and apt cache cleanup (already handled in the existing Dockerfile).</p>
<p dir="ltr"><strong>Question for reviewers:</strong> is there anything in the release or debugging workflow that reads symbols from the published binary? If so I can scope this to <code>-w</code> only, which still removes roughly 35 MB.</p>
<h2 dir="ltr">Checklist:</h2>
<ul dir="ltr">

- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] Does this PR requires documentation updates?
- [x] I have performed a self-review of my own code.
- [x] I have tested it for all user roles.
- [ ] I have added all the required unit/api test cases.
</ul>
<h2 dir="ltr">Does this PR introduce a user-facing change?</h2>
<p dir="ltr">No. The image is smaller and the binary is stripped. Runtime behaviour, the version endpoint and panic symbolisation are unchanged.</p>
<!--EndFragment-->
</body>
</html>