### PR TITLE
fix: remove identical if/else branch in GetRoleForOtherEntity (#6031)

### DIFF
--- a/pkg/auth/user/repository/UserAuthRepository.go
+++ b/pkg/auth/user/repository/UserAuthRepository.go
@@ -1149,8 +1149,6 @@ func (impl UserAuthRepositoryImpl) GetRoleForOtherEntity(team, app, env, act, ac
 
 		}
 		_, err = impl.dbConnection.Query(&model, query, queryParams...)
-	} else if team == "" && app == "" && env == "" && act == "" {
-		return model, nil
 	} else {
 		return model, nil
 	}


### PR DESCRIPTION
## What
In `GetRoleForOtherEntity`, the `else if team=="" && app=="" && env=="" && act==""` branch and the following `else` branch both returned `model, nil`. Removed the redundant `else if` so the final `else` handles that case.

## Why
Reported by the `revive` linter (identical if/else branches). No behavior change.

Fixes #6031