### PR TITLE
fix: collapse identical if/else branches in AppStoreApplicationVersionRepository.FindWithFilter (#6030)

### DIFF
--- a/pkg/appStore/discover/repository/AppStoreApplicationVersionRepository.go
+++ b/pkg/appStore/discover/repository/AppStoreApplicationVersionRepository.go
@@ -183,15 +183,7 @@ func (impl *AppStoreApplicationVersionRepositoryImpl) FindWithFilter(filter *app
 	query = query + ";"
 
 	var err error
-	if len(filter.ChartRepoId) > 0 && len(filter.RegistryId) > 0 {
-		_, err = impl.dbConnection.Query(&appStoreWithVersion, query, queryParams...)
-	} else if len(filter.RegistryId) > 0 {
-		_, err = impl.dbConnection.Query(&appStoreWithVersion, query, queryParams...)
-	} else if len(filter.ChartRepoId) > 0 {
-		_, err = impl.dbConnection.Query(&appStoreWithVersion, query, queryParams...)
-	} else {
-		_, err = impl.dbConnection.Query(&appStoreWithVersion, query, queryParams...)
-	}
+	_, err = impl.dbConnection.Query(&appStoreWithVersion, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What
All branches of the `if/else-if` construct in `FindWithFilter` executed the identical statement:
```go
_, err = impl.dbConnection.Query(&appStoreWithVersion, query, queryParams...)
```
The `query` and `queryParams` are fully built before the branch, so the branching on `ChartRepoId`/`RegistryId` was dead code. Collapsed the four identical branches into a single call.

## Why
Reported by the `revive` linter. Removes confusing dead branching with no behavior change.

Fixes #6030