### PR TITLE
fix: empty sync/health status for external ArgoCD apps in the app list

### DIFF
--- a/pkg/argoApplication/ArgoApplicationService.go
+++ b/pkg/argoApplication/ArgoApplicationService.go
@@ -39,6 +39,7 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"net/http"
+	"strings"
 )
 
 type ArgoApplicationService interface {
@@ -160,6 +161,11 @@ func (impl *ArgoApplicationServiceImpl) ListApplications(clusterIds []int) ([]*b
 
 func getApplicationListDtos(resp *k8s.ClusterResourceListMap, clusterName string, clusterId int) []*bean.ArgoApplicationListDto {
 	appLists := make([]*bean.ArgoApplicationListDto, 0)
+	// BuildK8sObjectListTableData (common-lib) lower-cases the Table column names when it builds the
+	// row maps, so the keys are "sync status" / "health status", not the "Sync Status" / "Health Status"
+	// printer-column names. Lower-case the lookup keys too, otherwise both statuses are always empty.
+	syncStatusKey := strings.ToLower(k8sCommonBean.K8sResourceColumnDefinitionSyncStatus)
+	healthStatusKey := strings.ToLower(k8sCommonBean.K8sResourceColumnDefinitionHealthStatus)
 	if resp != nil {
 		appLists = make([]*bean.ArgoApplicationListDto, len(resp.Data))
 		for i, rowData := range resp.Data {
@@ -175,13 +181,13 @@ func getApplicationListDtos(resp *k8s.ClusterResourceListMap, clusterName string
 					appListDto.Name = nameStr
 				}
 			}
-			if rowData[k8sCommonBean.K8sResourceColumnDefinitionSyncStatus] != nil {
-				if syncStatusStr, ok := rowData[k8sCommonBean.K8sResourceColumnDefinitionSyncStatus].(string); ok {
+			if rowData[syncStatusKey] != nil {
+				if syncStatusStr, ok := rowData[syncStatusKey].(string); ok {
 					appListDto.SyncStatus = syncStatusStr
 				}
 			}
-			if rowData[k8sCommonBean.K8sResourceColumnDefinitionHealthStatus] != nil {
-				if healthStatusStr, ok := rowData[k8sCommonBean.K8sResourceColumnDefinitionHealthStatus].(string); ok {
+			if rowData[healthStatusKey] != nil {
+				if healthStatusStr, ok := rowData[healthStatusKey].(string); ok {
 					appListDto.HealthStatus = healthStatusStr
 				}
 			}


### PR DESCRIPTION
## Description

Fixes #7030

On the **ArgoCD Apps** tab every external Argo CD application shows `-` as its status, and `GET /orchestrator/argo-application` returns empty `appStatus` / `syncStatus`, although the `Application` objects are `Synced` / `Healthy`.

`BuildK8sObjectListTableData` (common-lib `utils/k8s/K8sUtil.go`) lower-cases the Table column names when it builds the row maps, so the row keys are `sync status` / `health status`. `getApplicationListDtos` looked the values up with the printer-column constants `"Sync Status"` / `"Health Status"`, which never match.

This PR lower-cases the lookup keys (derived from the same constants, so the two places cannot drift apart again) and adds a comment explaining why.

## How was this verified

- `POST /orchestrator/k8s/resource/list` for `argoproj.io/v1alpha1 Application` on a running Devtron (`1188d0b9`) returns `headers: ["name", "namespace", "sync status", "health status"]` with `Synced` / `Healthy` in the rows, while the list endpoint returned empty strings.
- The constants are used only in this function (`pkg/argoApplication/ArgoApplicationService.go`), so nothing else changes behaviour.

## Checklist

- [x] Change is limited to the list DTO mapping; no API contract change.
- [x] DCO sign-off.
